### PR TITLE
refactor: use brick to handle key events

### DIFF
--- a/atelier.cabal
+++ b/atelier.cabal
@@ -223,6 +223,9 @@ library tricorder
       Tricorder.Socket.SocketPath
       Tricorder.SourceLookup
       Tricorder.Watch
+      Tricorder.Watch.Event
+      Tricorder.Watch.State
+      Tricorder.Watch.View
       Tricorder.Watcher
   other-modules:
       Paths_atelier

--- a/tricorder/src/Tricorder/Watch.hs
+++ b/tricorder/src/Tricorder/Watch.hs
@@ -4,63 +4,29 @@ module Tricorder.Watch
 
 import Brick
     ( App (..)
-    , AttrName
-    , BrickEvent (..)
-    , EventM
-    , ViewportType (..)
-    , Widget
     , attrMap
     , attrName
-    , halt
     , neverShowCursor
-    , str
-    , vBox
-    , vScrollBy
-    , viewport
-    , viewportScroll
     )
-import Brick.Widgets.Core (Padding (..), emptyWidget, hBox, padLeft, padTop, txt, txtWrap, withDefAttr)
-import Control.Monad.State (modify)
-import Data.Time (UTCTime, defaultTimeLocale, formatTime, utcToLocalTime)
-import System.FilePath (isAbsolute)
 
-import Data.Text qualified as T
-import Graphics.Vty qualified as Vty
 import Graphics.Vty.Attributes qualified as Attr
 import Graphics.Vty.Attributes.Color qualified as Color
 
-import Atelier.Effects.Clock (Clock, TimeZone)
+import Atelier.Effects.Clock (Clock)
 import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.File (File)
-import Tricorder.BuildState
-    ( BuildPhase (..)
-    , BuildResult (..)
-    , BuildState (..)
-    , DaemonInfo (..)
-    , Diagnostic (..)
-    , Severity (..)
-    , TestOutcome (..)
-    , TestRun (..)
-    )
 import Tricorder.Effects.Brick (Brick)
 import Tricorder.Effects.BrickChan (BrickChan)
 import Tricorder.Effects.UnixSocket (UnixSocket)
 import Tricorder.Socket.Client (queryWatch)
+import Tricorder.Watch.Event (Event (..), handleEvent)
+import Tricorder.Watch.State (Name (..), State (..))
+import Tricorder.Watch.View (view)
 
-import Atelier.Effects.Clock qualified as Clock
 import Atelier.Effects.Conc qualified as Conc
 import Tricorder.Effects.Brick qualified as Brick
 import Tricorder.Effects.BrickChan qualified as BrickChan
-
-
-data WatchName = WatcherViewport
-    deriving stock (Eq, Ord, Show)
-
-
-data WatchState = WatchState
-    { buildState :: Maybe BuildState
-    , timeZone :: TimeZone
-    }
+import Tricorder.Watch.State qualified as Model
 
 
 -- | Connect to the daemon and render a live-updating build status display using
@@ -76,24 +42,24 @@ watchDisplay
     => FilePath -> Eff es ()
 watchDisplay sockPath = do
     chan <- BrickChan.newBChan 10
-    tz <- Clock.currentTimeZone
+    initialState <- Model.init
     Conc.scoped do
         _ <-
             Conc.fork
                 $ queryWatch sockPath
-                $ BrickChan.writeBChan chan
+                $ BrickChan.writeBChan chan . NewBuildState
         void
             $ Brick.runBrickApp
                 chan
                 watchApp
-                WatchState {buildState = Nothing, timeZone = tz}
+                initialState
 
 
-watchApp :: App WatchState BuildState WatchName
+watchApp :: App State Event Name
 watchApp =
     App
         { appDraw = view
-        , appHandleEvent = update
+        , appHandleEvent = handleEvent
         , appStartEvent = pure ()
         , appAttrMap =
             const
@@ -107,222 +73,3 @@ watchApp =
                 )
         , appChooseCursor = neverShowCursor
         }
