### PR TITLE
feat(ghcib): run test suites after clean build

### DIFF
--- a/.claude-plugin/ghcib/skills/ghcib/SKILL.md
+++ b/.claude-plugin/ghcib/skills/ghcib/SKILL.md
@@ -43,6 +43,14 @@ A clean build prints:
 All good. (71 modules, 17.3s)
 ```
 
+If test suites are configured, their results follow the build summary:
+
+```
+All good. (71 modules, 17.3s)
+test:my-test  passed
+test:other-test  failed
+```
+
 With `--wait`, if a build is in progress `Building...` is printed immediately before blocking.
 
 With `--verbose`, the full GHC message body is printed under each diagnostic:
@@ -54,7 +62,7 @@ Variable not in scope: something
 1 error(s), 0 warning(s) (71 modules, 1.2s)
 ```
 
-**Exit code**: 1 when any errors are present, 0 otherwise (warnings alone → 0).
+**Exit code**: 1 when any errors are present or any test suite fails, 0 otherwise (warnings alone → 0).
 
 ### JSON output (`--json`)
 

--- a/atelier.cabal
+++ b/atelier.cabal
@@ -204,6 +204,7 @@ library ghcib
       Ghcib.Effects.FileWatcher
       Ghcib.Effects.GhciSession
       Ghcib.Effects.GhcPkg
+      Ghcib.Effects.TestRunner
       Ghcib.Effects.UnixSocket
       Ghcib.Events.FileChanged
       Ghcib.GhciSession
@@ -387,6 +388,7 @@ test-suite ghcib-test
       Unit.Ghcib.SocketSpec
       Unit.Ghcib.SourceLookupSpec
       Unit.Ghcib.SourceSpec
+      Unit.Ghcib.TestRunnerSpec
       Unit.Ghcib.WatchSpec
       Paths_atelier
   autogen-modules:

--- a/ghcib/proposals/004-tests-after-build/README.md
+++ b/ghcib/proposals/004-tests-after-build/README.md
@@ -1,0 +1,112 @@
+# Run Tests After Build — Work Package
+
+## High-level Description
+
+After a successful build (no compilation errors), automatically execute configured test
+suites and report results alongside build status. Developers get immediate feedback on both
+compilation and tests from a single `ghcib status` query, without a separate `cabal test`
+invocation.
+
+Tests run in short-lived `cabal repl test:<name>` sessions spawned after each clean build.
+The first run after a cold cache compiles to interpreted bytecode; subsequent runs reuse the
+cache and pay only GHCi startup overhead (~3s).
+
+**Deliverables:**
+
+- `testTargets` optional config field in `.ghcib.toml` to pin which suites to run
+- Auto-discovery: when `testTargets` is absent, all `test:` components in `targets` are run
+- `Testing` build phase visible in watch mode while suites are running
+- Test results (pass / fail / error + output) stored in `BuildResult` and surfaced in
+  `ghcib status` output
+- Exit code of `ghcib status` reflects test failures alongside build errors
+
+---
+
+## Core Objectives
+
+- Tests run automatically after every green build with no manual steps
+- Auto-discovery means a single-suite project needs zero extra config — when `targets` is
+  omitted entirely, all components (including test suites) are discovered from the cabal
+  file automatically
+- `testTargets = []` in `.ghcib.toml` opts a project out entirely; a project with no
+  `test:` components in `targets` is also unaffected
+- Test failures are clearly distinguished from compilation errors in output
+
+---
+
+## Metrics for Success
+
+- After a green build, `ghcib status` shows pass/fail test summary
+- GHCi-based test execution is noticeably faster than `cabal test` for incremental runs
+- A project with no `test:` components in `targets` behaves identically to today
+
+---
+
+## Classification
+
+- **New initiative or continuation of existing:** New initiative
+- **Primary nature:** Technical
+
+---
+
+## Milestones
+
+### Milestone 1 — Config & Type Plumbing
+
+Add `testTargets :: Maybe [Text]` to `Config` and `testRuns :: [TestRun]` to
+`BuildResult`. No runtime behavior change.
+
+**Deliverables:**
+- `TestRun` and `TestOutcome` types defined and JSON-serialisable
+- `Config` loads `testTargets` from TOML
+- `BuildResult` carries `testRuns :: [TestRun]`
+- `resolveTestTargets` auto-discovers `test:` components from `targets` when `testTargets`
+  is absent
+
+**Acceptance criteria:**
+- Config round-trips `.ghcib.toml` with `testTargets`
+- Wire protocol is unchanged when no test suites are present (existing clients unaffected)
+
+---
+
+### Milestone 2 — Test Execution
+
+After a successful build with no errors, spawn a short-lived `cabal repl test:<name>`
+per suite, send `:main\n:quit\n`, capture output, and infer pass/fail.
+
+**Deliverables:**
+- `TestRunner` effect with `runTestSuite :: Text -> m TestRun` operation
+- `GhciSession` listener transitions to `Testing` phase and runs suites after a clean build
+- `BuildResult.testRuns` populated on completion; empty when build has errors
+
+**Acceptance criteria:**
+- Passing tests → `TestsPassed` in status output
+- Failing tests → `TestsFailed` with captured output
+- GHCi-level exception or timeout → `TestsError` with message
+- `ghcib status` exit code is non-zero when tests fail
+
+---
+
+### Milestone 3 — Rendering & UX
+
+Show test results clearly across all output modes.
+
+**Deliverables:**
+- `ghcib status` text output: one-line pass/fail per suite appended after build summary
+- `ghcib status --verbose`: full test output included
+- `ghcib watch`: live update shows `Testing…` while tests run, then result
+
+**Acceptance criteria:**
+- Concise default output; full output behind `--verbose`
+- Test failure distinguishable from build error at a glance
+
+---
+
+## Notes
+
+- When `targets` is omitted, all components are auto-discovered from the cabal file
+  (including test suites), so tests run without any explicit config. To load only library
+  components without running tests, either set `targets` explicitly to non-test components
+  or set `testTargets = []` in `.ghcib.toml`.
+- Builds with warnings but no errors still trigger test execution.
+- See `design.md` for the rationale for separate test repls over in-session evaluation.

