### PR TITLE
feat(ui): show granular build and test status in real-time

### DIFF
--- a/tricorder/src/Tricorder/BuildState.hs
+++ b/tricorder/src/Tricorder/BuildState.hs
@@ -70,7 +70,7 @@ runDaemonInfo act = do
     runReader daemonInfo act
 
 
-data TestOutcome = TestsPassed | TestsFailed | TestsError Text
+data TestOutcome = TestsRunning | TestsPassed | TestsFailed | TestsError Text
     deriving stock (Eq, Generic, Show)
     deriving anyclass (FromJSON, ToJSON)
 
@@ -97,7 +97,8 @@ data BuildResult = BuildResult
 
 data BuildPhase
     = Building
-    | Testing
+    | Restarting
+    | Testing BuildResult
     | Done BuildResult
     deriving stock (Eq, Generic, Show)
     deriving anyclass (FromJSON, ToJSON)
@@ -144,7 +145,8 @@ instance ToJSON Severity where
 
 stateLabel :: BuildPhase -> Text
 stateLabel Building = "building"
-stateLabel Testing = "testing"
+stateLabel Restarting = "restarting"
+stateLabel (Testing _) = "testing"
 stateLabel (Done result)
     | any (\m -> m.severity == SError) result.diagnostics = "error"
     | any (\m -> m.severity == SWarning) result.diagnostics = "warning"

--- a/tricorder/src/Tricorder/Effects/BuildStore.hs
+++ b/tricorder/src/Tricorder/Effects/BuildStore.hs
@@ -5,6 +5,7 @@ module Tricorder.Effects.BuildStore
     , putState
     , waitUntilDone
     , waitForNext
+    , waitForAnyChange
     , setPhase
     , markDirty
     , waitDirty
@@ -38,6 +39,8 @@ data BuildStore :: Effect where
     WaitUntilDone :: BuildStore m BuildState
     -- | Block until a completed build with a different 'BuildId' is available.
     WaitForNext :: BuildId -> BuildStore m BuildState
+    -- | Block until the build state changes from the given state (any field).
+    WaitForAnyChange :: BuildState -> BuildStore m BuildState
     -- | Update the build id and phase without touching other fields (e.g. daemonInfo).
     SetPhase :: BuildId -> BuildPhase -> BuildStore m ()
     -- | Signal that files have changed and a rebuild is needed.
@@ -66,6 +69,7 @@ runBuildStoreSTM eff = do
             PutState s -> atomically (writeTVar ref s)
             WaitUntilDone -> poll ref (not . isBuilding)
             WaitForNext bid -> poll ref \s -> not (isBuilding s) && s.buildId /= bid
+            WaitForAnyChange prev -> poll ref (/= prev)
             SetPhase bid phase -> atomically $ modifyTVar ref \bs -> bs {buildId = bid, phase = phase}
             MarkDirty ck -> atomically (modifyTVar dirtyRef (max (Just ck)))
             WaitDirty -> pollDirtyRef dirtyRef
@@ -82,7 +86,8 @@ runBuildStoreSTM eff = do
     isBuilding :: BuildState -> Bool
     isBuilding s = case s.phase of
         Building -> True
-        Testing -> True
+        Restarting -> True
+        Testing _ -> True
         Done _ -> False
 
     emptyDaemonInfo = DaemonInfo {targets = [], watchDirs = [], sockPath = "", logFile = Nothing, metricsPort = Nothing}
@@ -98,6 +103,7 @@ runBuildStoreRef BuildStateRef {stateRef = ref, dirtyRef} =
             PutState s -> atomically (writeTVar ref s)
             WaitUntilDone -> pollRef ref (not . isBuilding)
             WaitForNext bid -> pollRef ref \s -> not (isBuilding s) && s.buildId /= bid
+            WaitForAnyChange prev -> pollRef ref (/= prev)
             SetPhase bid phase -> atomically $ modifyTVar ref \bs -> bs {buildId = bid, phase = phase}
             MarkDirty ck -> atomically (modifyTVar dirtyRef (max (Just ck)))
             WaitDirty -> pollDirtyRef dirtyRef
@@ -106,7 +112,8 @@ runBuildStoreRef BuildStateRef {stateRef = ref, dirtyRef} =
     isBuilding :: BuildState -> Bool
     isBuilding s = case s.phase of
         Building -> True
-        Testing -> True
+        Restarting -> True
+        Testing _ -> True
         Done _ -> False
 
 
@@ -146,6 +153,7 @@ runBuildStoreScripted states = reinterpret (evalState states) $ \_ -> \case
     PutState s -> modify (s :)
     WaitUntilDone -> advance (not . isBuilding)
     WaitForNext bid -> advance \s -> not (isBuilding s) && s.buildId /= bid
