### PR TITLE
fix(process): use concurrent unlift in forkProcess

### DIFF
--- a/atelier/src/Atelier/Effects/Posix/Process.hs
+++ b/atelier/src/Atelier/Effects/Posix/Process.hs
@@ -7,13 +7,13 @@ module Atelier.Effects.Posix.Process
     , runProcess
     ) where
 
-import Effectful (Dispatch (..), DispatchOf, Effect, IOE)
+import Effectful (Dispatch (..), DispatchOf, Effect, IOE, Limit (..), Persistence (..))
 import Effectful.Dispatch.Static
     ( SideEffects (..)
     , StaticRep
     , evalStaticRep
+    , unsafeConcUnliftIO
     , unsafeEff_
-    , unsafeSeqUnliftIO
     )
 import System.Posix (ProcessGroupID, ProcessID)
 
@@ -40,4 +40,4 @@ createSession = unsafeEff_ Posix.createSession
 
 -- | Lifted `System.Posix.Process.forkProcess`.
 forkProcess :: (HasCallStack, Process :> es) => Eff es () -> Eff es ProcessID
-forkProcess f = unsafeSeqUnliftIO \unlift -> Posix.forkProcess $ unlift f
+forkProcess f = unsafeConcUnliftIO Persistent Unlimited \unlift -> Posix.forkProcess $ unlift f


### PR DESCRIPTION
`Posix.forkProcess` runs the action in a child process, which effectful treats as a separate thread. `unsafeSeqUnliftIO` doesn't support this, causing a runtime crash:

```
❯ nix run --accept-flake-config github:atelier-hub/atelier#ghcib -- watch
trace: Checking materialization in
/nix/store/p1dalb7xjzvj4gqqm7hvp0l42dyv94cd-source/nix/materialized
trace: WARNING: license "LicenseRef-Apache" not found
ghcib: If you want to use the unlifting function to run Eff computations in multiple threads, have
 a look at UnliftStrategy (ConcUnlift).
CallStack (from HasCallStack):
  error, called at src/Effectful/Internal/Monad.hs:220:12 in
effectful-core-2.6.1.0-4HecmWllynLLj7p5nJdS4m:Effectful.Internal.Monad
  seqUnliftIO, called at src/Effectful/Dispatch/Static.hs:200:3 in
effectful-core-2.6.1.0-4HecmWllynLLj7p5nJdS4m:Effectful.Dispatch.Static
  unsafeSeqUnliftIO, called at atelier/src/Atelier/Effects/Posix/Process.hs:43:17 in
atelier-0.1.0.0-3MdRl6vC1Ni9zdbk0ZvIDj:Atelier.Effects.Posix.Process
  forkProcess, called at ghcib/src/Ghcib/Daemon.hs:105:12 in
atelier-0.1.0.0-BqipxU2KmEzC1ebEbQafRH-ghcib:Ghcib.Daemon
HasCallStack backtrace:
  collectBacktraces, called at libraries/ghc-internal/src/GHC/Internal/Exception.hs:169:13 in
ghc-internal:GHC.Internal.Exception
  toExceptionWithBacktrace, called at libraries/ghc-internal/src/GHC/Internal/Exception.hs:204:5
in ghc-internal:GHC.Internal.Exception
  error, called at src/Effectful/Internal/Monad.hs:220:12 in
effectful-core-2.6.1.0-4HecmWllynLLj7p5nJdS4m:Effectful.Internal.Monad
  seqUnliftIO, called at src/Effectful/Dispatch/Static.hs:200:3 in
effectful-core-2.6.1.0-4HecmWllynLLj7p5nJdS4m:Effectful.Dispatch.Static
  unsafeSeqUnliftIO, called at atelier/src/Atelier/Effects/Posix/Process.hs:43:17 in
atelier-0.1.0.0-3MdRl6vC1Ni9zdbk0ZvIDj:Atelier.Effects.Posix.Process
  forkProcess, called at ghcib/src/Ghcib/Daemon.hs:105:12 in
atelier-0.1.0.0-BqipxU2KmEzC1ebEbQafRH-ghcib:Ghcib.Daemon
```