### PR TITLE
feat: add --expand flag to status command

### DIFF
--- a/.claude-plugin/tricorder/skills/tricorder/SKILL.md
+++ b/.claude-plugin/tricorder/skills/tricorder/SKILL.md
@@ -18,8 +18,9 @@ tricorder is a daemon-based GHCi build monitor. It exposes build state over a Un
 - `tricorder status --json` — output full build state as JSON
 - `tricorder status --wait --json` — wait then output JSON
 - `tricorder status --verbose` / `-v` — print full GHC message body under each diagnostic
+- `tricorder status --expand <N>` — print the summary line and full GHC message body for diagnostic #N
 - `tricorder source MODULE...` — print Haskell source for one or more installed modules (e.g. `tricorder source Data.Map.Strict`)
-- `tricorder watch` — auto-refreshing terminal display (for humans)
+- `tricorder ui` — auto-refreshing terminal display (for humans)
 
 ## Checking Build Status
 
@@ -29,15 +30,15 @@ If `tricorder status` returns `Stopped.`, start the daemon with `tricorder start
 
 ### Text output (default)
 
-One line per diagnostic, followed by a summary:
+One line per diagnostic (prefixed with a 1-based index), followed by a summary:
 
 ```
-E src/Foo/Bar.hs:42 `something` not in scope
-W src/Foo/Bar.hs:10 redundant import
+[1] E src/Foo/Bar.hs:42 `something` not in scope
+[2] W src/Foo/Bar.hs:10 redundant import
 2 error(s), 1 warning(s) (71 modules, 1.2s)
 ```
 
-Format: `<E|W> <file>:<line> <title>`
+Format: `[N] <E|W> <file>:<line> <title>`
 
 A clean build prints:
 
@@ -58,10 +59,18 @@ With `--wait`, if a build is in progress `Building...` is printed immediately be
 With `--verbose`, the full GHC message body is printed under each diagnostic:
 
 ```
-E src/Foo/Bar.hs:42 `something` not in scope
+[1] E src/Foo/Bar.hs:42 `something` not in scope
 Variable not in scope: something
     suggested fix: ...
 1 error(s), 0 warning(s) (71 modules, 1.2s)