+    WaitForAnyChange prev -> advance (/= prev)
     SetPhase bid phase ->
         get >>= \case
             [] -> pure ()
@@ -156,7 +164,8 @@ runBuildStoreScripted states = reinterpret (evalState states) $ \_ -> \case
     isBuilding :: BuildState -> Bool
     isBuilding s = case s.phase of
         Building -> True
-        Testing -> True
+        Restarting -> True
+        Testing _ -> True
         Done _ -> False
 
     advance :: (BuildState -> Bool) -> Eff (State [BuildState] : es) BuildState

--- a/tricorder/src/Tricorder/GhciSession.hs
+++ b/tricorder/src/Tricorder/GhciSession.hs
@@ -1,5 +1,11 @@
-module Tricorder.GhciSession (component, filterToWatchDirs, mergeDiagnostics, sessionListener) where
+module Tricorder.GhciSession
+    ( component
+    , filterToWatchDirs
+    , mergeDiagnostics
+    , sessionListener
+    ) where
 
+import Control.Monad (foldM)
 import Data.Time (diffUTCTime)
 import Effectful.Exception (throwIO, try)
 import Effectful.Reader.Static (Reader, ask)
@@ -14,7 +20,7 @@ import Atelier.Effects.FileSystem (FileSystem, getCurrentDirectory)
 import Atelier.Effects.Log (Log)
 import Atelier.Exception (isGracefulShutdown)
 import Atelier.Time (Millisecond)
-import Tricorder.BuildState (BuildId (..), BuildPhase (..), BuildResult (..), ChangeKind (..), Diagnostic (..), Severity (..), TestRun)
+import Tricorder.BuildState (BuildId (..), BuildPhase (..), BuildResult (..), ChangeKind (..), Diagnostic (..), Severity (..), TestOutcome (..), TestRun (..))
 import Tricorder.Config (Config (..), resolveCommand, resolveTestTargets, resolveWatchDirs)
 import Tricorder.Effects.BuildStore (BuildStore, setPhase, waitDirty)
 import Tricorder.Effects.GhciSession (GhciSession, LoadResult (..))
@@ -113,6 +119,7 @@ sessionListener cmd projectRoot watchDirs testTargets = startSession (BuildId 1)
 
     startSession (BuildId n) = do
         Log.info $ "Starting GHCi session #" <> show n <> ": " <> cmd
+        setPhase (BuildId n) Building
         t0 <- Clock.currentTime
         result <- try @SomeException $ GhciSession.startGhci cmd projectRoot
         Log.debug $ "GhciSession.startGhci returned (session #" <> show n <> ")"
@@ -129,9 +136,9 @@ sessionListener cmd projectRoot watchDirs testTargets = startSession (BuildId 1)
                 Log.info $ "GHCi started (session #" <> show n <> "): " <> show (length filteredMsgs) <> " diagnostics"
                 let durationMs = round (realToFrac (diffUTCTime t1 t0) * 1000 :: Double) :: Int
                     accumulated = Map.fromListWith (++) [(d.file, [d]) | d <- filteredMsgs]
-                testRuns <- runTestsIfClean (BuildId n) filteredMsgs
-                let buildResult = BuildResult {completedAt = t1, durationMs, moduleCount, diagnostics = filteredMsgs, testRuns}
-                setPhase (BuildId n) (Done buildResult)
+                    partialResult = BuildResult {completedAt = t1, durationMs, moduleCount, diagnostics = filteredMsgs, testRuns = []}
+                testRuns <- runTestsIfClean (BuildId n) partialResult
+                setPhase (BuildId n) (Done partialResult {testRuns})
                 Log.debug $ "Build state updated to Done (session #" <> show n <> ")"
                 listenLoop (BuildId (n + 1)) accumulated
 
@@ -142,6 +149,7 @@ sessionListener cmd projectRoot watchDirs testTargets = startSession (BuildId 1)
         case changeKind of
             CabalChange -> do
                 Log.info "Cabal file changed; restarting GHCi session"
+                setPhase (BuildId n) Restarting
                 void $ try @SomeException GhciSession.stopGhci
                 startSession nextId
             SourceChange -> do
@@ -166,24 +174,30 @@ sessionListener cmd projectRoot watchDirs testTargets = startSession (BuildId 1)
                             durationMs = round (realToFrac (diffUTCTime t1 t0) * 1000 :: Double) :: Int
                             newAccumulated = mergeDiagnostics accumulated filteredResult
                             allMsgs = concat (Map.elems newAccumulated)
