### PR TITLE
refactor: use mockable Console effect

### DIFF
--- a/atelier.cabal
+++ b/atelier.cabal
@@ -24,6 +24,7 @@ library
       Atelier.Effects.Clock
       Atelier.Effects.Conc
       Atelier.Effects.Conc.Traced
+      Atelier.Effects.Console
       Atelier.Effects.DB
       Atelier.Effects.DB.Config
       Atelier.Effects.DB.Rel8
@@ -320,6 +321,7 @@ test-suite atelier-test
       Unit.Atelier.Effects.ChanSpec
       Unit.Atelier.Effects.Conc.TracedSpec
       Unit.Atelier.Effects.ConcSpec
+      Unit.Atelier.Effects.ConsoleSpec
       Unit.Atelier.Effects.DelaySpec
       Unit.Atelier.Effects.LogSpec
       Unit.Atelier.Effects.PublishingSpec

--- a/atelier/src/Atelier/Effects/Console.hs
+++ b/atelier/src/Atelier/Effects/Console.hs
@@ -1,0 +1,55 @@
+module Atelier.Effects.Console
+    ( -- * Effect
+      Console
+    , putStrLn
+    , putStr
+    , putTextLn
+    , putText
+
+      -- * Interpreters
+    , runConsoleHandle
+    , runConsole
+    , runConsoleToList
+    ) where
+
+import Effectful (Effect, IOE)
+import Effectful.Dispatch.Dynamic (interpret_, reinterpret_)
+import Effectful.State.Static.Shared (modify, runState)
+import Effectful.TH (makeEffect)
+
+import Data.ByteString.Char8 qualified as B8
+
+import Prelude hiding (putStr, putStrLn, putText, putTextLn)
+
+
+data Console :: Effect where
+    PutStr :: ByteString -> Console m ()
+
+
+makeEffect ''Console
+
+
+putStrLn :: (Console :> es) => ByteString -> Eff es ()
+putStrLn = putStr . (<> "\n")
+
+
+putText :: (Console :> es) => Text -> Eff es ()
+putText = putStr . encodeUtf8
+
+
+putTextLn :: (Console :> es) => Text -> Eff es ()
+putTextLn = putStrLn . encodeUtf8
+
+
+runConsoleHandle :: (IOE :> es) => Handle -> Eff (Console : es) a -> Eff es a
+runConsoleHandle h = interpret_ \case
+    PutStr s -> liftIO $ B8.hPut h s
+
+
+runConsole :: (IOE :> es) => Eff (Console : es) a -> Eff es a
+runConsole = runConsoleHandle stdout
+
+
+runConsoleToList :: Eff (Console : es) a -> Eff es (a, [ByteString])
+runConsoleToList = reinterpret_ (fmap (second reverse) . runState []) \case
+    PutStr s -> modify (s :)

--- a/atelier/test/Unit/Atelier/Effects/ConsoleSpec.hs
+++ b/atelier/test/Unit/Atelier/Effects/ConsoleSpec.hs
@@ -1,0 +1,40 @@
+module Unit.Atelier.Effects.ConsoleSpec (spec_Console) where
+
+import Effectful (runPureEff)
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+import Atelier.Effects.Console (runConsoleToList)
+
+import Atelier.Effects.Console qualified as Console
+
+
+spec_Console :: Spec
+spec_Console = do
+    describe "runConsoleToList" $ do
+        describe "when nothing is logged" $ it "returns an empty list" $ do
+            let (_, msgs) = runPureEff $ runConsoleToList $ pure ()
+            msgs `shouldBe` []
+
+        describe "when logging once" $ it "collects a single traced message" $ do
+            let (_, msgs) = runPureEff $ runConsoleToList $ Console.putStr "hello"
+            msgs `shouldBe` ["hello"]
+
+        it "collects multiple logged messages in order" $ do
+            let (_, msgs) =
+                    runPureEff . runConsoleToList $ do
+                        Console.putStr "first"
+                        Console.putStr "second"
+                        Console.putStr "third"
+            msgs `shouldBe` ["first", "second", "third"]
+
+        it "returns the result alongside the traced messages" $ do
+            let (result, msgs) =
+                    runPureEff . runConsoleToList $ do
+                        Console.putStr "side effect"
+                        pure (42 :: Int)
+            result `shouldBe` 42
+            msgs `shouldBe` ["side effect"]
+
+        it "traceLn appends a newline to the message" $ do
+            let (_, msgs) = runPureEff $ runConsoleToList $ Console.putStrLn "line"
+            msgs `shouldBe` ["line\n"]

