### PR TITLE
feat: prettify help screen

### DIFF
--- a/tricorder.cabal
+++ b/tricorder.cabal
@@ -41,6 +41,7 @@ library
       Tricorder.SourceLookup
       Tricorder.UI
       Tricorder.UI.Event
+      Tricorder.UI.Misc
       Tricorder.UI.State
       Tricorder.UI.View
       Tricorder.Watcher

--- a/tricorder/src/Tricorder/UI.hs
+++ b/tricorder/src/Tricorder/UI.hs
@@ -69,6 +69,7 @@ watchApp =
                     , (attrName "warning", Attr.withForeColor Attr.defAttr Color.yellow)
                     , (attrName "error", Attr.withForeColor Attr.defAttr Color.red)
                     , (attrName "emphasis", Attr.withStyle Attr.defAttr Attr.bold)
+                    , (attrName "subtle", Attr.withForeColor Attr.defAttr $ Color.rgbColor @Int 148 148 148)
                     ]
                 )
         , appChooseCursor = neverShowCursor

--- a/tricorder/src/Tricorder/UI/Event.hs
+++ b/tricorder/src/Tricorder/UI/Event.hs
@@ -37,7 +37,8 @@ import Brick.Keybindings
     , onEvent
     )
 import Brick.Keybindings.Pretty (ppBinding)
-import Control.Monad.State (modify)
+import Brick.Widgets.Core (hBox)
+import Control.Monad.State (gets, modify)
 import Graphics.Vty (Key (..))
 
 import Data.Map.Strict qualified as Map
@@ -46,6 +47,7 @@ import Data.Text qualified as T
 import Graphics.Vty qualified as Vty
 
 import Tricorder.BuildState (BuildState (..))
+import Tricorder.UI.Misc (warn)
 import Tricorder.UI.State (State (..), Viewports (..), invertCollapsible)
 
 
@@ -111,9 +113,13 @@ dispatcher =
             , onEvent Quit "Exit" do
                 halt
             , onEvent ScrollUp "Scroll diagnostic upwards" do
-                vScrollBy (viewportScroll DiagnosticViewport) (-1)
+                showingHelp <- gets (.showHelp)
+                unless showingHelp
+                    $ vScrollBy (viewportScroll DiagnosticViewport) (-1)
             , onEvent ScrollDown "Scroll diagnostic downwards" do
-                vScrollBy (viewportScroll DiagnosticViewport) 1
+                showingHelp <- gets (.showHelp)
+                unless showingHelp
+                    $ vScrollBy (viewportScroll DiagnosticViewport) 1
             , onEvent ToggleHelp "Toggle help" do
                 modify \s -> s {showHelp = not s.showHelp}
             ]
@@ -134,7 +140,10 @@ viewKeybindings kc =
 
 viewEventAndTriggers :: (Ord k, Show k) => KeyConfig k -> Text -> [EventTrigger k] -> Widget n
 viewEventAndTriggers kc eventName trigger =
-    txt $ eventName <> ": " <> (showBindings $ mconcat $ getBindings <$> trigger)
+    hBox
+        [ warn $ txt $ eventName <> ": "
+        , txt $ showBindings $ mconcat $ getBindings <$> trigger
+        ]
   where
     showBindings = T.intercalate ", " . fmap ppBinding . sort . toList
     getBindings = \case