--- a/ghcib/proposals/004-tests-after-build/design.md
+++ b/ghcib/proposals/004-tests-after-build/design.md
@@ -1,0 +1,161 @@
+# Design: Run Tests After Build
+
+## Status
+
+Draft. See `README.md` for the work package. Low-level contracts in `spec.md`.
+
+---
+
+## Problem
+
+After `ghcib` reports a clean build, the developer still has to separately run `cabal test`
+to know whether their changes are correct. That invocation recompiles and relinks, adding
+seconds to the feedback loop.
+
+---
+
+## Approach
+
+### Separate short-lived test repl per suite
+
+After each clean build, for each test suite to run, ghcib spawns a short-lived
+`cabal repl test:<name>` process, sends `:main\n:quit\n`, captures stdout/stderr, then
+exits. This approach was chosen after ruling out in-session evaluation (see below).
+
+Each test repl maintains its own bytecode cache in `dist-newstyle`. The first run after a
+cold cache compiles to interpreted bytecode (~3s total including startup); subsequent runs
+reuse the cache and cost only startup overhead (~3s). The ~3s floor is irreducible GHCi
+process startup and cabal plan resolution.
+
+### Configuration
+
+```toml
+# No config needed for a single-suite project — auto-discovered from targets
+targets = ["lib:mylib", "test:mylib-test"]
+
+# Monorepo: load everything but only run one suite
+targets = ["lib:atelier", "test:atelier-test", "lib:ghcib", "test:ghcib-test"]
+test_targets = ["test:ghcib-test"]
+```
+
+`testTargets` is an optional list of `test:<name>` components. When absent, all `test:`
+components in `targets` are run. When present, only the listed suites are run.
+
+### Entry point
+
+We always invoke `:main` in the test repl — GHCi's built-in command that respects the
+`-main-is` setting of the loaded component. The cabal file does not need to be parsed
+for the entry point at runtime; GHCi already knows it.
+
+The cabal file is parsed only to discover *which* test suites exist and to populate
+`testTargets` auto-discovery — not to determine the expression to evaluate.
+
+### Pass/fail detection
+
+All major test frameworks (`hspec`, `tasty`, `HUnit`) call `System.Exit.exitWith` on
+completion. GHCi surfaces this as:
+
+```
+*** Exception: ExitSuccess    -- pass
+*** Exception: ExitFailure 1  -- fail
+```
+
+Detection: scan output for `*** Exception: ExitSuccess` (pass) or
+`*** Exception: ExitFailure` (fail). Any other `*** Exception:` is an error (runner
+crashed). Absence of an exception line is treated as pass.
+
+### New build phase
+
+`BuildPhase` gains a `Testing` constructor:
+
+```haskell
+data BuildPhase = Building | Testing | Done BuildResult
+```
+
+The daemon transitions to `Testing` after a clean build, runs the test repls sequentially,
+then transitions to `Done` with results attached.
+
+### Results in `BuildResult`
+
+```haskell
+data BuildResult = BuildResult
+  { ...
+  , testRuns :: [TestRun]   -- empty when no test suites in targets, or build had errors
+  }
+
+data TestRun = TestRun
+  { target  :: Text         -- "test:ghcib-test"
+  , outcome :: TestOutcome
+  , output  :: Text         -- captured stdout+stderr
+  }
+
+data TestOutcome = TestsPassed | TestsFailed | TestsError Text
+```
+
+---
+
+## Why Not In-Session Evaluation
+
+The natural first idea is to evaluate the test entry point inside the already-running
+multi-repl GHCi session, avoiding a second process entirely. This was investigated and
+ruled out for fundamental reasons:
+
+**Home unit modules are inaccessible in the multi-repl interactive context.** GHCi
+multi-mode does not expose any home unit module to the evaluator by default. `:module` is
+explicitly unsupported (`Command is not supported (yet) in multi-mode`). There is no way
+to bring `Main` or any other test module into scope — regardless of naming scheme,
+`-XPackageImports`, or `-main-is` tricks. The limitation is in the GHCi multi-mode
+implementation, not in our design.
+
+**Session cloning is not viable.** OS `fork()` is unsafe on a multi-threaded Haskell RTS.
+CRIU requires elevated privileges and breaks on open sockets.
+
+**Artifact sharing between the multi-repl and a separate test repl is not possible.**
+Different flag fingerprints (unit-id, linking flags) cause `[Flags changed]` on the first
+run; the two sessions maintain separate bytecode caches permanently.
+
+---
+
+## Alternatives Considered
+
+### `cabal test`
+
+Full rebuild + relink on every run. Slower than a fresh test repl by the link step and
+cabal's separate build profile. Rejected for speed.
+
+### Keep main session as single-target (no multi-repl)
+
+Would enable in-session eval. Rejected — loses the core value of fast multi-package
+incremental builds.
+
+### Persistent per-suite GHCi session
+
+Keep a long-lived `cabal repl test:<name>` running alongside the main session and send
+`:reload` + `:main` after each clean build. This would eliminate the ~3s startup per test
+run at the cost of memory (one extra GHCi process per suite).
+
+This is a noteworthy avenue for a follow-on. GHC's built-in Prometheus metrics (RTS
+memory stats) would give concrete resident-memory figures per session, and the daemon can
+emit test latency metrics alongside them. That data would make the trade-off concrete
+rather than estimated.
+
+---
+
+## Trade-offs
+
+- **~3s per test suite** — startup-dominated, not recompilation-dominated. Acceptable for
+  post-build feedback; faster than `cabal test`.
+- **Sequential execution** — test suites run one at a time; parallel runs possible in future.
+- **Tests skip on build errors** — no test run is attempted when the build has any errors.
+- **No timeout** — a hung test suite blocks the daemon indefinitely. A configurable timeout
+  is a candidate for a follow-on.
+
+---
+
+## Open Questions
+
+1. ~~Should `ghcib status --wait` block until tests complete (build + tests) or just until
+   the build completes?~~ Resolved: `--wait` blocks through the `Testing` phase to `Done`,
+   so it always returns the full build + test result.
+2. Is a persistent per-suite session worth the memory cost? Revisit once basic approach
+   ships and we have real usage data.