--- a/ghcib/app/Main.hs
+++ b/ghcib/app/Main.hs
@@ -1,9 +1,9 @@
 module Main (main) where
 
 import Effectful (runEff)
-import Effectful.Console.ByteString (runConsole)
 
 import Atelier.Effects.Clock (runClock)
+import Atelier.Effects.Console (runConsole)
 import Atelier.Effects.FileSystem (runFileSystemIO)
 import Ghcib.Arguments (runArguments)
 import Ghcib.Effects.Display (runDisplayIO)

--- a/ghcib/src/Ghcib/Program.hs
+++ b/ghcib/src/Ghcib/Program.hs
@@ -5,14 +5,13 @@ import Data.Aeson (encode)
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import Data.Time.LocalTime (getCurrentTimeZone, utcToLocalTime)
 import Effectful (IOE, runEff)
-import Effectful.Console.ByteString (Console)
 import Effectful.Reader.Static (Reader, ask)
 import System.IO (hGetLine)
 
 import Data.ByteString.Lazy qualified as BSL
-import Effectful.Console.ByteString qualified as Console
 
 import Atelier.Effects.Clock (Clock)
+import Atelier.Effects.Console (Console)
 import Atelier.Effects.FileSystem
     ( FileSystem
     , doesFileExist
@@ -43,6 +42,7 @@ import Ghcib.Socket.Client
     )
 import Ghcib.Watch (watchDisplay)
 
+import Atelier.Effects.Console qualified as Console
 import Ghcib.Config qualified as Config
 
 
@@ -108,7 +108,7 @@ showStatus waitFlag jsonFlag verboseFlag = do
         else
             queryStatus sockPath
     case result of
-        Left err -> Console.putStrLn $ encodeUtf8 $ "Error: " <> toString err
+        Left err -> Console.putTextLn $ "Error: " <> err
         Right state ->
             if jsonFlag then do
                 Console.putStr $ BSL.toStrict $ encode state
@@ -122,18 +122,18 @@ showStatus waitFlag jsonFlag verboseFlag = do
             tz <- liftIO getCurrentTimeZone
             let printDiag =
                     if verbose then
-                        Console.putStr . encodeUtf8 . diagnosticBlock
+                        Console.putText . diagnosticBlock
                     else
-                        Console.putStrLn . encodeUtf8 . diagnosticLine
+                        Console.putTextLn . diagnosticLine
             mapM_ printDiag r.diagnostics
-            Console.putStrLn $ encodeUtf8 $ buildSummary tz r
+            Console.putTextLn $ buildSummary tz r
             when (any ((== SError) . (.severity)) r.diagnostics) $ liftIO exitFailure
 
     buildSummary tz r =
         let errs = length $ filter ((== SError) . (.severity)) r.diagnostics
             warns = length $ filter ((== SWarning) . (.severity)) r.diagnostics
-            ts = "— " <> formatTime defaultTimeLocale "%H:%M:%S" (utcToLocalTime tz r.completedAt)
-            stats = "(" <> show r.moduleCount <> " modules, " <> formatDuration r.durationMs <> ")"
+            ts = toText $ "— " <> formatTime defaultTimeLocale "%H:%M:%S" (utcToLocalTime tz r.completedAt)
+            stats = toText $ "(" <> show r.moduleCount <> " modules, " <> formatDuration r.durationMs <> ")"
         in  if null r.diagnostics then
                 "All good. " <> stats <> " " <> ts
             else
@@ -159,7 +159,7 @@ showLog followFlag = do
         Just path -> do
             exists <- doesFileExist path
             if not exists then
-                Console.putStrLn $ encodeUtf8 $ "Log file does not exist yet: " <> path
+                Console.putTextLn $ "Log file does not exist yet: " <> toText path
             else
                 if followFlag then
                     liftIO $ followLog path
@@ -204,7 +204,7 @@ showSource moduleNames = do
     unless running $ liftIO $ startDaemon projectRoot >> waitForSocket sockPath
     result <- querySource sockPath moduleNames
     case result of
-        Left err -> Console.putStrLn $ encodeUtf8 $ "Error: " <> err
+        Left err -> Console.putTextLn $ "Error: " <> err
         Right results -> renderSourceResults results
 
 

--- a/ghcib/src/Ghcib/Render.hs
+++ b/ghcib/src/Ghcib/Render.hs
@@ -22,12 +22,10 @@ module Ghcib.Render
 import Data.Time (UTCTime)
 import Data.Time.Format (defaultTimeLocale, formatTime)
 import Data.Time.LocalTime (TimeZone, utc, utcToLocalTime)
-import Effectful.Console.ByteString (Console)
 import Prettyprinter
 import System.FilePath (isAbsolute)
 
