### PR TITLE
refactor: move scoped/awaitAll into runSystem

### DIFF
--- a/atelier/src/Atelier/Component.hs
+++ b/atelier/src/Atelier/Component.hs
@@ -74,7 +74,7 @@ runSystem
      . (Conc :> es, Log :> es, Tracing :> es)
     => [Component es]
     -> Eff es ()
-runSystem components = do
+runSystem components = Conc.scoped do
     -- Phase 1: Setup all components
     traverse_ setupComponent components
 
@@ -83,6 +83,8 @@ runSystem components = do
 
     -- Phase 3: Fork post-start actions
     traverse_ postStartComponent components
+
+    Conc.awaitAll
   where
     setupComponent :: Component es -> Eff es ()
     setupComponent c = do

--- a/tricorder/src/Tricorder/Daemon.hs
+++ b/tricorder/src/Tricorder/Daemon.hs
@@ -27,7 +27,6 @@ import Tricorder.Effects.UnixSocket (UnixSocket)
 import Tricorder.GhcPkg.Types (ModuleName, PackageId)
 import Tricorder.Runtime (PidFile, SocketPath (..))
 
-import Atelier.Effects.Conc qualified as Conc
 import Atelier.Effects.Posix.Daemons qualified as Daemons
 import Tricorder.GhciSession qualified as GhciSession
 import Tricorder.Observability qualified as Observability
@@ -59,14 +58,13 @@ runDaemon
        , UnixSocket :> es
        )
     => Eff es ()
-runDaemon = Conc.scoped do
+runDaemon =
     runSystem
         [ Observability.component
         , Watcher.component
         , GhciSession.component
         , SocketServer.component
         ]
-    Conc.awaitAll
 
 
 -- | Fork the daemon as a background process and return immediately.


### PR DESCRIPTION
`runSystem` now owns the concurrency scope, so callers don't need to wrap it manually.