--- a/ghcib/proposals/004-tests-after-build/research.md
+++ b/ghcib/proposals/004-tests-after-build/research.md
@@ -1,0 +1,208 @@
+# Research: Run Tests After Build
+
+## Auto-Discovery of Test Entry Points from Cabal Metadata
+
+### The Cabal API already parses everything we need
+
+`Config.hs` already imports `Distribution.Types.TestSuite` and uses `condTestSuites`.
+The `TestSuite` record has a `testInterface` field:
+
+```haskell
+data TestSuiteInterface
+  = TestSuiteExeV10 Version FilePath   -- exitcode-stdio-1.0; FilePath is main-is
+  | TestSuiteLibV09 Version ModuleName -- detailed-0.9 (rare)
+  | TestSuiteUnsupported TestType
+```
+
+For `exitcode-stdio-1.0` (virtually all modern test suites), `TestSuiteExeV10` hands us
+the `main-is` filepath directly — no regex parsing required.
+
+**Source:** `Distribution.Types.TestSuiteInterface`; `Distribution.Types.TestSuite`
+
+### Framework detection is unnecessary
+
+From reading `Test.Hspec` and `Test.Tasty` sources via `ghcib source`:
+
+- HSpec: `hspec :: Spec -> IO ()` — user's `main` calls `hspec spec`
+- Tasty: `defaultMain :: TestTree -> IO ()` — user's `main` calls `defaultMain tests`
+
+Both ultimately call `exitWith`/`exitFailure` from `main`. The expression to run is always
+`main` regardless of framework.
+
+### The `-main-is` GHC option breaks the `Main.main` assumption
+
+The `ghc-options` field in a `test-suite` stanza can override which module and function
+serve as the entry point:
+
+```cabal
+-- ghcid's own test suite:
+test-suite ghcid_test
+    type:            exitcode-stdio-1.0
+    main-is:         Test.hs
+    ghc-options:     -main-is Test.main
+```
+
+Here the entry point is `Test.main`, not `Main.main`. Without parsing `-main-is`, we'd
+invoke the wrong function.
+
+GHC options live in `BuildInfo.options :: PerCompilerFlavor [String]`, extracted via
+`hcOptions GHC bi`. We scan the resulting `[String]` for a `-main-is` flag (either as a
+separate token followed by the qualified name, or combined as `"-main-is Foo.bar"`).
+
+---
+
+## Multi-REPL: In-Session Eval is a Dead End
+
+### Home unit modules are not accessible in the multi-repl interactive context
+
+In a `cabal repl --enable-multi-repl` session, the interactive evaluator has no access to
+any home unit module by default. Verified empirically:
+
+```
+ghci> main
+<interactive>:1:1: error: [GHC-88464]
+    Variable not in scope: main
+```
+
+`:module *Main` — the normal way to bring a `Main` into scope — is explicitly unsupported:
+
+```
+ghci> :module *Main
+Command is not supported (yet) in multi-mode
+```
+
+This applies even when only a single test suite is loaded alongside a library. As soon as
+`--enable-multi-repl` is used with more than one home unit, the interactive context is
+isolated from all of them.
+
+**Consequence:** evaluating a test entry point inside the main ghcib GHCi session is not
+possible. Any `-main-is` naming trick or module qualification scheme is irrelevant — the
+module simply cannot be reached.
+
+### `-XPackageImports` does not apply
+
+Test suite components are home units, not packages in the package database. They do not
+appear in `:show packages` output. Package-qualified import syntax (`import "pkg" Module`)
+only works for database packages, not home units.
+
+---
+
+## Separate-Process Approach: Artifact Sharing and Timing
+
+### The approach
+
+After each clean build, spawn a short-lived `cabal repl test:<name>` process, send `:main`,
+collect output, then exit. This sidesteps the multi-repl eval problem entirely.
+
+### Does the separate repl recompile from scratch?
+
+**First run after switching build flavor:** yes, full recompile. Observed when switching
+from a plain multi-repl session to a single-target repl — all 14 modules recompiled with
+`[Flags changed]`.
+
+**Subsequent runs (same flavor):** no recompilation. GHCi reuses interpreted bytecode from
+the previous single-target repl run. Verified by touching a source file — the run still
+showed `Ok, 13 modules loaded` with no compilation lines, using cached bytecode.
+
+**With `-fobject-code` on the multi-repl session:** writes `.o` files to the same
+`dist-newstyle` paths that a single-target repl uses, but the first single-target run still
+shows `[Flags changed]` and recompiles. The unit-id and flag fingerprints differ between
+multi-repl and single-target, so their artifacts are not compatible.
+
+**Conclusion:** artifact sharing between the multi-repl and the test repl is not feasible.
+The test repl maintains its own bytecode cache. After the first run it reuses that cache
+efficiently.
+
+### Timing (measured on ghcib/test:ghcib-test, 117 tests)
+
+| Scenario | Time |
+|----------|------|
+| First run (cold bytecode cache) | ~3s |
+| Subsequent run, no source changes | ~3s |
+| After touching one test file | ~3s |
+
+All ~3s is GHCi/cabal startup overhead. Recompilation cost is negligible (single changed
+module recompiles in <0.1s, absorbed into startup noise). Test execution itself is 0.31s.
+
+**The ~3s floor is irreducible** — it's process startup, cabal plan resolution, and GHCi
+initialisation. This is acceptable for a post-build test run.
+
+### Session cloning is not viable
+
+- **OS `fork()`**: unsafe on a multi-threaded Haskell RTS process.
+- **CRIU snapshot/restore**: requires elevated privileges (`CAP_SYS_PTRACE`), breaks on
+  open sockets (which ghcid holds), and is operationally complex.
+- Neither is practical.
+
+---
+
+## Multiple Test Suites and `testTargets`
+
+### The ghcib repo is a concrete collision case
+
+Both `test:atelier-test` and `test:ghcib-test` use `main-is: Driver.hs` with no `-main-is`
+override — both produce a `Main` module. This is representative of monorepo projects.
+
+### Design: auto-discover with optional `testTargets` filter
+
+- **Default:** discover all `test:` components in `targets`, run each in its own `cabal
+  repl` process sequentially after a clean build.
+- **`testTargets` config field:** optional list of `test:<name>` components to run. When
+  set, only those suites are run regardless of what else is in `targets`. Allows narrowing
+  in a monorepo without changing the build targets.
+- **No collision problem:** each test suite runs in its own single-target repl process,
+  so there is no module ambiguity. The multi-repl ambiguity issue is entirely avoided.
+
+```toml
+# Run all test suites in targets (default — no config needed for single-suite projects)
+targets = ["lib:mylib", "test:mylib-test"]
+
+# Monorepo: load everything but only run one suite
+targets = ["lib:atelier", "test:atelier-test", "lib:ghcib", "test:ghcib-test"]
+test_targets = ["test:ghcib-test"]
+```
+
+---
+
+## Pass/Fail Detection
+
+Standard Haskell test frameworks signal failure via `System.Exit.exitFailure`, which GHCi
+surfaces as:
+
+```
+*** Exception: ExitFailure 1
+```
+
+Observed in a real run:
+
+```
+All 117 tests passed (0.31s)
+*** Exception: ExitSuccess
+```
+
+Both pass and fail go through `exitWith`. Detection heuristic:
+
+- `*** Exception: ExitSuccess` → **pass**
+- `*** Exception: ExitFailure N` → **fail**
+- Any other `*** Exception:` → **error** (runner crashed)
+- No exception line (e.g. runner called `exitSuccess` then process ended) → treat as **pass**
+
+This covers HSpec, Tasty, HUnit, and any runner that calls `exitWith`. Runners that
+indicate failure only via output text (without `exitFailure`) are not covered, but none of
+the major frameworks do this.
+
+---
+
+## Summary of Findings
+
+| Question | Finding |
+|----------|---------|
+| Can we eval expressions in the multi-repl session? | **No** — home unit modules are inaccessible in multi-mode interactive context; `:module` unsupported |
+| Can `-XPackageImports` or `-main-is` naming help? | No — home units are not in the package database; naming tricks are irrelevant |
+| Can we clone the GHCi session? | No — fork is unsafe, CRIU is impractical |
+| Can artifacts be shared between multi-repl and test repl? | No — different flag fingerprints cause `[Flags changed]` rebuild on first run |
+| How fast is a separate single-target test repl? | ~3s total (startup-dominated); effectively free after first run |
+| Framework detection needed? | No — all frameworks go through `main`/`exitWith` |
+| Can we auto-discover the entry point? | Not needed — `:main` in the test repl resolves the entry point via GHCi's built-in `-main-is` handling; no cabal parsing required at runtime |
+| How to handle multiple test suites? | Run each in its own process; `testTargets` filters which ones |
+| Pass/fail detection | `*** Exception: ExitSuccess/ExitFailure` pattern; covers all major frameworks |

--- a/ghcib/proposals/README.md
+++ b/ghcib/proposals/README.md
@@ -5,3 +5,4 @@
 | [001](001-diagnostic-rename/) | Rename `Message` to `Diagnostic` | Done |
 | [002](002-plugin-diagnostics/) | Plugin-Based Structured Diagnostics | Draft |
 | [003](003-source-lookup/) | Package Source Lookup | Draft |
+| [004](004-tests-after-build/) | Run Tests After Build | Draft |

--- a/ghcib/src/Ghcib/BuildState.hs
+++ b/ghcib/src/Ghcib/BuildState.hs
@@ -3,6 +3,8 @@ module Ghcib.BuildState
     , BuildState (..)
     , BuildPhase (..)
     , BuildResult (..)
