### PR TITLE
feat(ghcib): command mode, watch_dirs config, and CPP error filtering

### DIFF
--- a/ghcib/src/Ghcib/Config.hs
+++ b/ghcib/src/Ghcib/Config.hs
@@ -45,6 +45,7 @@ import Atelier.Types.QuietSnake (QuietSnake (..))
 data Config = Config
     { command :: Maybe Text
     , targets :: [Text]
+    , watchDirs :: [FilePath]
     , debounceMs :: Millisecond
     , outputFile :: Maybe FilePath
     , logFile :: Maybe FilePath
@@ -58,6 +59,7 @@ instance Default Config where
         Config
             { command = Nothing
             , targets = []
+            , watchDirs = []
             , debounceMs = 100
             , outputFile = Just "build.json"
             , logFile = Nothing
@@ -73,6 +75,7 @@ instance DecodeTOML Config where
     tomlDecoder = do
         command <- getFieldOpt "command"
         targets <- getFieldOr [] "targets"
+        watchDirs <- getFieldOr [] "watch_dirs"
         debounceMs <- getFieldOr 100 "debounce_ms"
         outputFile <- getFieldOr (Just "build.json") "output_file"
         logFile <- getFieldOpt "log_file"
@@ -80,6 +83,7 @@ instance DecodeTOML Config where
             Config
                 { command = command
                 , targets = targets
+                , watchDirs = watchDirs
                 , debounceMs = debounceMs
                 , outputFile = outputFile
                 , logFile = logFile
@@ -123,12 +127,22 @@ detectCommand targets projectRoot = do
             | otherwise -> "cabal repl " <> targetStr
 
 
--- | Resolve the directories to watch based on the configured targets.
--- Parses the .cabal file and extracts hs-source-dirs for each target.
--- Falls back to ["."] if targets is empty or the cabal file can't be parsed.
-resolveWatchDirs :: (FileSystem :> es) => [Text] -> FilePath -> Eff es [FilePath]
-resolveWatchDirs [] _ = pure ["."]
-resolveWatchDirs targets projectRoot = do
+-- | Resolve the directories to watch.
+--
+-- Priority:
+-- 1. @watch_dirs@ from config, if non-empty (used as-is relative to project root)
+-- 2. @hs-source-dirs@ inferred from cabal targets, if targets are set
+-- 3. Falls back to @["."]@ (project root) if neither is available
+resolveWatchDirs :: (FileSystem :> es) => Config -> FilePath -> Eff es [FilePath]
+resolveWatchDirs cfg projectRoot =
+    case cfg.watchDirs of
+        dirs@(_ : _) -> pure (map (projectRoot </>) dirs)
+        [] -> resolveWatchDirsFromTargets cfg.targets projectRoot
+
+
+resolveWatchDirsFromTargets :: (FileSystem :> es) => [Text] -> FilePath -> Eff es [FilePath]
+resolveWatchDirsFromTargets [] _ = pure ["."]
+resolveWatchDirsFromTargets targets projectRoot = do
     cabalFiles <- filter (\f -> takeExtension f == ".cabal") <$> listDirectory projectRoot
     case cabalFiles of
         [] -> pure ["."]

--- a/ghcib/src/Ghcib/Daemon.hs
+++ b/ghcib/src/Ghcib/Daemon.hs
@@ -46,7 +46,8 @@ runDaemon projectRoot cfg = do
         runEff . runFileSystemIO $ do
             sp <- socketPath projectRoot
             et <- resolveTargets cfg.targets projectRoot
-            wd <- resolveWatchDirs et projectRoot
+            let effectiveCfg' = cfg {Config.targets = et}
+            wd <- resolveWatchDirs effectiveCfg' projectRoot
             pure (sp, et, wd)
     let effectiveCfg = cfg {Config.targets = effectiveTargets}
     let daemonInfo =

--- a/ghcib/src/Ghcib/GhciSession.hs
+++ b/ghcib/src/Ghcib/GhciSession.hs
@@ -1,8 +1,9 @@
-module Ghcib.GhciSession (component, mergeDiagnostics, sessionListener) where
+module Ghcib.GhciSession (component, filterToWatchDirs, mergeDiagnostics, sessionListener) where
 
 import Data.Time (diffUTCTime)
 import Effectful.Exception (throwIO, try)
 import Effectful.Reader.Static (Reader, ask)
+import System.FilePath (isAbsolute, (</>))
 
 import Data.Map.Strict qualified as Map
 
@@ -14,7 +15,7 @@ import Atelier.Effects.Log (Log)
 import Atelier.Exception (isGracefulShutdown)
 import Atelier.Time (Millisecond)
 import Ghcib.BuildState (BuildId (..), BuildPhase (..), BuildResult (..), ChangeKind (..), Diagnostic (..))
-import Ghcib.Config (Config (..), resolveCommand)
+import Ghcib.Config (Config (..), resolveCommand, resolveWatchDirs)
 import Ghcib.Effects.BuildStore (BuildStore, setPhase, waitDirty)
 import Ghcib.Effects.GhciSession (GhciSession, LoadResult (..))
 
@@ -34,6 +35,31 @@ mergeDiagnostics prev LoadResult {compiledFiles, diagnostics} =
     let cleared = foldr Map.delete prev compiledFiles
         newByFile = Map.fromListWith (++) [(d.file, [d]) | d <- diagnostics]
     in  Map.union newByFile cleared
+
+
+-- | Keep only diagnostics whose file is under one of the watched directories.
+--
+-- Diagnostics from outside the project (e.g. @.h@ files in the Nix store) and
+-- those with mangled filenames produced by the C preprocessor (e.g.
+-- @"In file included from ..."@) are dropped here, before they can enter the
+-- accumulation map where they would be impossible to evict.
+filterToWatchDirs :: FilePath -> [FilePath] -> [Diagnostic] -> [Diagnostic]
+filterToWatchDirs _ [] diags = diags
+filterToWatchDirs projectRoot watchDirs diags =
+    filter (isUnderAnyWatchDir . (.file)) diags
+  where
+    absWatchDirs = map toAbsWd watchDirs
+    toAbsWd wd
+        | wd == "." = projectRoot
+        | isAbsolute wd = wd
+        | otherwise = projectRoot </> wd
+    isUnderAnyWatchDir file
+        | not (isAbsolute file) && not ("./" `isPrefixOf` file) = False
+        | isAbsolute file =
+            any (\wd -> (wd ++ "/") `isPrefixOf` file || wd == file) absWatchDirs
+        | otherwise =
+            let absFile = projectRoot </> drop 2 file
+            in  any (\wd -> (wd ++ "/") `isPrefixOf` absFile || wd == absFile) absWatchDirs
 
 
 -- | GhciSession component.
@@ -57,9 +83,10 @@ component =
             cfg <- ask @Config
             projectRoot <- getCurrentDirectory
             cmd <- resolveCommand cfg projectRoot
+            watchDirs <- resolveWatchDirs cfg projectRoot
             Log.debug $ "GhciSession.component: resolved command = " <> cmd
             Log.debug $ "GhciSession.component: projectRoot = " <> toText projectRoot
-            pure [sessionListener cmd projectRoot]
+            pure [sessionListener cmd projectRoot watchDirs]
         }
 
 
@@ -72,9 +99,12 @@ sessionListener
        )
     => Text
     -> FilePath
+    -> [FilePath]
     -> Listener es
-sessionListener cmd projectRoot = startSession (BuildId 1)
+sessionListener cmd projectRoot watchDirs = startSession (BuildId 1)
   where
+    filterDiags = filterToWatchDirs projectRoot watchDirs
+
     startSession (BuildId n) = do
         Log.info $ "Starting GHCi session #" <> show n <> ": " <> cmd
         t0 <- Clock.currentTime
@@ -89,10 +119,11 @@ sessionListener cmd projectRoot = startSession (BuildId 1)
                 startSession (BuildId n)
             Right LoadResult {moduleCount, diagnostics = msgs} -> do
                 t1 <- Clock.currentTime
-                Log.info $ "GHCi started (session #" <> show n <> "): " <> show (length msgs) <> " diagnostics"
+                let filteredMsgs = filterDiags msgs
+                Log.info $ "GHCi started (session #" <> show n <> "): " <> show (length filteredMsgs) <> " diagnostics"
                 let durationMs = round (realToFrac (diffUTCTime t1 t0) * 1000 :: Double) :: Int
-                    buildResult = BuildResult {completedAt = t1, durationMs, moduleCount, diagnostics = msgs}
-                    accumulated = Map.fromListWith (++) [(d.file, [d]) | d <- msgs]
+                    buildResult = BuildResult {completedAt = t1, durationMs, moduleCount, diagnostics = filteredMsgs}
+                    accumulated = Map.fromListWith (++) [(d.file, [d]) | d <- filteredMsgs]
                 setPhase (BuildId n) (Done buildResult)
                 Log.debug $ "Build state updated to Done (session #" <> show n <> ")"
                 listenLoop (BuildId (n + 1)) accumulated
@@ -119,8 +150,14 @@ sessionListener cmd projectRoot = startSession (BuildId 1)
                         startSession nextId
                     Right loadResult -> do
                         t1 <- Clock.currentTime
-                        let durationMs = round (realToFrac (diffUTCTime t1 t0) * 1000 :: Double) :: Int
-                            newAccumulated = mergeDiagnostics accumulated loadResult
+                        let filteredResult =
+                                LoadResult
+                                    { moduleCount = loadResult.moduleCount
+                                    , compiledFiles = loadResult.compiledFiles
+                                    , diagnostics = filterDiags loadResult.diagnostics
+                                    }
+                            durationMs = round (realToFrac (diffUTCTime t1 t0) * 1000 :: Double) :: Int
+                            newAccumulated = mergeDiagnostics accumulated filteredResult
                             allMsgs = concat (Map.elems newAccumulated)
                             buildResult = BuildResult {completedAt = t1, durationMs, moduleCount = loadResult.moduleCount, diagnostics = allMsgs}
                         setPhase (BuildId n) (Done buildResult)

--- a/ghcib/src/Ghcib/Watcher.hs
+++ b/ghcib/src/Ghcib/Watcher.hs
@@ -8,7 +8,7 @@ import System.FilePath (takeExtension, takeFileName)
 import Atelier.Component (Component (..), defaultComponent)
 import Atelier.Effects.FileSystem (FileSystem, getCurrentDirectory)
 import Ghcib.BuildState (ChangeKind (..))
-import Ghcib.Config (Config (..), resolveWatchDirs)
+import Ghcib.Config (Config, resolveWatchDirs)
 import Ghcib.Effects.BuildStore (BuildStore, markDirty)
 import Ghcib.Effects.FileWatcher (FileWatcher, watchDirs)
 
@@ -30,7 +30,7 @@ component =
         , triggers = do
             cfg <- ask @Config
             projectRoot <- getCurrentDirectory
-            dirs <- resolveWatchDirs cfg.targets projectRoot
+            dirs <- resolveWatchDirs cfg projectRoot
             pure [forever $ watchDirs dirs \path -> markDirty (changeKindFor path)]
         }
 