-import Effectful.Console.ByteString qualified as Console
-
+import Atelier.Effects.Console (Console)
 import Ghcib.BuildState
     ( BuildPhase (..)
     , BuildResult (..)
@@ -39,6 +37,8 @@ import Ghcib.BuildState
 import Ghcib.Effects.Display (Style (..))
 import Ghcib.GhcPkg.Types (ModuleName (..), PackageId (..))
 import Ghcib.SourceLookup (ModuleSourceResult (..))
+
+import Atelier.Effects.Console qualified as Console
 
 
 -- | Map a 'Severity' to its display 'Style'.
@@ -144,17 +144,17 @@ daemonInfoDoc di =
 -- | Single-line diagnostic for plain-text / shell output.
 --
 -- Format: @E src\/Foo\/Bar.hs:42 \`something\` not in scope@
-diagnosticLine :: Diagnostic -> String
+diagnosticLine :: Diagnostic -> Text
 diagnosticLine d =
-    prefix d.severity <> " " <> d.file <> ":" <> show d.line <> " " <> toString d.title
+    prefix d.severity <> " " <> toText d.file <> ":" <> show d.line <> " " <> d.title
   where
     prefix SError = "E"
     prefix SWarning = "W"
 
 
 -- | One-liner followed by the full GHC message body (verbose mode).
-diagnosticBlock :: Diagnostic -> String
-diagnosticBlock d = diagnosticLine d <> "\n" <> toString d.text
+diagnosticBlock :: Diagnostic -> Text
+diagnosticBlock d = diagnosticLine d <> "\n" <> d.text
 
 
 instance Pretty Diagnostic where
@@ -173,16 +173,14 @@ renderSourceResults :: (Console :> es) => [ModuleSourceResult] -> Eff es ()
 renderSourceResults results = mapM_ renderOne results
   where
     renderOne (SourceFound modName src) = do
-        when (length results > 1) $ Console.putStrLn (encodeUtf8 $ "-- " <> unModuleName modName)
-        Console.putStr (encodeUtf8 src)
+        when (length results > 1) $ Console.putTextLn $ "-- " <> unModuleName modName
+        Console.putText src
         when (length results > 1) $ Console.putStrLn ""
     renderOne (SourceNotFound modName) =
-        Console.putStrLn
-            $ encodeUtf8
+        Console.putTextLn
             $ "Not found: " <> unModuleName modName <> " (module not in any installed package)"
     renderOne (SourceNoHaddock modName pkgId) =
-        Console.putStrLn
-            $ encodeUtf8
+        Console.putTextLn
             $ "No source available: "
                 <> unModuleName modName
                 <> " (package "

--- a/ghcib/test/Unit/Ghcib/WatchSpec.hs
+++ b/ghcib/test/Unit/Ghcib/WatchSpec.hs
@@ -76,18 +76,18 @@ spec_Watch = do
 
     describe "diagnosticBlock" do
         it "includes the one-liner prefix for an error" do
-            diagnosticBlock errMsg `shouldContain` "E Foo.hs:10 type mismatch"
+            diagnosticBlock errMsg `shouldContainT` "E Foo.hs:10 type mismatch"
 
         it "includes the full text body after the first line" do
-            diagnosticBlock errMsg `shouldContain` "\ntype mismatch"
+            diagnosticBlock errMsg `shouldContainT` "\ntype mismatch"
 
         it "uses 'W' prefix for warnings" do
-            diagnosticBlock warnMsg `shouldContain` "W Bar.hs:3 unused import"
+            diagnosticBlock warnMsg `shouldContainT` "W Bar.hs:3 unused import"
 
         it "contains both title and text when they differ" do
             let d = mixedMsg
-            diagnosticBlock d `shouldContain` "short title"
-            diagnosticBlock d `shouldContain` "full body of the message"
+            diagnosticBlock d `shouldContainT` "short title"
+            diagnosticBlock d `shouldContainT` "full body of the message"
 
     describe "daemonInfoDoc" do
         it "shows '(all)' when targets is empty" do
@@ -113,6 +113,9 @@ spec_Watch = do
         it "shows log file path when configured" do
             let di = emptyDaemonInfo {logFile = Just "/tmp/ghcib.log"}
             render (daemonInfoDoc di) `shouldContain` "/tmp/ghcib.log"
+  where
+    shouldContainT :: Text -> Text -> Expectation
+    shouldContainT a b = toString a `shouldContain` toString b
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Replaces the use of `effectful`'s `Effectful.Console.ByteString` effect with a dynamic effect we can use to more easily test code that writes to the console (which this application does a lot).