+    , TestRun (..)
+    , TestOutcome (..)
     , DaemonInfo (..)
     , Diagnostic (..)
     , Severity (..)
@@ -33,11 +35,26 @@ data DaemonInfo = DaemonInfo
     deriving anyclass (FromJSON, ToJSON)
 
 
+data TestOutcome = TestsPassed | TestsFailed | TestsError Text
+    deriving stock (Eq, Generic, Show)
+    deriving anyclass (FromJSON, ToJSON)
+
+
+data TestRun = TestRun
+    { target :: Text
+    , outcome :: TestOutcome
+    , output :: Text
+    }
+    deriving stock (Eq, Generic, Show)
+    deriving anyclass (FromJSON, ToJSON)
+
+
 data BuildResult = BuildResult
     { completedAt :: UTCTime
     , durationMs :: Int
     , moduleCount :: Int
     , diagnostics :: [Diagnostic]
+    , testRuns :: [TestRun]
     }
     deriving stock (Eq, Generic, Show)
     deriving anyclass (FromJSON, ToJSON)
@@ -45,6 +62,7 @@ data BuildResult = BuildResult
 
 data BuildPhase
     = Building
+    | Testing
     | Done BuildResult
     deriving stock (Eq, Generic, Show)
     deriving anyclass (FromJSON, ToJSON)
@@ -91,6 +109,7 @@ instance ToJSON Severity where
 
 stateLabel :: BuildPhase -> Text
 stateLabel Building = "building"
+stateLabel Testing = "testing"
 stateLabel (Done result)
     | any (\m -> m.severity == SError) result.diagnostics = "error"
     | any (\m -> m.severity == SWarning) result.diagnostics = "warning"

--- a/ghcib/src/Ghcib/Config.hs
+++ b/ghcib/src/Ghcib/Config.hs
@@ -5,6 +5,7 @@ module Ghcib.Config
     , loadConfig
     , resolveCommand
     , resolveTargets
+    , resolveTestTargets
     , resolveWatchDirs
     , allComponentTargets
     , sourceDirsForTarget