--- a/ghcib/test/Unit/Ghcib/GhciSessionSpec.hs
+++ b/ghcib/test/Unit/Ghcib/GhciSessionSpec.hs
@@ -25,7 +25,7 @@ import Ghcib.Effects.GhciSession
     , startGhci
     , stopGhci
     )
-import Ghcib.GhciSession (mergeDiagnostics, sessionListener)
+import Ghcib.GhciSession (filterToWatchDirs, mergeDiagnostics, sessionListener)
 
 
 spec_GhciSession :: Spec
@@ -33,6 +33,7 @@ spec_GhciSession = do
     describe "runGhciSessionScripted" testScripted
     describe "sessionListener" testSessionListener
     describe "mergeDiagnostics" testMergeDiagnostics
+    describe "filterToWatchDirs" testFilterToWatchDirs
     describe "extractTitle" testExtractTitle
 
 
@@ -109,7 +110,7 @@ testSessionListener = do
             let t0 = epoch
                 t1 = addUTCTime 2 epoch -- 2 seconds later
             result <- runListenerTest [t0, t1] [simpleResult []] do
-                void $ fork $ sessionListener "cabal repl" "/"
+                void $ fork $ sessionListener "cabal repl" "/" []
                 waitUntilDone
             case result.phase of
                 Done br -> br.durationMs `shouldBe` 2000
