### PR TITLE
feat(ghcib): expose flake outputs for external consumption

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,61 @@ Test utilities for database-backed tests using [tmp-postgres](https://github.com
 
 A GHCi-based incremental build daemon. Watches source files, triggers reloads, and exposes build state over a Unix socket. See `ghcib/` for details.
 
+## Using with Nix
+
+> [!TIP]
+> Configure the binary cache to avoid building GHC from scratch:
+> ```nix
+> nix.settings = {
+>   extra-substituters = [ "https://atelier.cachix.org" ];
+>   extra-trusted-public-keys = [ "atelier.cachix.org-1:rEyd/Z4TiXZbBVuU/lDnKZ/7WtnFTwJ17OKHGcahVUo=" ];
+> };
+> ```
+
+### Try it out
+
+```bash
+nix run --accept-flake-config github:atelier-hub/atelier#ghcib
+```
+
+`--accept-flake-config` tells Nix to use the binary caches declared in this flake. Without it, Nix will build the entire Haskell toolchain from source.
+
+### Dev shell
+
+To make `ghcib` available in a project's dev shell without installing it system-wide:
+
+```nix
+inputs.ghcib.url = "github:atelier-hub/atelier";
+
+devShells.default = pkgs.mkShell {
+  packages = [ inputs.ghcib.packages.${system}.ghcib ];
+};
+```
+
+### Installing
+
+Add the flake input and apply the overlay:
+
+```nix
+inputs.ghcib.url = "github:cgeorgii/atelier";
+
+nixpkgs.overlays = [ inputs.ghcib.overlays.default ];
+```
+
+### Home Manager
+
+```nix
+imports = [ inputs.ghcib.homeManagerModules.default ];
+programs.ghcib.enable = true;
+```
+
+### NixOS (without Home Manager)
+
+```nix
+imports = [ inputs.ghcib.nixosModules.default ];
+programs.ghcib.enable = true;
+```
+
 ## Development
 
 Enter the dev shell:

--- a/flake.nix
+++ b/flake.nix
@@ -43,11 +43,19 @@
   };
 
   outputs =
-    inputs:
+    { self, ... }@inputs:
     inputs.flake-utils.lib.eachSystem [ "x86_64-linux" ] (
       system:
       import ./nix/outputs.nix {
-        inherit inputs system;
+        inherit inputs system self;
       }
-    );
+    )
+    // {
+      overlays.default = final: _: {
+        ghcib = self.packages.${final.stdenv.system}.default;
+      };
+
+      homeManagerModules.default = import ./nix/home-module.nix;
+      nixosModules.default = import ./nix/nixos-module.nix;
+    };
 }

--- a/nix/home-module.nix
+++ b/nix/home-module.nix
@@ -1,0 +1,19 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+let
+  cfg = config.programs.ghcib;
+in
+{
+  options.programs.ghcib = {
+    enable = lib.mkEnableOption "ghcib GHCi build daemon";
+    package = lib.mkPackageOption pkgs "ghcib" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+  };
+}

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -1,0 +1,19 @@
+{
+  pkgs,
+  lib,
+  config,
+  ...
+}:
+let
+  cfg = config.programs.ghcib;
+in
+{
+  options.programs.ghcib = {
+    enable = lib.mkEnableOption "ghcib GHCi build daemon";
+    package = lib.mkPackageOption pkgs "ghcib" { };
+  };
+
+  config = lib.mkIf cfg.enable {
+    environment.systemPackages = [ cfg.package ];
+  };
+}

--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -1,4 +1,8 @@
-{ inputs, system }:
+{
+  inputs,
+  system,
+  self,
+}:
 let
   # GHC version to use across all tools and the project
   compiler-nix-name = "ghc9102";
@@ -49,6 +53,13 @@ let
     fi
   '';
 
+  ghcibExe = projectFlake.packages."atelier:exe:ghcib-exe";
+  # Wrap the cabal executable (ghcib-exe) so consumers get a binary named `ghcib`
+  ghcib = pkgs.runCommand "ghcib" { } ''
+    mkdir -p $out/bin
+    ln -s ${ghcibExe}/bin/ghcib-exe $out/bin/ghcib
+  '';
+
   # Git hooks check (defined once, used in both checks and shell)
   gitHooks = inputs.git-hooks.lib.${system}.run {
     src = ../.;
@@ -83,7 +94,8 @@ in
 {
   # Expose packages built by haskell.nix
   packages = projectFlake.packages // {
-    default = projectFlake.packages."atelier:exe:ghcib-exe";
+    default = ghcib;
+    ghcib = ghcib;
   };
 
   # Development shell
@@ -98,6 +110,10 @@ in
 
   # Custom apps
   apps = observability.apps // {
+    ghcib = {
+      type = "app";
+      program = "${ghcib}/bin/ghcib";
+    };
     # ghcid with multi-repl for all packages and tests
     ghcid-multi = {
       type = "app";
@@ -141,6 +157,16 @@ in
   checks = projectFlake.checks // {
     git-hooks = gitHooks;
     # Ensure the executable builds in CI
-    ghcib-exe = projectFlake.packages."atelier:exe:ghcib-exe";
+    ghcib-exe = ghcibExe;
+    # Ensure the overlay correctly exposes pkgs.ghcib
+    overlay =
+      pkgs.runCommand "check-overlay"
+        {
+          ghcib = (pkgs.extend self.overlays.default).ghcib;
+        }
+        ''
+          test -x $ghcib/bin/ghcib
+          touch $out
+        '';
   };
 }

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -11,11 +11,6 @@ pkgs.haskell-nix.cabalProject' {
   materialized = ./materialized;
   checkMaterialization = true;
 
-  # Enable CHaP (Cardano Haskell Packages) repository
-  inputMap = {
-    "https://chap.intersectmbo.org/" = inputs.CHaP;
-  };
-
   # Add tmp-postgres from flake input
   cabalProjectLocal = ''
     source-repository-package


### PR DESCRIPTION
- `overlays.default` adds `pkgs.ghcib` to nixpkgs
- `homeManagerModules.default` — `programs.ghcib.enable` via Home Manager
- `nixosModules.default` — `programs.ghcib.enable` for non-HM NixOS users
- `apps.ghcib` enables `nix run github:atelier-hub/atelier#ghcib`
- `packages.ghcib` / `packages.default` wrap `ghcib-exe` so the binary is named `ghcib`
- `checks.overlay` validates the overlay end-to-end in CI
- Pass `self` into `outputs.nix` to support the overlay check derivation
- Document `nix run`, dev shell, and installation options in README