@@ -46,6 +47,7 @@ data Config = Config
     { command :: Maybe Text
     , targets :: [Text]
     , watchDirs :: [FilePath]
+    , testTargets :: Maybe [Text]
     , debounceMs :: Millisecond
     , outputFile :: Maybe FilePath
     , logFile :: Maybe FilePath
@@ -61,6 +63,7 @@ instance Default Config where
             { command = Nothing
             , targets = []
             , watchDirs = []
+            , testTargets = Nothing
             , debounceMs = 100
             , outputFile = Just "build.json"
             , logFile = Nothing
@@ -78,6 +81,7 @@ instance DecodeTOML Config where
         command <- getFieldOpt "command"
         targets <- getFieldOr [] "targets"
         watchDirs <- getFieldOr [] "watch_dirs"
+        testTargets <- getFieldOpt "test_targets"
         debounceMs <- getFieldOr 100 "debounce_ms"
         outputFile <- getFieldOr (Just "build.json") "output_file"
         logFile <- getFieldOpt "log_file"
@@ -87,6 +91,7 @@ instance DecodeTOML Config where
                 { command = command
                 , targets = targets
                 , watchDirs = watchDirs
+                , testTargets = testTargets
                 , debounceMs = debounceMs
                 , outputFile = outputFile
                 , logFile = logFile
@@ -210,3 +215,13 @@ sourceDirsForTarget gpd target =
     libDirs = hsSourceDirs . libBuildInfo
     testDirs = hsSourceDirs . testBuildInfo
     exeDirs = hsSourceDirs . buildInfo
+
+
+-- | Resolve which test suites to run after a clean build.
+--
+-- When 'testTargets' is set in config, those suites are used directly.
+-- Otherwise, all @test:@ components in 'targets' are inferred.
+resolveTestTargets :: Config -> [Text]
+resolveTestTargets cfg = case cfg.testTargets of
+    Just explicit -> explicit
+    Nothing -> filter ("test:" `T.isPrefixOf`) cfg.targets

--- a/ghcib/src/Ghcib/Daemon.hs
+++ b/ghcib/src/Ghcib/Daemon.hs
@@ -27,6 +27,7 @@ import Ghcib.Effects.BuildStore (runBuildStore)
 import Ghcib.Effects.FileWatcher (runFileWatcherIO)
 import Ghcib.Effects.GhcPkg (runGhcPkgIO)
 import Ghcib.Effects.GhciSession (runGhciSessionIO)
+import Ghcib.Effects.TestRunner (runTestRunnerIO)
 import Ghcib.Effects.UnixSocket (runUnixSocketIO)
 import Ghcib.GhcPkg.Types (ModuleName, PackageId)
 import Ghcib.Socket.Client (socketPath)
@@ -77,6 +78,7 @@ runDaemon projectRoot cfg = do
             . runConc
             . runFileWatcherIO
             . runGhciSessionIO
+            . runTestRunnerIO projectRoot
             . runUnixSocketIO
             . runFileSystemIO
             . runReader effectiveCfg

--- a/ghcib/src/Ghcib/Effects/BuildStore.hs
+++ b/ghcib/src/Ghcib/Effects/BuildStore.hs
@@ -81,6 +81,7 @@ runBuildStoreSTM eff = do
     isBuilding :: BuildState -> Bool
     isBuilding s = case s.phase of
         Building -> True
+        Testing -> True
         Done _ -> False
 
     emptyDaemonInfo = DaemonInfo {targets = [], watchDirs = [], sockPath = "", logFile = Nothing, metricsPort = Nothing}
@@ -104,6 +105,7 @@ runBuildStoreRef BuildStateRef {stateRef = ref, dirtyRef} =
     isBuilding :: BuildState -> Bool
     isBuilding s = case s.phase of
         Building -> True
+        Testing -> True
         Done _ -> False
 
 
@@ -153,6 +155,7 @@ runBuildStoreScripted states = reinterpret (evalState states) $ \_ -> \case
     isBuilding :: BuildState -> Bool
     isBuilding s = case s.phase of
         Building -> True
+        Testing -> True
         Done _ -> False
 
     advance :: (BuildState -> Bool) -> Eff (State [BuildState] : es) BuildState

--- a/ghcib/src/Ghcib/Effects/TestRunner.hs
+++ b/ghcib/src/Ghcib/Effects/TestRunner.hs
@@ -1,0 +1,102 @@
+module Ghcib.Effects.TestRunner
+    ( -- * Effect
+      TestRunner
+    , runTestSuite
+
+      -- * Interpreters
+    , runTestRunnerIO
+    , runTestRunnerScripted
+
+      -- * Parsing utilities
+    , detectOutcome
+    ) where
+
+import Control.Exception (throwIO)
+import Effectful (Effect, IOE)
+import Effectful.Dispatch.Dynamic (interpret_, reinterpret)
+import Effectful.Exception (try)
+import Effectful.State.Static.Shared (State, evalState, get, put)
+import Effectful.TH (makeEffect)
+import System.Process.Typed (byteStringInput, proc, readProcess, setStdin, setWorkingDir)
+
+import Data.ByteString.Lazy qualified as BSL
+import Data.List qualified as List
+import Data.Text qualified as T
+
+import Ghcib.BuildState (TestOutcome (..), TestRun (..))
+
+
+data TestRunner :: Effect where
+    -- | Run a single test suite in a short-lived @cabal repl@ process and
+    -- return the captured output and detected outcome.
+    RunTestSuite :: Text -> TestRunner m TestRun
+
+
+makeEffect ''TestRunner
+
+
+-- | Production interpreter that spawns a short-lived @cabal repl test:\<name\>@
+-- process for each suite, feeds @:main\\n:quit\\n@ to stdin, captures combined
+-- stdout+stderr, and detects the outcome via 'detectOutcome'.
+runTestRunnerIO :: (IOE :> es) => FilePath -> Eff (TestRunner : es) a -> Eff es a
+runTestRunnerIO projectRoot = interpret_ \case
+    RunTestSuite target -> do
+        result <- try @SomeException $ liftIO do
+            let config =
+                    setStdin (byteStringInput ":main\n:quit\n")
+                        $ setWorkingDir projectRoot
+                        $ proc "cabal" ["repl", toString target]
+            (_, out, err) <- readProcess config
+            pure (out, err)
+        pure $ case result of
+            Left ex ->
+                TestRun {target, outcome = TestsError (show ex :: Text), output = ""}
+            Right (out, err) ->
+                let output = decodeUtf8 (BSL.toStrict out) <> decodeUtf8 (BSL.toStrict err)
+                in  TestRun {target, outcome = detectOutcome output, output}
+
+
+-- | Scripted interpreter for testing.
+--
+-- Each call to 'runTestSuite' pops the next result from the pre-loaded list.
+-- 'Left' results are re-thrown as exceptions, simulating process failures.
+runTestRunnerScripted
+    :: forall es a
+     . (IOE :> es)
+    => [Either SomeException TestRun]
+    -> Eff (TestRunner : es) a
+    -> Eff es a
+runTestRunnerScripted results = reinterpret (evalState results) $ \_ ->
+    let popResult :: Eff (State [Either SomeException TestRun] : es) TestRun
+        popResult =
+            get >>= \case
+                [] -> error "TestRunnerScripted: no more results in queue"
+                Left ex : rest -> put rest >> liftIO (throwIO ex)
+                Right r : rest -> put rest >> pure r
+    in  \case
+            RunTestSuite _ -> popResult
+
+
+-- | Detect the test outcome from raw GHCi output.
+--
+-- All major test frameworks (@hspec@, @tasty@, @HUnit@) call
+-- 'System.Exit.exitWith' on completion. GHCi surfaces this as a line
+-- matching @*** Exception: ExitSuccess@ (pass) or
+-- @*** Exception: ExitFailure N@ (fail). Any other @*** Exception:@ line
+-- means the runner crashed. Absence of an exception line is treated as pass.
+detectOutcome :: Text -> TestOutcome
+detectOutcome output =
+    case List.find ("*** Exception: " `T.isPrefixOf`) (T.lines output) of
+        Nothing -> TestsPassed
+        Just line ->
+            case T.stripPrefix "*** Exception: " line of
+                Nothing -> TestsPassed
+                Just rest ->
+                    let r = T.strip rest
+                    in  if r == "ExitSuccess" then
+                            TestsPassed
+                        else
+                            if "ExitFailure" `T.isPrefixOf` r then
+                                TestsFailed
+                            else
+                                TestsError r

--- a/ghcib/src/Ghcib/GhciSession.hs
+++ b/ghcib/src/Ghcib/GhciSession.hs
@@ -14,14 +14,16 @@ import Atelier.Effects.FileSystem (FileSystem, getCurrentDirectory)
 import Atelier.Effects.Log (Log)
 import Atelier.Exception (isGracefulShutdown)
 import Atelier.Time (Millisecond)
-import Ghcib.BuildState (BuildId (..), BuildPhase (..), BuildResult (..), ChangeKind (..), Diagnostic (..))
-import Ghcib.Config (Config (..), resolveCommand, resolveWatchDirs)
+import Ghcib.BuildState (BuildId (..), BuildPhase (..), BuildResult (..), ChangeKind (..), Diagnostic (..), Severity (..), TestRun)
+import Ghcib.Config (Config (..), resolveCommand, resolveTestTargets, resolveWatchDirs)
 import Ghcib.Effects.BuildStore (BuildStore, setPhase, waitDirty)
 import Ghcib.Effects.GhciSession (GhciSession, LoadResult (..))
+import Ghcib.Effects.TestRunner (TestRunner)
 
 import Atelier.Effects.Clock qualified as Clock
 import Atelier.Effects.Log qualified as Log
 import Ghcib.Effects.GhciSession qualified as GhciSession
+import Ghcib.Effects.TestRunner qualified as TestRunner
 
 
 -- | Merge a new 'LoadResult' into the accumulated per-file diagnostic map.
@@ -74,6 +76,7 @@ component
        , GhciSession :> es
        , Log :> es
        , Reader Config :> es
+       , TestRunner :> es
        )
     => Component es
 component =
@@ -84,9 +87,10 @@ component =
             projectRoot <- getCurrentDirectory
             cmd <- resolveCommand cfg projectRoot
             watchDirs <- resolveWatchDirs cfg projectRoot
+            let testTargets = resolveTestTargets cfg
             Log.debug $ "GhciSession.component: resolved command = " <> cmd
             Log.debug $ "GhciSession.component: projectRoot = " <> toText projectRoot
-            pure [sessionListener cmd projectRoot watchDirs]
+            pure [sessionListener cmd projectRoot watchDirs testTargets]
         }
 
 
@@ -96,12 +100,14 @@ sessionListener
        , Delay :> es
        , GhciSession :> es
        , Log :> es
+       , TestRunner :> es
        )
     => Text
     -> FilePath
     -> [FilePath]
+    -> [Text]
     -> Listener es
-sessionListener cmd projectRoot watchDirs = startSession (BuildId 1)
+sessionListener cmd projectRoot watchDirs testTargets = startSession (BuildId 1)
   where
     filterDiags = filterToWatchDirs projectRoot watchDirs
 
@@ -122,8 +128,9 @@ sessionListener cmd projectRoot watchDirs = startSession (BuildId 1)
                 let filteredMsgs = filterDiags msgs
                 Log.info $ "GHCi started (session #" <> show n <> "): " <> show (length filteredMsgs) <> " diagnostics"
                 let durationMs = round (realToFrac (diffUTCTime t1 t0) * 1000 :: Double) :: Int
-                    buildResult = BuildResult {completedAt = t1, durationMs, moduleCount, diagnostics = filteredMsgs}
                     accumulated = Map.fromListWith (++) [(d.file, [d]) | d <- filteredMsgs]
+                testRuns <- runTestsIfClean (BuildId n) filteredMsgs
+                let buildResult = BuildResult {completedAt = t1, durationMs, moduleCount, diagnostics = filteredMsgs, testRuns}
                 setPhase (BuildId n) (Done buildResult)
                 Log.debug $ "Build state updated to Done (session #" <> show n <> ")"
                 listenLoop (BuildId (n + 1)) accumulated
@@ -159,6 +166,24 @@ sessionListener cmd projectRoot watchDirs = startSession (BuildId 1)
                             durationMs = round (realToFrac (diffUTCTime t1 t0) * 1000 :: Double) :: Int
                             newAccumulated = mergeDiagnostics accumulated filteredResult
                             allMsgs = concat (Map.elems newAccumulated)