-                        testRuns <- runTestsIfClean (BuildId n) allMsgs
-                        let buildResult = BuildResult {completedAt = t1, durationMs, moduleCount = loadResult.moduleCount, diagnostics = allMsgs, testRuns}
-                        setPhase (BuildId n) (Done buildResult)
+                        let partialResult = BuildResult {completedAt = t1, durationMs, moduleCount = loadResult.moduleCount, diagnostics = allMsgs, testRuns = []}
+                        testRuns <- runTestsIfClean (BuildId n) partialResult
+                        setPhase (BuildId n) (Done partialResult {testRuns})
                         listenLoop nextId newAccumulated
 
     -- Run all configured test suites if the build has no errors.
     -- Transitions to 'Testing' phase while suites are running.
     runTestsIfClean
         :: (BuildStore :> es, Log :> es, TestRunner :> es)
-        => BuildId -> [Diagnostic] -> Eff es [TestRun]
-    runTestsIfClean bid diags
-        | not (null testTargets) && not (any (\d -> d.severity == SError) diags) = do
-            setPhase bid Testing
+        => BuildId -> BuildResult -> Eff es [TestRun]
+    runTestsIfClean bid partialResult
+        | not (null testTargets) && not (any (\d -> d.severity == SError) partialResult.diagnostics) = do
+            let pendingRun t = TestRun {target = t, outcome = TestsRunning, output = ""}
+            setPhase bid (Testing partialResult {testRuns = map pendingRun testTargets})
             Log.info $ "Running " <> show (length testTargets) <> " test suite(s)"