@@ -117,7 +118,7 @@ testSessionListener = do
 
         it "records moduleCount from LoadResult" do
             result <- runListenerTest [epoch, epoch] [simpleResultWith 7 []] do
-                void $ fork $ sessionListener "cabal repl" "/"
+                void $ fork $ sessionListener "cabal repl" "/" []
                 waitUntilDone
             case result.phase of
                 Done br -> br.moduleCount `shouldBe` 7
@@ -176,6 +177,47 @@ testMergeDiagnostics = do
                     }
         let merged = mergeDiagnostics Map.empty result
         Map.lookup warnMsg.file merged `shouldBe` Just [warnMsg]
+
+
+--------------------------------------------------------------------------------
+-- filterToWatchDirs tests
+--------------------------------------------------------------------------------
+
+testFilterToWatchDirs :: Spec
+testFilterToWatchDirs = do
+    let root = "/project"
+        watchDirs = ["/project/src"]
+
+    it "keeps diagnostics under a watched directory" do
+        -- ./src/Foo.hs is what toRelative produces for an absolute project file
+        let d = errMsg {file = "./src/Foo.hs"}
+        filterToWatchDirs root watchDirs [d] `shouldBe` [d]
+
+    it "drops diagnostics from outside the project (e.g. Nix store .h files)" do
+        let d = errMsg {file = "/nix/store/abc123/ghcautoconf.h"}
+        filterToWatchDirs root watchDirs [d] `shouldBe` []
+
+    it "drops diagnostics with mangled CPP filenames" do
+        -- The ghcid parser produces "In file included from <path>" as the file
+        -- field for GCC-style CPP include-chain messages.
+        let d = errMsg {file = "In file included from src/Foo.hs"}
+        filterToWatchDirs root watchDirs [d] `shouldBe` []
+
+    it "drops mangled CPP filenames when watchDirs is [\".\"] (project root)" do
+        -- With watchDirs=["."], the watch dir resolves to projectRoot itself.
+        -- A mangled path joined onto projectRoot would incorrectly start with
+        -- projectRoot+"/", so this case requires an explicit guard.
+        let d = errMsg {file = "In file included from src/Foo.hs"}
+        filterToWatchDirs root ["."] [d] `shouldBe` []
+
+    it "passes everything through when watchDirs is empty" do
+        let d = errMsg {file = "/nix/store/abc123/ghcautoconf.h"}
+        filterToWatchDirs root [] [d] `shouldBe` [d]
+
+    it "works with the '.' fallback watch dir (whole project root)" do
+        let d = errMsg {file = "./src/Foo.hs"}
+            nixD = errMsg {file = "/nix/store/abc123/ghcautoconf.h"}
+        filterToWatchDirs root ["."] [d, nixD] `shouldBe` [d]
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
## Motivation