-                            buildResult = BuildResult {completedAt = t1, durationMs, moduleCount = loadResult.moduleCount, diagnostics = allMsgs}
+                        testRuns <- runTestsIfClean (BuildId n) allMsgs
+                        let buildResult = BuildResult {completedAt = t1, durationMs, moduleCount = loadResult.moduleCount, diagnostics = allMsgs, testRuns}
                         setPhase (BuildId n) (Done buildResult)
                         listenLoop nextId newAccumulated
+
+    -- Run all configured test suites if the build has no errors.
+    -- Transitions to 'Testing' phase while suites are running.
+    runTestsIfClean
+        :: (BuildStore :> es, Log :> es, TestRunner :> es)
+        => BuildId -> [Diagnostic] -> Eff es [TestRun]
+    runTestsIfClean bid diags
+        | not (null testTargets) && not (any (\d -> d.severity == SError) diags) = do
+            setPhase bid Testing
+            Log.info $ "Running " <> show (length testTargets) <> " test suite(s)"
+            mapM
+                ( \target -> do
+                    Log.info $ "Running tests: " <> target
+                    TestRunner.runTestSuite target
+                )
+                testTargets
+        | otherwise = pure []

--- a/ghcib/src/Ghcib/Program.hs
+++ b/ghcib/src/Ghcib/Program.hs
@@ -26,6 +26,8 @@ import Ghcib.BuildState
     , DaemonInfo (..)
     , Diagnostic (..)
     , Severity (..)
+    , TestOutcome (..)
+    , TestRun (..)
     )
 import Ghcib.Config (loadConfig)
 import Ghcib.Daemon (startDaemon, stopDaemon)
@@ -104,6 +106,7 @@ showStatus waitFlag jsonFlag verboseFlag = do
         current <- queryStatus sockPath
         case current of
             Right BuildState {phase = Building} -> Console.putStrLn "Building..."
+            Right BuildState {phase = Testing} -> Console.putStrLn "Testing..."
             _ -> pure ()
     result <-
         if waitFlag then
@@ -121,6 +124,7 @@ showStatus waitFlag jsonFlag verboseFlag = do
   where
     renderText verbose state = case state.phase of
         Building -> Console.putStrLn "Building..."
+        Testing -> Console.putStrLn "Testing..."
         Done r -> do
             tz <- liftIO getCurrentTimeZone
             let printDiag =
@@ -130,7 +134,20 @@ showStatus waitFlag jsonFlag verboseFlag = do
                         Console.putTextLn . diagnosticLine
             mapM_ printDiag r.diagnostics
             Console.putTextLn $ buildSummary tz r
-            when (any ((== SError) . (.severity)) r.diagnostics) $ liftIO exitFailure
+            mapM_ (printTestRun verbose) r.testRuns
+            when (buildHasErrors r || testsFailed r) $ liftIO exitFailure
+
+    printTestRun verbose tr = do
+        Console.putTextLn $ testRunSummary tr.target tr.outcome
+        when verbose
+            $ mapM_ (Console.putTextLn . ("  " <>) . toText) (lines tr.output)
+      where
+        testRunSummary t TestsPassed = t <> "  passed"
+        testRunSummary t TestsFailed = t <> "  failed"
+        testRunSummary t (TestsError msg) = t <> "  error: " <> msg
+
+    buildHasErrors r = any ((== SError) . (.severity)) r.diagnostics
+    testsFailed r = any ((/= TestsPassed) . (.outcome)) r.testRuns
 
     buildSummary tz r =
         let errs = length $ filter ((== SError) . (.severity)) r.diagnostics

--- a/ghcib/src/Ghcib/Render.hs
+++ b/ghcib/src/Ghcib/Render.hs
@@ -33,6 +33,8 @@ import Ghcib.BuildState
     , DaemonInfo (..)
     , Diagnostic (..)
     , Severity (..)
+    , TestOutcome (..)
+    , TestRun (..)
     )
 import Ghcib.Effects.Display (Style (..))
 import Ghcib.GhcPkg.Types (ModuleName (..), PackageId (..))
@@ -57,11 +59,14 @@ buildStateDoc tz bs =
     statusDoc = case bs.phase of
         Building ->
             annotate Warn "Building..."
+        Testing ->
+            annotate Warn "Testing..."
         Done result
             | null result.diagnostics ->
                 annotate Ok "All good."
                     <+> buildSummaryDoc result.moduleCount result.durationMs
                     <+> timestampDoc tz result.completedAt
+                    <> testRunsSection result.testRuns
         Done result ->
             let msgs = result.diagnostics
                 errCount = length $ filter (\m -> m.severity == SError) msgs
@@ -77,6 +82,7 @@ buildStateDoc tz bs =
                     <> hardline
                     <> hardline
                     <> vsep (map diagnosticDoc msgs)
+                    <> testRunsSection result.testRuns
 
 
 buildSummaryDoc :: Int -> Int -> Doc ann
@@ -85,6 +91,21 @@ buildSummaryDoc mods ms = "(" <> pretty mods <+> "modules," <+> pretty (formatDu
 
 durationDoc :: Int -> Doc ann
 durationDoc ms = "(" <> pretty (formatDuration ms) <> ")"
+
+
+testRunsSection :: [TestRun] -> Doc Style
+testRunsSection [] = mempty
+testRunsSection runs = hardline <> hardline <> vsep (map testRunLine runs)
+
+
+testRunLine :: TestRun -> Doc Style
+testRunLine tr = pretty tr.target <> "  " <> testOutcomeDoc tr.outcome
+
+
+testOutcomeDoc :: TestOutcome -> Doc Style
+testOutcomeDoc TestsPassed = annotate Ok "passed"
+testOutcomeDoc TestsFailed = annotate Err "failed"
+testOutcomeDoc (TestsError msg) = annotate Err "error:" <+> pretty msg
 
 
 timestampDoc :: TimeZone -> UTCTime -> Doc ann

--- a/ghcib/src/Ghcib/Socket/Server.hs
+++ b/ghcib/src/Ghcib/Socket/Server.hs
@@ -144,6 +144,7 @@ respondWhenDone h = awaitResult >>= sendJson h
         s <- getState
         case s.phase of
             Building -> waitUntilDone
+            Testing -> waitUntilDone
             Done _ -> awaitBuildStart (5 :: Int) s
 
     -- Poll up to n × 50ms for a build to start, then wait for it to finish.
@@ -153,6 +154,7 @@ respondWhenDone h = awaitResult >>= sendJson h
         s' <- getState
         case s'.phase of
             Building -> waitUntilDone
+            Testing -> waitUntilDone
             Done _ -> awaitBuildStart (n - 1) s'
 
 

--- a/ghcib/test/Unit/Ghcib/BuildStateSpec.hs
+++ b/ghcib/test/Unit/Ghcib/BuildStateSpec.hs
@@ -60,7 +60,7 @@ mkBuildState :: [Diagnostic] -> BuildState
 mkBuildState msgs =
     BuildState
         { buildId = BuildId 1
-        , phase = Done (BuildResult {completedAt = epoch, durationMs = 0, moduleCount = 0, diagnostics = msgs})
+        , phase = Done (BuildResult {completedAt = epoch, durationMs = 0, moduleCount = 0, diagnostics = msgs, testRuns = []})
         , daemonInfo = DaemonInfo {targets = [], watchDirs = [], sockPath = "", logFile = Nothing, metricsPort = Nothing}
         }
   where

--- a/ghcib/test/Unit/Ghcib/BuildStoreSpec.hs
+++ b/ghcib/test/Unit/Ghcib/BuildStoreSpec.hs
@@ -139,7 +139,7 @@ buildingAt n = BuildState (BuildId n) Building emptyDaemonInfo
 
 
 doneAt :: Int -> BuildState
-doneAt n = BuildState (BuildId n) (Done (BuildResult {completedAt = epoch, durationMs = 0, moduleCount = 0, diagnostics = []})) emptyDaemonInfo
+doneAt n = BuildState (BuildId n) (Done (BuildResult {completedAt = epoch, durationMs = 0, moduleCount = 0, diagnostics = [], testRuns = []})) emptyDaemonInfo
 
 
 epoch :: UTCTime

--- a/ghcib/test/Unit/Ghcib/ConfigSpec.hs
+++ b/ghcib/test/Unit/Ghcib/ConfigSpec.hs
@@ -1,14 +1,16 @@
 module Unit.Ghcib.ConfigSpec (spec_Config) where
 
+import Data.Default (Default (..))
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescriptionMaybe)
 import Distribution.Types.GenericPackageDescription (GenericPackageDescription)
 import Test.Hspec
 