-
-
-view :: WatchState -> [Widget WatchName]
-view ws =
-    [ case ws.buildState of
-        Nothing -> str "Waiting for build..."
-        Just bs ->
-            viewport WatcherViewport Vertical
-                $ viewBuildState ws.timeZone bs
-    ]
-
-
-viewBuildState :: TimeZone -> BuildState -> Widget n
-viewBuildState tz bs =
-    vBoxSpaced
-        1
-        [ viewBuildPhase tz bs.phase
-        , viewDaemonInfo bs.daemonInfo
-        ]
-
-
-viewDaemonInfo :: DaemonInfo -> Widget n
-viewDaemonInfo di =
-    vBox
-        $ [ viewTargets di.targets
-          , viewWatchDirs di.watchDirs
-          , viewSockPath di.sockPath
-          , viewLogFile di.logFile
-          , viewMetrics di.metricsPort
-          ]
-
-
-viewTargets :: [Text] -> Widget n
-viewTargets targets =
-    hBoxSpaced
-        1
-        [ emphasis $ txt "Targets:"
-        , if null targets then
-            txt "(all)"
-          else
-            txtWrap (T.intercalate " " targets)
-        ]
-
-
-viewMetrics :: Maybe Int -> Widget n
-viewMetrics Nothing =
-    hBoxSpaced
-        1
-        [ emphasis $ txt "Metrics:"
-        , warn $ txt "disabled"
-        ]
-viewMetrics (Just port) =
-    hBoxSpaced
-        1
-        [ emphasis $ txt "Metrics:"
-        , ok $ txt $ "http://localhost:" <> show port <> "/metrics"
-        ]
-
-
-viewLogFile :: Maybe FilePath -> Widget n
-viewLogFile = \case
-    Nothing -> emptyWidget
-    Just p -> hBoxSpaced 1 [emphasis $ txt "Log:", txt $ toText p]
-
-
-viewSockPath :: FilePath -> Widget n
-viewSockPath sockPath =
-    hBoxSpaced 1 [emphasis $ txt "Socket:", txt $ toText sockPath]
-
-
-viewWatchDirs :: [FilePath] -> Widget n
-viewWatchDirs watchDirs =
-    vBox
-        [ emphasis $ txt "Watching:"
-        , padLeft (Pad 2)
-            $ vBox
-            $ viewWatchDir <$> watchDirs
-        ]
-
-
-viewWatchDir :: FilePath -> Widget n
-viewWatchDir dir = hBox [txt "- ", txt $ toText displayDir]
-  where
-    displayDir
-        | isAbsolute dir = dir
-        | dir == "." = "./"
-        | otherwise = "./" <> dir
-
-
-viewBuildPhase :: TimeZone -> BuildPhase -> Widget n
-viewBuildPhase tz = \case
-    Building -> warn $ txt "Building..."
-    Testing -> warn $ txt "Testing..."
-    Done result
-        | null result.diagnostics ->
-            vBoxSpaced
-                1
-                [ hBoxSpaced
-                    1
-                    [ ok $ txt "All good."
-                    , viewBuildSummary result.moduleCount result.durationMs
-                    , viewTimestamp tz result.completedAt
-                    ]
-                , viewTestRuns result.testRuns
-                ]
-    Done result ->
-        let msgs = result.diagnostics
-            errCount = length $ filter (\m -> m.severity == SError) msgs
-            warnCount = length $ filter (\m -> m.severity == SWarning) msgs
-            header =
-                if errCount > 0 then
-                    err $ txt $ show errCount <> " error(s), " <> show warnCount <> " warning(s)"
-                else
-                    warn $ txt $ show warnCount <> " warning(s)"
-        in  vBoxSpaced
-                1
-                [ hBoxSpaced
-                    1
-                    [ header
-                    , viewDuration result.durationMs
-                    , viewTimestamp tz result.completedAt
-                    ]
-                , vBox $ viewDiagnostic <$> msgs
-                , viewTestRuns result.testRuns
-                ]
-
-
-viewDiagnostic :: Diagnostic -> Widget n
-viewDiagnostic m =
-    vBox
-        [ hBoxSpaced
-            1
-            [ severityLabel
-            , txt $ toText loc
-            ]
-        , txt m.text
-        ]
-  where
-    loc = m.file <> ":" <> show m.line <> ":" <> show m.col
-    severityLabel = withDefAttr (severityToAttrName m.severity) $ txt $ case m.severity of
-        SError -> "error:"
-        SWarning -> "warning:"
-
-
-severityToAttrName :: Severity -> AttrName
-severityToAttrName SError = attrName "error"
-severityToAttrName SWarning = attrName "warning"
-
-
-viewDuration :: Int -> Widget n
-viewDuration ms = txt $ "(" <> formatDuration ms <> ")"
-
-
-viewTestRuns :: [TestRun] -> Widget n
-viewTestRuns [] = emptyWidget
-viewTestRuns runs = vBox $ viewTestRun <$> runs
-
-
-viewTestRun :: TestRun -> Widget n
-viewTestRun tr = hBox [txt tr.target, txt "  ", viewTestOutcome tr.outcome]
-
-
-viewTestOutcome :: TestOutcome -> Widget n
-viewTestOutcome TestsPassed = ok $ txt "passed"
-viewTestOutcome TestsFailed = err $ txt "failed"
-viewTestOutcome (TestsError msg) = hBox [err $ txt "error:", txt msg]
-
-
-viewTimestamp :: TimeZone -> UTCTime -> Widget n
-viewTimestamp tz t = txt $ "— " <> toText (formatTime defaultTimeLocale "%H:%M:%S" $ utcToLocalTime tz t)
-
-
-viewBuildSummary :: Int -> Int -> Widget n
-viewBuildSummary moduleCount durationMs =
-    txt $ "(" <> show moduleCount <> " modules, " <> formatDuration durationMs <> ")"
-
-
-update :: BrickEvent WatchName BuildState -> EventM WatchName WatchState ()
-update (AppEvent bs) = modify \s -> s {buildState = Just bs}
-update (VtyEvent (Vty.EvKey (Vty.KChar 'q') [])) = halt
-update (VtyEvent (Vty.EvKey Vty.KEsc [])) = halt
-update (VtyEvent (Vty.EvKey (Vty.KChar 'c') [Vty.MCtrl])) = halt
-update (VtyEvent (Vty.EvKey Vty.KDown [])) = vScrollBy (viewportScroll WatcherViewport) 1
-update (VtyEvent (Vty.EvKey Vty.KUp [])) = vScrollBy (viewportScroll WatcherViewport) (-1)
-update _ = pure ()
-
-
-err :: Widget n -> Widget n
-err = withDefAttr $ attrName "error"
-
-
-warn :: Widget n -> Widget n
-warn = withDefAttr $ attrName "warning"
-
-
-ok :: Widget n -> Widget n
-ok = withDefAttr $ attrName "ok"
-
-
-emphasis :: Widget n -> Widget n
-emphasis = withDefAttr $ attrName "emphasis"
-
-
-formatDuration :: Int -> Text
-formatDuration ms =
-    if ms < 1000 then
-        show ms <> "ms"
-    else
-        show (ms `div` 1000) <> "." <> show ((ms `mod` 1000) `div` 100) <> "s"
-
-
-hBoxSpaced :: Int -> [Widget n] -> Widget n
-hBoxSpaced _ [] = hBox []
-hBoxSpaced pad (x : xs) = hBox $ x : (padLeft (Pad pad) <$> xs)
-
-
-vBoxSpaced :: Int -> [Widget n] -> Widget n
-vBoxSpaced _ [] = vBox []
-vBoxSpaced pad (x : xs) = vBox $ x : (padTop (Pad pad) <$> xs)