+```
+
+With `--expand <N>`, only diagnostic #N is expanded (summary line + full body):
+
+```
+[1] E src/Foo/Bar.hs:42 `something` not in scope
+Variable not in scope: something
+    suggested fix: ...
 ```
 
 **Exit code**: 1 when any errors are present or any test suite fails, 0 otherwise (warnings alone → 0).

--- a/tricorder/src/Tricorder/Arguments.hs
+++ b/tricorder/src/Tricorder/Arguments.hs
@@ -10,6 +10,7 @@ import Options.Applicative
     ( Parser
     , ParserInfo
     , argument
+    , auto
     , command
     , execParser
     , fullDesc
@@ -20,6 +21,7 @@ import Options.Applicative
     , info
     , long
     , metavar
+    , option
     , progDesc
     , short
     , str
@@ -32,7 +34,7 @@ import Tricorder.GhcPkg.Types (ModuleName (..))
 data Command
     = Start
     | Stop
-    | Status Bool Bool Bool
+    | Status Bool Bool Bool (Maybe Int)
     | UI
     | Log Bool
     | Source [ModuleName]
@@ -93,6 +95,14 @@ statusParser =
             ( long "verbose"
                 <> short 'v'
                 <> help "Print full GHC message body under each diagnostic"
+            )
+        <*> optional
+            ( option
+                auto
+                ( long "expand"
+                    <> metavar "N"
+                    <> help "Print full GHC message body for diagnostic #N"
+                )
             )
 
 

--- a/tricorder/src/Tricorder/Program.hs
+++ b/tricorder/src/Tricorder/Program.hs
@@ -46,7 +46,7 @@ import Tricorder.Effects.GhciSession (GhciSession)
 import Tricorder.Effects.TestRunner (TestRunner)
 import Tricorder.Effects.UnixSocket (UnixSocket)
 import Tricorder.GhcPkg.Types (ModuleName, PackageId)
-import Tricorder.Render (diagnosticBlock, diagnosticLine, formatDuration, renderSourceResults)
+import Tricorder.Render (diagnosticLineIndexed, formatDuration, renderSourceResults)
 import Tricorder.Socket.Client
     ( isDaemonRunning
     , querySource
@@ -95,7 +95,7 @@ run =
     ask >>= \case
         Start -> start
         Stop -> stop
-        (Status waitFlag jsonFlag verboseFlag) -> showStatus waitFlag jsonFlag verboseFlag
+        (Status waitFlag jsonFlag verboseFlag expandFlag) -> showStatus waitFlag jsonFlag verboseFlag expandFlag
         (Log followFlag) -> showLog followFlag
         UI -> ui
         (Source moduleNames) -> showSource moduleNames
@@ -149,8 +149,8 @@ showStatus
        , IOE :> es
        , UnixSocket :> es
        )
-    => Bool -> Bool -> Bool -> Eff es ()
-showStatus waitFlag jsonFlag verboseFlag = do
+    => Bool -> Bool -> Bool -> Maybe Int -> Eff es ()
+showStatus waitFlag jsonFlag verboseFlag expandFlag = do
     projectRoot <- getCurrentDirectory
     sockPath <- socketPath projectRoot
     running <- isDaemonRunning sockPath
@@ -176,23 +176,38 @@ showStatus waitFlag jsonFlag verboseFlag = do
                     Console.putStr $ BSL.toStrict $ encode state
                     Console.putStrLn ""
                 else
-                    renderText verboseFlag state
+                    renderText verboseFlag expandFlag state
   where
-    renderText verbose state = case state.phase of
+    renderText verbose expand state = case state.phase of
         Building -> Console.putStrLn "Building..."
         Restarting -> Console.putStrLn "Restarting..."
         Testing _ -> Console.putStrLn "Testing..."
         Done r -> do
             tz <- liftIO getCurrentTimeZone
-            let printDiag =
-                    if verbose then
-                        Console.putText . diagnosticBlock
-                    else
-                        Console.putTextLn . diagnosticLine
-            mapM_ printDiag r.diagnostics
-            Console.putTextLn $ buildSummary tz r
-            mapM_ (printTestRun verbose) r.testRuns
-            when (buildHasErrors r || testsFailed r) $ liftIO exitFailure
+            case expand of
+                Just n ->
+                    case r.diagnostics !!? (n - 1) of
+                        Nothing ->
+                            Console.putTextLn
+                                $ "No diagnostic #"
+                                    <> show n
+                                    <> " (current build has "
+                                    <> show (length r.diagnostics)
+                                    <> ")"
+                        Just d -> do
+                            Console.putTextLn $ diagnosticLineIndexed n d
+                            Console.putText d.text
+                Nothing -> do
+                    let printDiag (i, d) =
+                            if verbose then do
+                                Console.putTextLn $ diagnosticLineIndexed i d
+                                Console.putText d.text
+                            else
+                                Console.putTextLn $ diagnosticLineIndexed i d
+                    mapM_ printDiag (zip [1 ..] r.diagnostics)
+                    Console.putTextLn $ buildSummary tz r
+                    mapM_ (printTestRun verbose) r.testRuns
+                    when (buildHasErrors r || testsFailed r) $ liftIO exitFailure
 
     printTestRun verbose tr = do
         Console.putTextLn $ testRunSummary tr.target tr.outcome

--- a/tricorder/src/Tricorder/Render.hs
+++ b/tricorder/src/Tricorder/Render.hs
@@ -1,6 +1,7 @@
 module Tricorder.Render
     ( -- * Plain-text formatting
       diagnosticLine
+    , diagnosticLineIndexed
     , diagnosticBlock
     , formatDuration
     , renderSourceResults
@@ -34,6 +35,13 @@ diagnosticLine d =
   where
     prefix SError = "E"
     prefix SWarning = "W"
+
+
+-- | Like 'diagnosticLine' but prefixed with a 1-based index.
+--
+-- Format: @[N] E src\/Foo\/Bar.hs:42 \`something\` not in scope@
+diagnosticLineIndexed :: Int -> Diagnostic -> Text
+diagnosticLineIndexed n d = "[" <> show n <> "] " <> diagnosticLine d
 
 
 -- | One-liner followed by the full GHC message body (verbose mode).

--- a/tricorder/src/Tricorder/Socket/Client.hs
+++ b/tricorder/src/Tricorder/Socket/Client.hs
@@ -3,6 +3,7 @@ module Tricorder.Socket.Client
     , queryStatusWait
     , queryWatch
     , querySource
+    , queryDiagnostic
     , isDaemonRunning
     ) where
 
@@ -12,10 +13,10 @@ import Effectful.Exception (try)
 import Data.ByteString.Lazy qualified as BSL
 
 import Atelier.Effects.File (File)
-import Tricorder.BuildState (BuildState)
+import Tricorder.BuildState (BuildState, Diagnostic)
 import Tricorder.Effects.UnixSocket (UnixSocket, withConnection)
 import Tricorder.GhcPkg.Types (ModuleName)
-import Tricorder.Socket.Protocol (Query (..), StatusQuery (..))
+import Tricorder.Socket.Protocol (DiagnosticQuery (..), Query (..), StatusQuery (..))
 import Tricorder.SourceLookup (ModuleSourceResult)
 
 import Atelier.Effects.File qualified as File
@@ -70,6 +71,20 @@ querySource sockPath moduleNames = withConnection sockPath \h -> do
     case eitherDecode (BSL.fromStrict (encodeUtf8 (toText line))) of
         Left err -> pure $ Left (toText err)
         Right results -> pure $ Right results
+
+
+-- | Fetch the full body of a single diagnostic by 1-based index.
+queryDiagnostic
+    :: (File :> es, UnixSocket :> es)
+    => FilePath
+    -> Int
+    -> Eff es (Either Text Diagnostic)
+queryDiagnostic sockPath idx = withConnection sockPath \h -> do
+    sendQuery h (DiagnosticAt (DiagnosticQuery {index = idx}))
+    line <- File.hGetLine h
+    case eitherDecode (BSL.fromStrict (encodeUtf8 (toText line))) of
+        Left err -> pure $ Left (toText err)
+        Right d -> pure $ Right d
 
 
 -- | Check whether the daemon is running by attempting a socket connection.

--- a/tricorder/src/Tricorder/Socket/Protocol.hs
+++ b/tricorder/src/Tricorder/Socket/Protocol.hs
@@ -1,6 +1,7 @@
 module Tricorder.Socket.Protocol
     ( Query (..)
     , StatusQuery (..)
+    , DiagnosticQuery (..)
     , ErrorResponse (..)
     ) where
 
@@ -14,10 +15,16 @@ data StatusQuery = StatusQuery {awaitDone :: Bool}
     deriving anyclass (FromJSON, ToJSON)
 
 
+newtype DiagnosticQuery = DiagnosticQuery {index :: Int}
+    deriving stock (Eq, Generic, Show)
+    deriving anyclass (FromJSON, ToJSON)
+
+
 data Query
     = Status StatusQuery
     | Watch
     | Source [ModuleName]
+    | DiagnosticAt DiagnosticQuery
     deriving stock (Eq, Generic, Show)
     deriving anyclass (FromJSON, ToJSON)
 

--- a/tricorder/src/Tricorder/Socket/Server.hs
+++ b/tricorder/src/Tricorder/Socket/Server.hs
@@ -13,7 +13,7 @@ import Atelier.Effects.Delay (Delay, wait)
 import Atelier.Effects.FileSystem (FileSystem)
 import Atelier.Effects.Log (Log)
 import Atelier.Time (Millisecond)
-import Tricorder.BuildState (BuildPhase (..), BuildState (..))
+import Tricorder.BuildState (BuildPhase (..), BuildResult (..), BuildState (..), Diagnostic)
 import Tricorder.Effects.BuildStore (BuildStore, getState, waitForAnyChange, waitUntilDone)
 import Tricorder.Effects.GhcPkg (GhcPkg)
 import Tricorder.Effects.UnixSocket
@@ -26,7 +26,7 @@ import Tricorder.Effects.UnixSocket
     , sendLine
     , socketFileExists
     )
-import Tricorder.Socket.Protocol (ErrorResponse (..), Query (..), StatusQuery (..))
+import Tricorder.Socket.Protocol (DiagnosticQuery (..), ErrorResponse (..), Query (..), StatusQuery (..))
 import Tricorder.Socket.SocketPath (SocketPath (..))
 import Tricorder.SourceLookup (ModuleName, PackageId, lookupModuleSource)
 
@@ -137,6 +137,7 @@ dispatch query h = case query of
     Status (StatusQuery True) -> respondWhenDone h
     Watch -> watchStream h
     Source moduleNames -> respondSource moduleNames h
+    DiagnosticAt dq -> respondDiagnostic dq.index h
 
 
 respondOnce :: (BuildStore :> es, UnixSocket :> es) => Handle -> Eff es ()
@@ -183,6 +184,23 @@ watchStream h = do
         newState <- waitForAnyChange prev
         sendJson h newState
         loop newState
+
+
+respondDiagnostic :: (BuildStore :> es, UnixSocket :> es) => Int -> Handle -> Eff es ()
+respondDiagnostic idx h = do
+    state <- getState
+    case state.phase of
+        Done r -> case r.diagnostics !!? (idx - 1) of
+            Nothing ->
+                sendJson h
+                    $ ErrorResponse
+                    $ "No diagnostic #"
+                        <> show idx
+                        <> " (current build has "
+                        <> show (length r.diagnostics)
+                        <> ")"
+            Just d -> sendJson h (d :: Diagnostic)
+        _ -> sendJson h $ ErrorResponse "Build in progress"
 
 
 -- | Look up source for each requested module and send the results as a JSON array.


### PR DESCRIPTION
Closes #41 

- Prefix all diagnostic lines with a 1-based index `[N]` in text output
- `--expand N` prints the summary line and full GHC message body for diagnostic #N only, instead of expanding all with `--verbose`
- Add `DiagnosticAt` query variant to the socket protocol
- Add `queryDiagnostic` client helper and `respondDiagnostic` server handler
- Add `diagnosticLineIndexed` to `Render`
- Update skill documentation
<img width="1929" height="985" alt="diagnostic-expansion" src="https://github.com/user-attachments/assets/480e7e97-95f8-404a-8ce9-0b556e3b765f" />