-import Ghcib.Config (allComponentTargets, sourceDirsForTarget)
+import Ghcib.Config (Config (..), allComponentTargets, resolveTestTargets, sourceDirsForTarget)
 
 
 spec_Config :: Spec
 spec_Config = do
+    describe "resolveTestTargets" testResolveTestTargets
     describe "sourceDirsForTarget" do
         describe "lib:" do
             it "returns main library source dirs" do
@@ -53,6 +55,29 @@ spec_Config = do
         it "returns all four components for the fixture" do
             allComponentTargets gpd
                 `shouldBe` ["lib:myapp", "lib:myapp-utils", "exe:myapp-exe", "test:myapp-test"]
+
+
+testResolveTestTargets :: Spec
+testResolveTestTargets = do
+    it "infers test: components from targets when testTargets is absent" do
+        let cfg = def {targets = ["lib:mylib", "test:mylib-test"]}
+        resolveTestTargets cfg `shouldBe` ["test:mylib-test"]
+
+    it "returns empty list when no test: components in targets" do
+        let cfg = def {targets = ["lib:mylib", "exe:myapp"]}
+        resolveTestTargets cfg `shouldBe` []
+
+    it "uses explicit testTargets list when set" do
+        let cfg = def {targets = ["lib:a", "test:a-test", "test:b-test"], testTargets = Just ["test:b-test"]}
+        resolveTestTargets cfg `shouldBe` ["test:b-test"]
+
+    it "returns empty list when testTargets is explicitly empty" do
+        let cfg = def {targets = ["lib:a", "test:a-test"], testTargets = Just []}
+        resolveTestTargets cfg `shouldBe` []
+
+    it "infers multiple test: components" do
+        let cfg = def {targets = ["lib:a", "test:a-test", "test:b-test"]}
+        resolveTestTargets cfg `shouldBe` ["test:a-test", "test:b-test"]
 
 
 --------------------------------------------------------------------------------

--- a/ghcib/test/Unit/Ghcib/GhciSessionSpec.hs
+++ b/ghcib/test/Unit/Ghcib/GhciSessionSpec.hs
@@ -25,6 +25,7 @@ import Ghcib.Effects.GhciSession
     , startGhci
     , stopGhci
     )
+import Ghcib.Effects.TestRunner (TestRunner, runTestRunnerScripted)
 import Ghcib.GhciSession (filterToWatchDirs, mergeDiagnostics, sessionListener)
 
 
@@ -110,7 +111,7 @@ testSessionListener = do
             let t0 = epoch
                 t1 = addUTCTime 2 epoch -- 2 seconds later
             result <- runListenerTest [t0, t1] [simpleResult []] do
-                void $ fork $ sessionListener "cabal repl" "/" []
+                void $ fork $ sessionListener "cabal repl" "/" [] []
                 waitUntilDone
             case result.phase of
                 Done br -> br.durationMs `shouldBe` 2000
@@ -118,7 +119,7 @@ testSessionListener = do
 
         it "records moduleCount from LoadResult" do
             result <- runListenerTest [epoch, epoch] [simpleResultWith 7 []] do
-                void $ fork $ sessionListener "cabal repl" "/" []
+                void $ fork $ sessionListener "cabal repl" "/" [] []
                 waitUntilDone
             case result.phase of
                 Done br -> br.moduleCount `shouldBe` 7
@@ -354,7 +355,7 @@ runScripted results = runEff . runGhciSessionScripted results
 runListenerTest
     :: [UTCTime]
     -> [Either SomeException LoadResult]
-    -> Eff '[GhciSession, Conc, Clock, BuildStore, Delay, Log, Concurrent, IOE] a
+    -> Eff '[GhciSession, TestRunner, Conc, Clock, BuildStore, Delay, Log, Concurrent, IOE] a
     -> IO a
 runListenerTest times results =
     runEff
@@ -364,4 +365,5 @@ runListenerTest times results =
         . runBuildStoreSTM
         . runClockList times
         . runConc
+        . runTestRunnerScripted []
         . runGhciSessionScripted results