-            mapM
-                ( \target -> do
+            foldM
+                ( \done target -> do
                     Log.info $ "Running tests: " <> target
-                    TestRunner.runTestSuite target
+                    result <- TestRunner.runTestSuite target
+                    let remaining = drop (length done + 1) testTargets
+                        runs = done ++ [result] ++ map pendingRun remaining
+                    setPhase bid (Testing partialResult {testRuns = runs})
+                    pure (done ++ [result])
                 )
+                []
                 testTargets
         | otherwise = pure []

--- a/tricorder/src/Tricorder/Program.hs
+++ b/tricorder/src/Tricorder/Program.hs
@@ -161,7 +161,8 @@ showStatus waitFlag jsonFlag verboseFlag = do
             current <- queryStatus sockPath
             case current of
                 Right BuildState {phase = Building} -> Console.putStrLn "Building..."
-                Right BuildState {phase = Testing} -> Console.putStrLn "Testing..."
+                Right BuildState {phase = Restarting} -> Console.putStrLn "Restarting..."
+                Right BuildState {phase = Testing _} -> Console.putStrLn "Testing..."
                 _ -> pure ()
         result <-
             if waitFlag then
@@ -179,7 +180,8 @@ showStatus waitFlag jsonFlag verboseFlag = do
   where
     renderText verbose state = case state.phase of
         Building -> Console.putStrLn "Building..."
-        Testing -> Console.putStrLn "Testing..."
+        Restarting -> Console.putStrLn "Restarting..."
+        Testing _ -> Console.putStrLn "Testing..."
         Done r -> do
             tz <- liftIO getCurrentTimeZone
             let printDiag =
@@ -197,12 +199,17 @@ showStatus waitFlag jsonFlag verboseFlag = do
         when verbose
             $ mapM_ (Console.putTextLn . ("  " <>) . toText) (lines tr.output)
       where
+        testRunSummary t TestsRunning = t <> "  running..."
         testRunSummary t TestsPassed = t <> "  passed"
         testRunSummary t TestsFailed = t <> "  failed"
         testRunSummary t (TestsError msg) = t <> "  error: " <> msg
 
     buildHasErrors r = any ((== SError) . (.severity)) r.diagnostics
-    testsFailed r = any ((/= TestsPassed) . (.outcome)) r.testRuns
+    testsFailed r = any (notPassed . (.outcome)) r.testRuns
+      where
+        notPassed TestsPassed = False
+        notPassed TestsRunning = False
+        notPassed _ = True
 
     buildSummary tz r =
         let errs = length $ filter ((== SError) . (.severity)) r.diagnostics

--- a/tricorder/src/Tricorder/Socket/Server.hs
+++ b/tricorder/src/Tricorder/Socket/Server.hs
@@ -14,7 +14,7 @@ import Atelier.Effects.FileSystem (FileSystem)
 import Atelier.Effects.Log (Log)
 import Atelier.Time (Millisecond)
 import Tricorder.BuildState (BuildPhase (..), BuildState (..))
-import Tricorder.Effects.BuildStore (BuildStore, getState, waitForNext, waitUntilDone)
+import Tricorder.Effects.BuildStore (BuildStore, getState, waitForAnyChange, waitUntilDone)
 import Tricorder.Effects.GhcPkg (GhcPkg)
 import Tricorder.Effects.UnixSocket
     ( UnixSocket
@@ -156,7 +156,8 @@ respondWhenDone h = awaitResult >>= sendJson h
         s <- getState
         case s.phase of
             Building -> waitUntilDone
-            Testing -> waitUntilDone
+            Restarting -> waitUntilDone
+            Testing _ -> waitUntilDone
             Done _ -> awaitBuildStart (5 :: Int) s
 
     -- Poll up to n × 50ms for a build to start, then wait for it to finish.
@@ -166,21 +167,22 @@ respondWhenDone h = awaitResult >>= sendJson h
         s' <- getState
         case s'.phase of
             Building -> waitUntilDone
-            Testing -> waitUntilDone
+            Restarting -> waitUntilDone
+            Testing _ -> waitUntilDone
             Done _ -> awaitBuildStart (n - 1) s'
 
 
--- | Stream a JSON object after each completed build (loops until handle closes or error).
+-- | Stream a JSON object after each state change (loops until handle closes or error).
 watchStream :: (BuildStore :> es, UnixSocket :> es) => Handle -> Eff es ()
 watchStream h = do
     state0 <- getState
     sendJson h state0
-    loop state0.buildId
+    loop state0
   where
-    loop bid = do
-        newState <- waitForNext bid
+    loop prev = do
+        newState <- waitForAnyChange prev
         sendJson h newState
-        loop newState.buildId
+        loop newState
 
 
 -- | Look up source for each requested module and send the results as a JSON array.

--- a/tricorder/src/Tricorder/UI/View.hs
+++ b/tricorder/src/Tricorder/UI/View.hs
@@ -163,20 +163,21 @@ viewWatchDir dir = hBox [txt "- ", txt $ toText displayDir]
 viewBuildPhase :: TimeZone -> BuildPhase -> Widget n
 viewBuildPhase tz = \case
     Building -> warn $ txt "Building..."
-    Testing -> warn $ txt "Testing..."
-    Done result
-        | null result.diagnostics ->
-            vBoxSpaced
-                1
-                [ hBoxSpaced
-                    1
-                    [ ok $ txt "All good."
-                    , viewBuildSummary result.moduleCount result.durationMs
-                    , viewTimestamp tz result.completedAt
-                    ]
-                , viewTestRuns result.testRuns
-                ]
-    Done result ->
+    Restarting -> warn $ txt "Restarting..."
+    Testing result -> vBoxSpaced 1 [viewBuildResult tz result, viewTestRuns result.testRuns]
+    Done result -> vBoxSpaced 1 [viewBuildResult tz result, viewTestRuns result.testRuns]
+
+
+viewBuildResult :: TimeZone -> BuildResult -> Widget n
+viewBuildResult tz result
+    | null result.diagnostics =
+        hBoxSpaced
+            1
+            [ ok $ txt "All good."
+            , viewBuildSummary result.moduleCount result.durationMs
+            , viewTimestamp tz result.completedAt
+            ]
+    | otherwise =
         let msgs = result.diagnostics
             errCount = length $ filter (\m -> m.severity == SError) msgs
             warnCount = length $ filter (\m -> m.severity == SWarning) msgs
@@ -194,7 +195,6 @@ viewBuildPhase tz = \case
                     , viewTimestamp tz result.completedAt
                     ]
                 , vBox $ viewDiagnostic <$> msgs
-                , viewTestRuns result.testRuns
                 ]
 
 
@@ -234,6 +234,7 @@ viewTestRun tr = hBox [txt tr.target, txt "  ", viewTestOutcome tr.outcome]
 
 
 viewTestOutcome :: TestOutcome -> Widget n
+viewTestOutcome TestsRunning = warn $ txt "running..."
 viewTestOutcome TestsPassed = ok $ txt "passed"
 viewTestOutcome TestsFailed = err $ txt "failed"
 viewTestOutcome (TestsError msg) = hBox [err $ txt "error:", txt msg]


### PR DESCRIPTION
- Add `Restarting` phase, set immediately when a cabal file change is detected (before GHCi stops)
- Set `Building` at session start so the TUI shows it during initial load, not just on source reloads
- `Testing` now carries the completed `BuildResult` so diagnostics remain visible while tests run
- Per-suite test progress: all suites start as `running...` and update to `passed`/`failed` as each one finishes (incremental `setPhase` calls via `foldM`)
- Add `TestsRunning` to `TestOutcome`; `testsFailed` excludes it from the failure check
- Socket `watchStream` now uses `waitForAnyChange` instead of `waitForNext`, broadcasting every phase transition to the TUI
- Extract `viewBuildResult` helper shared by `Testing` and `Done` views