--- a/tricorder/src/Tricorder/UI/Misc.hs
+++ b/tricorder/src/Tricorder/UI/Misc.hs
@@ -1,0 +1,50 @@
+module Tricorder.UI.Misc
+    ( err
+    , warn
+    , ok
+    , emphasis
+    , subtle
+    , hBoxSpaced
+    , vBoxSpaced
+    ) where
+
+import Brick
+    ( Padding (..)
+    , Widget
+    , attrName
+    , hBox
+    , padLeft
+    , padTop
+    , vBox
+    , withDefAttr
+    )
+
+
+err :: Widget n -> Widget n
+err = withDefAttr $ attrName "error"
+
+
+warn :: Widget n -> Widget n
+warn = withDefAttr $ attrName "warning"
+
+
+ok :: Widget n -> Widget n
+ok = withDefAttr $ attrName "ok"
+
+
+emphasis :: Widget n -> Widget n
+emphasis = withDefAttr $ attrName "emphasis"
+
+
+subtle :: Widget n -> Widget n
+subtle = withDefAttr $ attrName "subtle"
+
+
+hBoxSpaced :: Int -> [Widget n] -> Widget n
+hBoxSpaced _ [] = hBox []
+hBoxSpaced pad (x : xs) = hBox $ x : (padLeft (Pad pad) <$> xs)
+
+
+vBoxSpaced :: Int -> [Widget n] -> Widget n
+vBoxSpaced _ [] = vBox []
+vBoxSpaced pad (x : xs) = vBox $ x : (padTop (Pad pad) <$> xs)

--- a/tricorder/src/Tricorder/UI/View.hs
+++ b/tricorder/src/Tricorder/UI/View.hs
@@ -17,7 +17,6 @@ import Brick.Widgets.Core
     , hBox
     , padBottom
     , padLeft
-    , padTop
     , txt
     , txtWrap
     , withClickableVScrollBars
@@ -42,6 +41,7 @@ import Tricorder.BuildState
     , TestRun (..)
     )
 import Tricorder.UI.Event (viewKeybindings)
+import Tricorder.UI.Misc (emphasis, err, hBoxSpaced, ok, subtle, vBoxSpaced, warn)
 import Tricorder.UI.State (Collapsible (..), State (..), Viewports (..))
 
 import Tricorder.UI.Event qualified as Event
@@ -63,9 +63,9 @@ viewHelp :: Widget n
 viewHelp =
     vBoxSpaced
         1
-        [ txt "Keymap:"
+        [ ok $ txt "Keymap:"
         , viewKeybindings Event.keyConfig handlers
-        , txt "Press h to go back"
+        , subtle $ txt "Press 'h' to go back"
         ]
   where
     handlers = (.khHandler) . snd <$> keyDispatcherToList Event.dispatcher
@@ -91,8 +91,10 @@ viewDaemonInfo state di =
                 emptyWidget
         , viewHint
         ]
+
+
 viewHint :: Widget n
-viewHint = txt "Press 'h' for help"
+viewHint = subtle $ txt "Press 'h' for help"
 
 
 viewExpandedDaemonInfo :: DaemonInfo -> Widget n
@@ -257,35 +259,9 @@ viewBuildSummary moduleCount durationMs =
     txt $ "(" <> show moduleCount <> " modules, " <> formatDuration durationMs <> ")"
 
 
-err :: Widget n -> Widget n
-err = withDefAttr $ attrName "error"
-
-
-warn :: Widget n -> Widget n
-warn = withDefAttr $ attrName "warning"
-
-
-ok :: Widget n -> Widget n
-ok = withDefAttr $ attrName "ok"
-
-
-emphasis :: Widget n -> Widget n
-emphasis = withDefAttr $ attrName "emphasis"
-
-
 formatDuration :: Int -> Text
 formatDuration ms =
     if ms < 1000 then
         show ms <> "ms"
     else
         show (ms `div` 1000) <> "." <> show ((ms `mod` 1000) `div` 100) <> "s"
-
-
-hBoxSpaced :: Int -> [Widget n] -> Widget n
-hBoxSpaced _ [] = hBox []
-hBoxSpaced pad (x : xs) = hBox $ x : (padLeft (Pad pad) <$> xs)
-
-
-vBoxSpaced :: Int -> [Widget n] -> Widget n
-vBoxSpaced _ [] = vBox []
-vBoxSpaced pad (x : xs) = vBox $ x : (padTop (Pad pad) <$> xs)


### PR DESCRIPTION
Also make it so that scrolling for the diagnostics view is paused while the help screen is visible.

<img width="272" height="171" alt="image" src="https://github.com/user-attachments/assets/e03954f0-3794-417c-834e-185033025bcf" />

Depends on https://github.com/atelier-hub/tricorder/pull/40