--- a/tricorder/src/Tricorder/Watch/Event.hs
+++ b/tricorder/src/Tricorder/Watch/Event.hs
@@ -1,0 +1,137 @@
+module Tricorder.Watch.Event
+    ( Event (..)
+    , handleEvent
+    , keys
+    , keyConfig
+    , dispatcher
+    , viewKeybindings
+    ) where
+
+import Brick
+    ( BrickEvent (..)
+    , EventM
+    , Widget
+    , halt
+    , txt
+    , vBox
+    , vScrollBy
+    , viewportScroll
+    )
+import Brick.Keybindings
+    ( Binding
+    , EventTrigger (..)
+    , Handler (..)
+    , KeyConfig
+    , KeyDispatcher
+    , KeyEventHandler (..)
+    , KeyEvents
+    , KeyHandler (..)
+    , ToBinding (..)
+    , allActiveBindings
+    , binding
+    , ctrl
+    , handleKey
+    , keyDispatcher
+    , keyEvents
+    , newKeyConfig
+    , onEvent
+    )
+import Brick.Keybindings.Pretty (ppBinding)
+import Control.Monad.State (modify)
+import Graphics.Vty (Key (..))
+
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Data.Text qualified as T
+import Graphics.Vty qualified as Vty
+
+import Tricorder.BuildState (BuildState (..))
+import Tricorder.Watch.State (Name (..), State (..))
+
+
+data Event
+    = NewBuildState BuildState
+
+
+handleEvent :: BrickEvent Name Event -> EventM Name State ()
+handleEvent (AppEvent ev) = handleAppEvent ev
+handleEvent (VtyEvent (Vty.EvKey key modifiers)) = void $ handleKey dispatcher key modifiers
+handleEvent _ = pure ()
+
+
+handleAppEvent :: Event -> EventM Name State ()
+handleAppEvent = \case
+    NewBuildState bs ->
+        modify \s -> s {buildState = Just bs}
+
+
+data KeyEvent
+    = Quit
+    | ScrollUp
+    | ScrollDown
+    | ToggleHelp
+    deriving stock (Eq, Ord, Show)
+
+
+keys :: KeyEvents KeyEvent
+keys =
+    keyEvents
+        [ ("quit", Quit)
+        , ("scroll up", ScrollUp)
+        , ("scroll down", ScrollDown)
+        , ("toggle help", ToggleHelp)
+        ]
+
+
+bindings :: [(KeyEvent, [Binding])]
+bindings =
+    [ (Quit, [bind 'q', ctrl 'c', binding KEsc []])
+    , (ScrollUp, [binding KUp []])
+    , (ScrollDown, [binding KDown []])
+    , (ToggleHelp, [bind 'h'])
+    ]
+
+
+keyConfig :: KeyConfig KeyEvent
+keyConfig =
+    newKeyConfig keys bindings []
+
+
+dispatcher :: KeyDispatcher KeyEvent (EventM Name State)
+dispatcher =
+    -- TODO: Handle this error more gracefully.
+    either (error . ("Invalid key dispatcher config: " <>) . stringify) id
+        $ keyDispatcher
+            keyConfig
+            [ onEvent Quit "Exit" do
+                halt
+            , onEvent ScrollUp "Scrolling upwards" do
+                vScrollBy (viewportScroll Watcher) (-1)
+            , onEvent ScrollDown "Scrolling downwards" do
+                vScrollBy (viewportScroll Watcher) 1
+            , onEvent ToggleHelp "Toggle help" do
+                modify \s -> s {showHelp = not s.showHelp}
+            ]
+  where
+    stringify =
+        show . fmap (second $ fmap $ handlerDescription . kehHandler . khHandler)
+
+
+viewKeybindings :: (Ord k, Show k) => KeyConfig k -> [KeyEventHandler k m] -> Widget n
+viewKeybindings kc =
+    vBox
+        . fmap (uncurry (viewEventAndTriggers kc))
+        . Map.toList
+        . foldr groupByEventName Map.empty
+  where
+    groupByEventName ev = Map.insertWith (<>) ev.kehHandler.handlerDescription [ev.kehEventTrigger]
+
+
+viewEventAndTriggers :: (Ord k, Show k) => KeyConfig k -> Text -> [EventTrigger k] -> Widget n
+viewEventAndTriggers kc eventName trigger =
+    txt $ eventName <> ": " <> (showBindings $ mconcat $ getBindings <$> trigger)
+  where
+    showBindings = T.intercalate ", " . fmap ppBinding . sort . toList
+    getBindings = \case
+        ByKey k -> Set.singleton k
+        ByEvent e -> Set.fromList $ allActiveBindings kc e