--- a/ghcib/test/Unit/Ghcib/TestRunnerSpec.hs
+++ b/ghcib/test/Unit/Ghcib/TestRunnerSpec.hs
@@ -1,0 +1,125 @@
+module Unit.Ghcib.TestRunnerSpec (spec_TestRunner) where
+
+import Control.Exception (ErrorCall (..))
+import Effectful (IOE, runEff)
+import Effectful.Exception (try)
+import Test.Hspec
+
+import Ghcib.BuildState (TestOutcome (..), TestRun (..))
+import Ghcib.Effects.TestRunner
+    ( TestRunner
+    , detectOutcome
+    , runTestRunnerScripted
+    , runTestSuite
+    )
+
+
+spec_TestRunner :: Spec
+spec_TestRunner = do
+    describe "detectOutcome" testDetectOutcome
+    describe "runTestRunnerScripted" testScripted
+
+
+--------------------------------------------------------------------------------
+-- detectOutcome tests
+--------------------------------------------------------------------------------
+
+testDetectOutcome :: Spec
+testDetectOutcome = do
+    describe "no exception line" do
+        it "treats empty output as pass" do
+            detectOutcome "" `shouldBe` TestsPassed
+
+        it "treats output with no exception as pass" do
+            detectOutcome "2 examples, 0 failures\n" `shouldBe` TestsPassed
+
+        it "does not match 'ExitSuccess' without the exception prefix" do
+            detectOutcome "ExitSuccess\n" `shouldBe` TestsPassed
+
+    describe "ExitSuccess" do
+        it "detects ExitSuccess as pass" do
+            detectOutcome "*** Exception: ExitSuccess\n" `shouldBe` TestsPassed
+
+        it "detects ExitSuccess anywhere in output" do
+            detectOutcome "All tests passed\n*** Exception: ExitSuccess\n"
+                `shouldBe` TestsPassed
+
+    describe "ExitFailure" do
+        it "detects ExitFailure 1 as fail" do
+            detectOutcome "1 failure\n*** Exception: ExitFailure 1\n"
+                `shouldBe` TestsFailed
+
+        it "detects ExitFailure with any exit code as fail" do
+            detectOutcome "*** Exception: ExitFailure 42\n" `shouldBe` TestsFailed
+
+        it "detects ExitFailure anywhere in output" do
+            detectOutcome "Some output\n*** Exception: ExitFailure 1\nMore output\n"
+                `shouldBe` TestsFailed
+
+    describe "other exception" do
+        it "classifies unknown exception as error with message" do
+            detectOutcome "*** Exception: SomeException \"oops\"\n"
+                `shouldBe` TestsError "SomeException \"oops\""
+
+        it "trims trailing whitespace from the error message" do
+            detectOutcome "*** Exception: Crashed  \n"
+                `shouldBe` TestsError "Crashed"
+
+
+--------------------------------------------------------------------------------
+-- Scripted interpreter tests
+--------------------------------------------------------------------------------
+
+testScripted :: Spec
+testScripted = do
+    it "returns scripted TestRun" do
+        result <- runScripted [Right passingRun] $ runTestSuite "test:foo"
+        result `shouldBe` passingRun
+
+    it "ignores the target name argument" do
+        result <- runScripted [Right failingRun] $ runTestSuite "test:anything"
+        result `shouldBe` failingRun
+
+    it "throws when scripted result is Left" do
+        result <-
+            runScripted [Left (toException boom)]
+                $ try @ErrorCall
+                $ runTestSuite "test:foo"
+        result `shouldBe` Left boom
+
+    describe "sequencing" do
+        it "consumes results in order across multiple calls" do
+            (a, b) <- runScripted [Right passingRun, Right failingRun] do
+                a <- runTestSuite "test:foo"
+                b <- runTestSuite "test:bar"
+                pure (a, b)
+            a `shouldBe` passingRun
+            b `shouldBe` failingRun
+
+        it "recover scenario: error then success" do
+            result <- runScripted [Left (toException boom), Right passingRun] do
+                r1 <- try @ErrorCall $ runTestSuite "test:foo"
+                r2 <- runTestSuite "test:bar"
+                pure (r1, r2)
+            fst result `shouldBe` Left boom
+            snd result `shouldBe` passingRun
+
+
+--------------------------------------------------------------------------------
+-- Helpers
+--------------------------------------------------------------------------------
+
+boom :: ErrorCall
+boom = ErrorCall "simulated process crash"
+
+
+passingRun :: TestRun
+passingRun = TestRun {target = "test:foo", outcome = TestsPassed, output = "2 examples, 0 failures\n"}
+
+
+failingRun :: TestRun
+failingRun = TestRun {target = "test:bar", outcome = TestsFailed, output = "1 example, 1 failure\n"}
+
+
+runScripted :: [Either SomeException TestRun] -> Eff '[TestRunner, IOE] a -> IO a
+runScripted results = runEff . runTestRunnerScripted results

--- a/ghcib/test/Unit/Ghcib/WatchSpec.hs
+++ b/ghcib/test/Unit/Ghcib/WatchSpec.hs
@@ -14,6 +14,8 @@ import Ghcib.BuildState
     , DaemonInfo (..)
     , Diagnostic (..)
     , Severity (..)
+    , TestOutcome (..)
+    , TestRun (..)
     )
 import Ghcib.Effects.Display (Style)
 import Ghcib.Render (buildStateDoc, daemonInfoDoc, diagnosticBlock, diagnosticDoc)
@@ -60,6 +62,38 @@ spec_Watch = do
                 let rendered = render (buildStateDoc utc (doneState 0 [errMsg, warnMsg]))
                 rendered `shouldContain` "1 error(s)"
                 rendered `shouldContain` "1 warning(s)"
+
+        describe "test runs" do
+            it "shows nothing extra when testRuns is empty" do
+                render (buildStateDoc utc (doneState 0 []))
+                    `shouldNotContain` "passed"
+
+            it "shows 'passed' for a passing suite" do
+                render (buildStateDoc utc (doneStateWith [] [passingRun]))
+                    `shouldContain` "test:foo  passed"
+
+            it "shows 'failed' for a failing suite" do
+                render (buildStateDoc utc (doneStateWith [] [failingRun]))
+                    `shouldContain` "test:bar  failed"
+
+            it "shows 'error:' for a crashed suite" do
+                render (buildStateDoc utc (doneStateWith [] [errorRun]))
+                    `shouldContain` "error: Crashed"
+
+            it "shows all suites when multiple test runs are present" do
+                let rendered = render (buildStateDoc utc (doneStateWith [] [passingRun, failingRun]))
+                rendered `shouldContain` "test:foo  passed"
+                rendered `shouldContain` "test:bar  failed"
+
+            it "shows test runs after 'All good.' for a clean build" do
+                let rendered = render (buildStateDoc utc (doneStateWith [] [passingRun]))
+                rendered `shouldContain` "All good."
+                rendered `shouldContain` "test:foo  passed"
+
+            it "shows test runs after diagnostics when build has warnings" do
+                let rendered = render (buildStateDoc utc (doneStateWith [warnMsg] [passingRun]))
+                rendered `shouldContain` "warning(s)"
+                rendered `shouldContain` "test:foo  passed"
 
     describe "diagnosticDoc" do
         it "shows file location" do
@@ -135,7 +169,23 @@ buildingState = BuildState (BuildId 1) Building emptyDaemonInfo
 
 
 doneState :: Int -> [Diagnostic] -> BuildState
-doneState mods msgs = BuildState (BuildId 1) (Done (BuildResult {completedAt = epoch, durationMs = 500, moduleCount = mods, diagnostics = msgs})) emptyDaemonInfo
+doneState mods msgs = BuildState (BuildId 1) (Done (BuildResult {completedAt = epoch, durationMs = 500, moduleCount = mods, diagnostics = msgs, testRuns = []})) emptyDaemonInfo
+
+
+doneStateWith :: [Diagnostic] -> [TestRun] -> BuildState
+doneStateWith msgs runs = BuildState (BuildId 1) (Done (BuildResult {completedAt = epoch, durationMs = 500, moduleCount = 0, diagnostics = msgs, testRuns = runs})) emptyDaemonInfo
+
+
+passingRun :: TestRun
+passingRun = TestRun {target = "test:foo", outcome = TestsPassed, output = ""}
+
+
+failingRun :: TestRun
+failingRun = TestRun {target = "test:bar", outcome = TestsFailed, output = "1 failure\n"}
+
+
+errorRun :: TestRun
+errorRun = TestRun {target = "test:baz", outcome = TestsError "Crashed", output = ""}
 
 
 epoch :: UTCTime


### PR DESCRIPTION
After each successful build (no errors), ghcib now spawns a short-lived `cabal repl test:<name>` process per configured test suite, runs `:main`, captures output, and surfaces results in `ghcib status` and `ghcib watch`.

- `TestRun` / `TestOutcome` types; `testRuns` field in `BuildResult`
- `Testing` build phase while suites are running
- `testTargets` TOML field (optional; auto-inferred from `targets`)
- `Ghcib.Effects.TestRunner` effect with IO and scripted interpreters
- `detectOutcome` parses `*** Exception: ExitSuccess/Failure` lines
- `sessionListener` transitions Building → Testing → Done with results
- Test results displayed in status and watch; exit code 1 on failure
- Unit tests (TestRunnerSpec, WatchSpec, ConfigSpec)