`ghcib` previously only worked with `cabal repl <target>` invocations. This PR adds support for projects that start GHCi via a custom shell command, the primary use case being GHC development itself, where `hadrian/ghci-cabal` replaces `cabal repl`.

### `watch_dirs` config field

Added `watchDirs :: [FilePath]` to `Config` (TOML key: `watch_dirs`).

When set, it takes precedence over target-based `hs-source-dirs` inference in `resolveWatchDirs`. Resolution priority is now:

1. `watch_dirs` from config, if non-empty
2. `hs-source-dirs` inferred from cabal targets
3. Falls back to `["."]` (project root)

### Non-project error filtering (`filterToWatchDirs`)

Added `filterToWatchDirs :: FilePath -> [FilePath] -> [Diagnostic] -> [Diagnostic]` in `GhciSession.hs`. Applied in sessionListener` to diagnostics before accumulation and before building `BuildResult`.

**Why filtering is necessary at this point:** The diagnostic accumulation map is keyed by file path and only evicts entries when a file appears in `compiledFiles`. CPP error messages have file fields like `/nix/store/.../ghcautoconf.h` or the mangled string `"In file included from ..."` — neither of which will ever appear in `compiledFiles`, so they accumulate forever without this filter.

**Mangled path bug (fixed):** With `watch_dirs = ["."]`, the watch dir resolves to `projectRoot`. A mangled filename joined onto `projectRoot` (e.g. `/project/In file included from ...`) incorrectly starts with `projectRoot + "/"`, causing it to pass the prefix check. The fix adds an explicit guard: any file that is neither absolute nor starts with `"./"` is immediately rejected as a mangled path.

## Example `.ghcib.toml` for GHC development

```toml
command   = "hadrian/ghci-cabal"
```