--- a/tricorder/src/Tricorder/Watch/State.hs
+++ b/tricorder/src/Tricorder/Watch/State.hs
@@ -1,0 +1,33 @@
+module Tricorder.Watch.State
+    ( Name (..)
+    , State (..)
+    , init
+    ) where
+
+import Atelier.Effects.Clock (Clock, TimeZone)
+import Tricorder.BuildState (BuildState (..))
+import Prelude hiding (init)
+
+import Atelier.Effects.Clock qualified as Clock
+
+
+data Name = Watcher
+    deriving stock (Eq, Ord, Show)
+
+
+data State = State
+    { buildState :: Maybe BuildState
+    , timeZone :: TimeZone
+    , showHelp :: Bool
+    }
+
+
+init :: (Clock :> es) => Eff es State
+init = do
+    tz <- Clock.currentTimeZone
+    pure
+        State
+            { buildState = Nothing
+            , timeZone = tz
+            , showHelp = False
+            }

--- a/tricorder/src/Tricorder/Watch/View.hs
+++ b/tricorder/src/Tricorder/Watch/View.hs
@@ -1,0 +1,266 @@
+module Tricorder.Watch.View (view) where
+
+import Brick
+    ( AttrName
+    , ViewportType (..)
+    , Widget
+    , attrName
+    , str
+    , vBox
+    , viewport
+    )
+import Brick.Keybindings (KeyHandler (..), keyDispatcherToList)
+import Brick.Widgets.Core
+    ( Padding (..)
+    , emptyWidget
+    , hBox
+    , padLeft
+    , padTop
+    , txt
+    , txtWrap
+    , withDefAttr
+    )
+import Data.Time (UTCTime, defaultTimeLocale, formatTime, utcToLocalTime)
+import System.FilePath (isAbsolute)
+
+import Data.Text qualified as T
+
+import Atelier.Effects.Clock (TimeZone)
+import Tricorder.BuildState
+    ( BuildPhase (..)
+    , BuildResult (..)
+    , BuildState (..)
+    , DaemonInfo (..)
+    , Diagnostic (..)
+    , Severity (..)
+    , TestOutcome (..)
+    , TestRun (..)
+    )
+import Tricorder.Watch.Event (viewKeybindings)
+import Tricorder.Watch.State (Name (..), State (..))
+
+import Tricorder.Watch.Event qualified as Event
+
+
+view :: State -> [Widget Name]
+view ws =
+    [ case ws.buildState of
+        Nothing -> str "Waiting for build..."
+        Just bs ->
+            viewport Watcher Vertical
+                $ if ws.showHelp then
+                    viewHelp
+                else
+                    viewBuildState ws bs
+    ]
+
+
+viewHelp :: Widget n
+viewHelp =
+    vBoxSpaced
+        1
+        [ txt "Keymap:"
+        , viewKeybindings Event.keyConfig handlers
+        , txt "Press h to go back"
+        ]
+  where
+    handlers = (.khHandler) . snd <$> keyDispatcherToList Event.dispatcher
+
+
+viewBuildState :: State -> BuildState -> Widget n
+viewBuildState state bs =
+    vBoxSpaced
+        1
+        [ viewBuildPhase state.timeZone bs.phase
+        , viewDaemonInfo bs.daemonInfo
+        ]
+
+
+viewDaemonInfo :: DaemonInfo -> Widget n
+viewDaemonInfo di =
+    vBox
+        $ [ viewTargets di.targets
+          , viewWatchDirs di.watchDirs
+          , viewSockPath di.sockPath
+          , viewLogFile di.logFile
+          , viewMetrics di.metricsPort
+          ]
+
+
+viewTargets :: [Text] -> Widget n
+viewTargets targets =
+    hBoxSpaced
+        1
+        [ emphasis $ txt "Targets:"
+        , if null targets then
+            txt "(all)"
+          else
+            txtWrap (T.intercalate " " targets)
+        ]
+
+
+viewMetrics :: Maybe Int -> Widget n
+viewMetrics Nothing =
+    hBoxSpaced
+        1
+        [ emphasis $ txt "Metrics:"
+        , warn $ txt "disabled"
+        ]
+viewMetrics (Just port) =
+    hBoxSpaced
+        1
+        [ emphasis $ txt "Metrics:"
+        , ok $ txt $ "http://localhost:" <> show port <> "/metrics"
+        ]
+
+
+viewLogFile :: Maybe FilePath -> Widget n
+viewLogFile = \case
+    Nothing -> emptyWidget
+    Just p -> hBoxSpaced 1 [emphasis $ txt "Log:", txt $ toText p]
+
+
+viewSockPath :: FilePath -> Widget n
+viewSockPath sockPath =
+    hBoxSpaced 1 [emphasis $ txt "Socket:", txt $ toText sockPath]
+
+
+viewWatchDirs :: [FilePath] -> Widget n
+viewWatchDirs watchDirs =
+    vBox
+        [ emphasis $ txt "Watching:"
+        , padLeft (Pad 2)
+            $ vBox
+            $ viewWatchDir <$> watchDirs
+        ]
+
+
+viewWatchDir :: FilePath -> Widget n
+viewWatchDir dir = hBox [txt "- ", txt $ toText displayDir]
+  where
+    displayDir
+        | isAbsolute dir = dir
+        | dir == "." = "./"
+        | otherwise = "./" <> dir
+
+
+viewBuildPhase :: TimeZone -> BuildPhase -> Widget n
+viewBuildPhase tz = \case
+    Building -> warn $ txt "Building..."
+    Testing -> warn $ txt "Testing..."
+    Done result
+        | null result.diagnostics ->
+            vBoxSpaced
+                1
+                [ hBoxSpaced
+                    1
+                    [ ok $ txt "All good."
+                    , viewBuildSummary result.moduleCount result.durationMs
+                    , viewTimestamp tz result.completedAt
+                    ]
+                , viewTestRuns result.testRuns
+                ]
+    Done result ->
+        let msgs = result.diagnostics
+            errCount = length $ filter (\m -> m.severity == SError) msgs
+            warnCount = length $ filter (\m -> m.severity == SWarning) msgs
+            header =
+                if errCount > 0 then
+                    err $ txt $ show errCount <> " error(s), " <> show warnCount <> " warning(s)"
+                else
+                    warn $ txt $ show warnCount <> " warning(s)"
+        in  vBoxSpaced
+                1
+                [ hBoxSpaced
+                    1
+                    [ header
+                    , viewDuration result.durationMs
+                    , viewTimestamp tz result.completedAt
+                    ]
+                , vBox $ viewDiagnostic <$> msgs
+                , viewTestRuns result.testRuns
+                ]
+
+
+viewDiagnostic :: Diagnostic -> Widget n
+viewDiagnostic m =
+    vBox
+        [ hBoxSpaced
+            1
+            [ severityLabel
+            , txt $ toText loc
+            ]
+        , txt m.text
+        ]
+  where
+    loc = m.file <> ":" <> show m.line <> ":" <> show m.col
+    severityLabel = withDefAttr (severityToAttrName m.severity) $ txt $ case m.severity of
+        SError -> "error:"
+        SWarning -> "warning:"
+
+
+severityToAttrName :: Severity -> AttrName
+severityToAttrName SError = attrName "error"
+severityToAttrName SWarning = attrName "warning"
+
+
+viewDuration :: Int -> Widget n
+viewDuration ms = txt $ "(" <> formatDuration ms <> ")"
+
+
+viewTestRuns :: [TestRun] -> Widget n
+viewTestRuns [] = emptyWidget
+viewTestRuns runs = vBox $ viewTestRun <$> runs
+
+
+viewTestRun :: TestRun -> Widget n
+viewTestRun tr = hBox [txt tr.target, txt "  ", viewTestOutcome tr.outcome]
+
+
+viewTestOutcome :: TestOutcome -> Widget n
+viewTestOutcome TestsPassed = ok $ txt "passed"
+viewTestOutcome TestsFailed = err $ txt "failed"
+viewTestOutcome (TestsError msg) = hBox [err $ txt "error:", txt msg]
+
+
+viewTimestamp :: TimeZone -> UTCTime -> Widget n
+viewTimestamp tz t = txt $ "— " <> toText (formatTime defaultTimeLocale "%H:%M:%S" $ utcToLocalTime tz t)
+
+
+viewBuildSummary :: Int -> Int -> Widget n
+viewBuildSummary moduleCount durationMs =
+    txt $ "(" <> show moduleCount <> " modules, " <> formatDuration durationMs <> ")"
+
+
+err :: Widget n -> Widget n
+err = withDefAttr $ attrName "error"
+
+
+warn :: Widget n -> Widget n
+warn = withDefAttr $ attrName "warning"
+
+
+ok :: Widget n -> Widget n
+ok = withDefAttr $ attrName "ok"
+
+
+emphasis :: Widget n -> Widget n
+emphasis = withDefAttr $ attrName "emphasis"
+
+
+formatDuration :: Int -> Text
+formatDuration ms =
+    if ms < 1000 then
+        show ms <> "ms"
+    else
+        show (ms `div` 1000) <> "." <> show ((ms `mod` 1000) `div` 100) <> "s"
+
+
+hBoxSpaced :: Int -> [Widget n] -> Widget n
+hBoxSpaced _ [] = hBox []
+hBoxSpaced pad (x : xs) = hBox $ x : (padLeft (Pad pad) <$> xs)
+
+
+vBoxSpaced :: Int -> [Widget n] -> Widget n
+vBoxSpaced _ [] = vBox []
+vBoxSpaced pad (x : xs) = vBox $ x : (padTop (Pad pad) <$> xs)


### PR DESCRIPTION
A few things happening here:
- Split up `Tricorder.Watch` into separate modules. It was getting a bit hairy in there, especially with all the rendering logic.
- Use `brick` for handling key events.
- Add a help screen for showing keybinds.