### PR TITLE
refactor: reorganize `Tricorder` namespace, add flag types

### DIFF
--- a/tricorder.cabal
+++ b/tricorder.cabal
@@ -18,6 +18,8 @@ library
       Tricorder
       Tricorder.Arguments
       Tricorder.BuildState
+      Tricorder.CLI
+      Tricorder.CLI.Render
       Tricorder.Config
       Tricorder.Daemon
       Tricorder.Effects.Brick
@@ -32,7 +34,6 @@ library
       Tricorder.GhciSession
       Tricorder.GhcPkg.Types
       Tricorder.Observability
-      Tricorder.Render
       Tricorder.Runtime
       Tricorder.Socket.Client
       Tricorder.Socket.Protocol
@@ -401,10 +402,10 @@ test-suite tricorder-test
   other-modules:
       Unit.Tricorder.BuildStateSpec
       Unit.Tricorder.BuildStoreSpec
+      Unit.Tricorder.CLI.RenderSpec
       Unit.Tricorder.ConfigSpec
       Unit.Tricorder.GhciSessionSpec
       Unit.Tricorder.GhcPkgSpec
-      Unit.Tricorder.RenderSpec
       Unit.Tricorder.SocketSpec
       Unit.Tricorder.SourceLookupSpec
       Unit.Tricorder.SourceSpec

--- a/tricorder.cabal
+++ b/tricorder.cabal
@@ -15,6 +15,7 @@ build-type:     Simple
 
 library
   exposed-modules:
+      Tricorder
       Tricorder.Arguments
       Tricorder.BuildState
       Tricorder.Config
@@ -31,7 +32,6 @@ library
       Tricorder.GhciSession
       Tricorder.GhcPkg.Types
       Tricorder.Observability
-      Tricorder.Program
       Tricorder.Render
       Tricorder.Runtime
       Tricorder.Socket.Client

--- a/tricorder/app/Main.hs
+++ b/tricorder/app/Main.hs
@@ -30,8 +30,8 @@ import Tricorder.Effects.UnixSocket (runUnixSocketIO)
 import Tricorder.Runtime (runPidFile, runProjectRoot, runRuntimeDir, runSocketPath)
 
 import Atelier.Effects.Cache.Config qualified as CacheConfig
+import Tricorder qualified
 import Tricorder.GhcPkg.Types qualified as GhcPkg
-import Tricorder.Program qualified as Program
 
 
 main :: IO ()
@@ -66,4 +66,4 @@ main =
         . runBuildStore
         . runArguments
         . runUnixSocketIO
-        $ Program.run
+        $ Tricorder.run

--- a/tricorder/src/Tricorder.hs
+++ b/tricorder/src/Tricorder.hs
@@ -1,12 +1,7 @@
 module Tricorder (run) where
 
-import Data.Aeson (encode)
-import Data.Time.Format (defaultTimeLocale, formatTime)
-import Data.Time.LocalTime (getCurrentTimeZone, utcToLocalTime)
 import Effectful (IOE)
 import Effectful.Reader.Static (Reader, ask, asks)
-
-import Data.ByteString.Lazy qualified as BSL
 
 import Atelier.Effects.Cache (Cache)
 import Atelier.Effects.Clock (Clock)
@@ -15,32 +10,16 @@ import Atelier.Effects.Console (Console)
 import Atelier.Effects.Debounce (Debounce)
 import Atelier.Effects.Delay (Delay)
 import Atelier.Effects.File (File)
-import Atelier.Effects.FileSystem (FileSystem, doesFileExist, readFileLbs)
+import Atelier.Effects.FileSystem (FileSystem)
 import Atelier.Effects.FileWatcher (FileWatcher)
 import Atelier.Effects.Log (Log)
 import Atelier.Effects.Monitoring.Tracing (Tracing)
 import Atelier.Effects.Posix.Daemons (Daemons)
-import Atelier.Time (Millisecond)
-import Tricorder.Arguments
-    ( Command (..)
-    , FollowMode (..)
-    , OutputFormat (..)
-    , StatusOptions (..)
-    , Verbosity (..)
-    , WaitMode (..)
-    )
-import Tricorder.BuildState
-    ( BuildPhase (..)
-    , BuildResult (..)
-    , BuildState (..)
-    , DaemonInfo (..)
-    , Diagnostic (..)
-    , Severity (..)
-    , TestOutcome (..)
-    , TestRun (..)
-    )
+import Tricorder.Arguments (Command (..))
+import Tricorder.BuildState (BuildState (..), DaemonInfo (..))
+import Tricorder.CLI (showLog, showSource, showStatus)
 import Tricorder.Config (Config)
-import Tricorder.Daemon (startDaemon, stopDaemon)
+import Tricorder.Daemon (startDaemon, stopDaemon, waitForDaemon)
 import Tricorder.Effects.Brick (Brick)
 import Tricorder.Effects.BrickChan (BrickChan)
 import Tricorder.Effects.BuildStore (BuildStore)
@@ -49,19 +28,11 @@ import Tricorder.Effects.GhciSession (GhciSession)
 import Tricorder.Effects.TestRunner (TestRunner)
 import Tricorder.Effects.UnixSocket (UnixSocket)
 import Tricorder.GhcPkg.Types (ModuleName, PackageId)
-import Tricorder.Render (diagnosticLineIndexed, formatDuration, renderSourceResults)
 import Tricorder.Runtime (PidFile (..), SocketPath (..))
-import Tricorder.Socket.Client
-    ( isDaemonRunning
-    , querySource
-    , queryStatus
-    , queryStatusWait
-    )
+import Tricorder.Socket.Client (isDaemonRunning, queryStatus)
 import Tricorder.UI (viewUi)
 
 import Atelier.Effects.Console qualified as Console
-import Atelier.Effects.Delay qualified as Delay
-import Atelier.Effects.File qualified as File
 import Atelier.Effects.FileSystem qualified as FileSystem
 import Tricorder.Observability qualified as Observability
 
@@ -97,281 +68,45 @@ run
     => Eff es ()
 run =
     ask >>= \case
-        Start -> start
-        Stop -> stop
-        (Status opts) -> showStatus opts
-        (Log followMode) -> showLog followMode
-        UI -> ui
-        (Source moduleNames) -> showSource moduleNames
-
-
-start
-    :: ( BuildStore :> es
-       , Cache (PackageId, ModuleName) Text :> es
-       , Cache ModuleName PackageId :> es
-       , Clock :> es
-       , Conc :> es
-       , Console :> es
-       , Daemons :> es
-       , Debounce FilePath :> es
-       , Delay :> es
-       , FileSystem :> es
-       , FileWatcher :> es
-       , GhcPkg :> es
-       , GhciSession :> es
-       , IOE :> es
-       , Log :> es
-       , Reader Config :> es
-       , Reader Observability.Config :> es
-       , Reader PidFile :> es
-       , Reader SocketPath :> es
-       , TestRunner :> es
-       , Tracing :> es
-       , UnixSocket :> es
-       )
-    => Eff es ()
-start = do
-    running <- isDaemonRunning
-    if running then
-        Console.putStrLn "Daemon already running."
-    else do
-        startDaemon
-        Console.putStrLn "Daemon started."
-
-
-stop
-    :: ( Console :> es
-       , Daemons :> es
-       , FileSystem :> es
-       , Reader PidFile :> es
-       , Reader SocketPath :> es
-       )
-    => Eff es ()
-stop = do
-    stopDaemon
-    Console.putStrLn "Daemon stopped."
-    FileSystem.removeFile =<< asks getSocketPath
-    FileSystem.removeFile =<< asks getPidFile
-
-
-showStatus
-    :: ( Console :> es
-       , Daemons :> es
-       , File :> es
-       , IOE :> es
-       , Reader PidFile :> es
-       , Reader SocketPath :> es
-       , UnixSocket :> es
-       )
-    => StatusOptions -> Eff es ()
-showStatus opts = do
-    running <- isDaemonRunning
-    if not running then
-        Console.putStrLn "Stopped."
-    else do
-        SocketPath sockPath <- ask
-        when (opts.wait == WaitForBuild && opts.format == TextOutput) $ do
-            current <- queryStatus sockPath
-            case current of
-                Right BuildState {phase = Building} -> Console.putStrLn "Building..."
-                Right BuildState {phase = Restarting} -> Console.putStrLn "Restarting..."
-                Right BuildState {phase = Testing _} -> Console.putStrLn "Testing..."
-                _ -> pure ()
-        result <-
-            case opts.wait of
-                WaitForBuild -> queryStatusWait sockPath
-                ShowCurrent -> queryStatus sockPath
-        case result of
-            Left err -> Console.putTextLn $ "Error: " <> err
-            Right state ->
-                case opts.format of
-                    JsonOutput -> do
-                        Console.putStr $ BSL.toStrict $ encode state
-                        Console.putStrLn ""
-                    TextOutput ->
-                        renderText opts.verbosity opts.expand state
-  where
-    renderText verbosity expand state = case state.phase of
-        Building -> Console.putStrLn "Building..."
-        Restarting -> Console.putStrLn "Restarting..."
-        Testing _ -> Console.putStrLn "Testing..."
-        Done r -> do
-            tz <- liftIO getCurrentTimeZone
-            case expand of
-                Just n ->
-                    case r.diagnostics !!? (n - 1) of
-                        Nothing ->
-                            Console.putTextLn
-                                $ "No diagnostic #"
-                                    <> show n
-                                    <> " (current build has "
-                                    <> show (length r.diagnostics)
-                                    <> ")"
-                        Just d -> do
-                            Console.putTextLn $ diagnosticLineIndexed n d
-                            Console.putText d.text
-                Nothing -> do
-                    let printDiag (i, d) = case verbosity of
-                            Verbose -> do
-                                Console.putTextLn $ diagnosticLineIndexed i d
-                                Console.putText d.text
-                            Concise ->
-                                Console.putTextLn $ diagnosticLineIndexed i d
-                    mapM_ printDiag (zip [1 ..] r.diagnostics)
-                    Console.putTextLn $ buildSummary tz r
-                    mapM_ (printTestRun verbosity) r.testRuns
-                    when (buildHasErrors r || testsFailed r) $ liftIO exitFailure
-
-    printTestRun verbosity tr = do
-        Console.putTextLn $ testRunSummary tr.target tr.outcome
-        when (verbosity == Verbose)
-            $ mapM_ (Console.putTextLn . ("  " <>) . toText) (lines tr.output)
-      where
-        testRunSummary t TestsRunning = t <> "  running..."
-        testRunSummary t TestsPassed = t <> "  passed"
-        testRunSummary t TestsFailed = t <> "  failed"
-        testRunSummary t (TestsError msg) = t <> "  error: " <> msg
-
-    buildHasErrors r = any ((== SError) . (.severity)) r.diagnostics
-    testsFailed r = any (notPassed . (.outcome)) r.testRuns
-      where
-        notPassed TestsPassed = False
-        notPassed TestsRunning = False
-        notPassed _ = True
-
-    buildSummary tz r =
-        let errs = length $ filter ((== SError) . (.severity)) r.diagnostics
-            warns = length $ filter ((== SWarning) . (.severity)) r.diagnostics
-            ts = toText $ "— " <> formatTime defaultTimeLocale "%H:%M:%S" (utcToLocalTime tz r.completedAt)
-            stats = toText $ "(" <> show r.moduleCount <> " modules, " <> formatDuration r.durationMs <> ")"
-        in  if null r.diagnostics then
-                "All good. " <> stats <> " " <> ts
+        Start -> do
+            running <- isDaemonRunning
+            if running then
+                Console.putStrLn "Daemon already running."
+            else do
+                startDaemon
+                Console.putStrLn "Daemon started."
+        Stop -> do
+            stopDaemon
+            Console.putStrLn "Daemon stopped."
+            FileSystem.removeFile =<< asks getSocketPath
+            FileSystem.removeFile =<< asks getPidFile
+        Status opts -> do
+            running <- isDaemonRunning
+            if not running then
+                Console.putStrLn "Stopped."
             else
-                show errs <> " error(s), " <> show warns <> " warning(s) " <> stats <> " " <> ts
-
-
-showLog
-    :: ( Console :> es
-       , Daemons :> es
-       , Delay :> es
-       , File :> es
-       , FileSystem :> es
-       , Reader Observability.Config :> es
-       , Reader PidFile :> es
-       , Reader SocketPath :> es
-       , UnixSocket :> es
-       )
-    => FollowMode -> Eff es ()
-showLog followMode = do
-    running <- isDaemonRunning
-    mLogFile <-
-        if running then do
-            SocketPath sp <- ask
-            result <- queryStatus sp
-            pure $ case result of
-                Right state -> state.daemonInfo.logFile
-                Left _ -> Nothing
-        else
-            asks @Observability.Config (.logFile)
-    case mLogFile of
-        Nothing ->
-            Console.putStrLn "No log file configured. Add `log_file: /path/to/tricorder.log` to .tricorder.yaml"
-        Just path -> do
-            exists <- doesFileExist path
-            if not exists then
-                Console.putTextLn $ "Log file does not exist yet: " <> toText path
-            else case followMode of
-                Follow -> followLog path
-                NoFollow -> readFileLbs path >>= Console.putStr . BSL.toStrict
-  where
-    followLog path = File.withFile path ReadMode loop
-    loop h =
-        File.hIsEOF h >>= \case
-            True -> do
-                Delay.wait (200 :: Millisecond)
-                loop h
-            False -> do
-                File.hGetLine h >>= Console.putTextLn
-                loop h
-
-
-ui
-    :: ( Brick :> es
-       , BrickChan :> es
-       , BuildStore :> es
-       , Cache (PackageId, ModuleName) Text :> es
-       , Cache ModuleName PackageId :> es
-       , Clock :> es
-       , Conc :> es
-       , Daemons :> es
-       , Debounce FilePath :> es
-       , Delay :> es
-       , File :> es
-       , FileSystem :> es
-       , FileWatcher :> es
-       , GhcPkg :> es
-       , GhciSession :> es
-       , IOE :> es
-       , Log :> es
-       , Reader Config :> es
-       , Reader Observability.Config :> es
-       , Reader PidFile :> es
-       , Reader SocketPath :> es
-       , TestRunner :> es
-       , Tracing :> es
-       , UnixSocket :> es
-       )
-    => Eff es ()
-ui = do
-    running <- isDaemonRunning
-    unless running do
-        startDaemon
-        waitForDaemon
-    viewUi
-
-
-showSource
-    :: ( BuildStore :> es
-       , Cache (PackageId, ModuleName) Text :> es
-       , Cache ModuleName PackageId :> es
-       , Clock :> es
-       , Conc :> es
-       , Console :> es
-       , Daemons :> es
-       , Debounce FilePath :> es
-       , Delay :> es
-       , File :> es
-       , FileSystem :> es
-       , FileWatcher :> es
-       , GhcPkg :> es
-       , GhciSession :> es
-       , IOE :> es
-       , Log :> es
-       , Reader Config :> es
-       , Reader Observability.Config :> es
-       , Reader PidFile :> es
-       , Reader SocketPath :> es
-       , TestRunner :> es
-       , Tracing :> es
-       , UnixSocket :> es
-       )
-    => [ModuleName]
-    -> Eff es ()
-showSource moduleNames = do
-    running <- isDaemonRunning
-    unless running $ do
-        startDaemon
-        waitForDaemon
-    SocketPath sockPath <- ask
-    result <- querySource sockPath moduleNames
-    case result of
-        Left err -> Console.putTextLn $ "Error: " <> err
-        Right results -> renderSourceResults results
-
-
--- | Poll until the daemon socket becomes connectable.
-waitForDaemon :: (Daemons :> es, Delay :> es, Reader PidFile :> es, UnixSocket :> es) => Eff es ()
-waitForDaemon = do
-    Delay.wait (200 :: Millisecond)
-    running <- isDaemonRunning
-    unless running waitForDaemon
+                showStatus opts
+        Log followMode -> do
+            running <- isDaemonRunning
+            mLogFile <-
+                if running then do
+                    SocketPath sp <- ask
+                    result <- queryStatus sp
+                    pure $ case result of
+                        Right state -> state.daemonInfo.logFile
+                        Left _ -> Nothing
+                else
+                    asks @Observability.Config (.logFile)
+            showLog mLogFile followMode
+        UI -> do
+            running <- isDaemonRunning
+            unless running do
+                startDaemon
+                waitForDaemon
+            viewUi
+        Source moduleNames -> do
+            running <- isDaemonRunning
+            unless running $ do
+                startDaemon
+                waitForDaemon
+            showSource moduleNames

--- a/tricorder/src/Tricorder.hs
+++ b/tricorder/src/Tricorder.hs
@@ -21,7 +21,14 @@ import Atelier.Effects.Log (Log)
 import Atelier.Effects.Monitoring.Tracing (Tracing)
 import Atelier.Effects.Posix.Daemons (Daemons)
 import Atelier.Time (Millisecond)
-import Tricorder.Arguments (Command (..))
+import Tricorder.Arguments
+    ( Command (..)
+    , FollowMode (..)
+    , OutputFormat (..)
+    , StatusOptions (..)
+    , Verbosity (..)
+    , WaitMode (..)
+    )
 import Tricorder.BuildState
     ( BuildPhase (..)
     , BuildResult (..)
@@ -92,8 +99,8 @@ run =
     ask >>= \case
         Start -> start
         Stop -> stop
-        (Status waitFlag jsonFlag verboseFlag expandFlag) -> showStatus waitFlag jsonFlag verboseFlag expandFlag
-        (Log followFlag) -> showLog followFlag
+        (Status opts) -> showStatus opts
+        (Log followMode) -> showLog followMode
         UI -> ui
         (Source moduleNames) -> showSource moduleNames
 
@@ -156,14 +163,14 @@ showStatus
        , Reader SocketPath :> es
        , UnixSocket :> es
        )
-    => Bool -> Bool -> Bool -> Maybe Int -> Eff es ()
-showStatus waitFlag jsonFlag verboseFlag expandFlag = do
+    => StatusOptions -> Eff es ()
+showStatus opts = do
     running <- isDaemonRunning
     if not running then
         Console.putStrLn "Stopped."
     else do
         SocketPath sockPath <- ask
-        when (waitFlag && not jsonFlag) $ do
+        when (opts.wait == WaitForBuild && opts.format == TextOutput) $ do
             current <- queryStatus sockPath
             case current of
                 Right BuildState {phase = Building} -> Console.putStrLn "Building..."
@@ -171,20 +178,20 @@ showStatus waitFlag jsonFlag verboseFlag expandFlag = do
                 Right BuildState {phase = Testing _} -> Console.putStrLn "Testing..."
                 _ -> pure ()
         result <-
-            if waitFlag then
-                queryStatusWait sockPath
-            else
-                queryStatus sockPath
+            case opts.wait of
+                WaitForBuild -> queryStatusWait sockPath
+                ShowCurrent -> queryStatus sockPath
         case result of
             Left err -> Console.putTextLn $ "Error: " <> err
             Right state ->
-                if jsonFlag then do
-                    Console.putStr $ BSL.toStrict $ encode state
-                    Console.putStrLn ""
-                else
-                    renderText verboseFlag expandFlag state
+                case opts.format of
+                    JsonOutput -> do
+                        Console.putStr $ BSL.toStrict $ encode state
+                        Console.putStrLn ""
+                    TextOutput ->
+                        renderText opts.verbosity opts.expand state
   where
-    renderText verbose expand state = case state.phase of
+    renderText verbosity expand state = case state.phase of
         Building -> Console.putStrLn "Building..."
         Restarting -> Console.putStrLn "Restarting..."
         Testing _ -> Console.putStrLn "Testing..."
@@ -204,20 +211,20 @@ showStatus waitFlag jsonFlag verboseFlag expandFlag = do
                             Console.putTextLn $ diagnosticLineIndexed n d
                             Console.putText d.text
                 Nothing -> do
-                    let printDiag (i, d) =
-                            if verbose then do
+                    let printDiag (i, d) = case verbosity of
+                            Verbose -> do
                                 Console.putTextLn $ diagnosticLineIndexed i d
                                 Console.putText d.text
-                            else
+                            Concise ->
                                 Console.putTextLn $ diagnosticLineIndexed i d
                     mapM_ printDiag (zip [1 ..] r.diagnostics)
                     Console.putTextLn $ buildSummary tz r
-                    mapM_ (printTestRun verbose) r.testRuns
+                    mapM_ (printTestRun verbosity) r.testRuns
                     when (buildHasErrors r || testsFailed r) $ liftIO exitFailure
 
-    printTestRun verbose tr = do
+    printTestRun verbosity tr = do
         Console.putTextLn $ testRunSummary tr.target tr.outcome
-        when verbose
+        when (verbosity == Verbose)
             $ mapM_ (Console.putTextLn . ("  " <>) . toText) (lines tr.output)
       where
         testRunSummary t TestsRunning = t <> "  running..."
@@ -254,8 +261,8 @@ showLog
        , Reader SocketPath :> es
        , UnixSocket :> es
        )
-    => Bool -> Eff es ()
-showLog followFlag = do
+    => FollowMode -> Eff es ()
+showLog followMode = do
     running <- isDaemonRunning
     mLogFile <-
         if running then do
@@ -273,11 +280,9 @@ showLog followFlag = do
             exists <- doesFileExist path
             if not exists then
                 Console.putTextLn $ "Log file does not exist yet: " <> toText path
-            else
-                if followFlag then
-                    followLog path
-                else
-                    readFileLbs path >>= Console.putStr . BSL.toStrict
+            else case followMode of
+                Follow -> followLog path
+                NoFollow -> readFileLbs path >>= Console.putStr . BSL.toStrict
   where
     followLog path = File.withFile path ReadMode loop
     loop h =

--- a/tricorder/src/Tricorder.hs
+++ b/tricorder/src/Tricorder.hs
@@ -1,4 +1,4 @@
-module Tricorder.Program (run) where
+module Tricorder (run) where
 
 import Data.Aeson (encode)
 import Data.Time.Format (defaultTimeLocale, formatTime)

--- a/tricorder/src/Tricorder/Arguments.hs
+++ b/tricorder/src/Tricorder/Arguments.hs
@@ -1,5 +1,10 @@
 module Tricorder.Arguments
     ( Command (..)
+    , FollowMode (..)
+    , OutputFormat (..)
+    , StatusOptions (..)
+    , Verbosity (..)
+    , WaitMode (..)
     , parseArguments
     , runArguments
     ) where
@@ -13,6 +18,7 @@ import Options.Applicative
     , auto
     , command
     , execParser
+    , flag
     , fullDesc
     , header
     , help
@@ -25,18 +31,49 @@ import Options.Applicative
     , progDesc
     , short
     , str
-    , switch
     )
 
 import Tricorder.GhcPkg.Types (ModuleName (..))
 
 
+data WaitMode
+    = ShowCurrent
+    | WaitForBuild
+    deriving stock (Eq)
+
+
+data OutputFormat
+    = TextOutput
+    | JsonOutput
+    deriving stock (Eq)
+
+
+data Verbosity
+    = Concise
+    | Verbose
+    deriving stock (Eq)
+
+
+data FollowMode
+    = NoFollow
+    | Follow
+    deriving stock (Eq)
+
+
+data StatusOptions = StatusOptions
+    { wait :: WaitMode
+    , format :: OutputFormat
+    , verbosity :: Verbosity
+    , expand :: Maybe Int
+    }
+
+
 data Command
     = Start
     | Stop
-    | Status Bool Bool Bool (Maybe Int)
+    | Status StatusOptions
     | UI
-    | Log Bool
+    | Log FollowMode
     | Source [ModuleName]
 
 
@@ -73,7 +110,9 @@ commandParser =
 logParser :: Parser Command
 logParser =
     Log
-        <$> switch
+        <$> flag
+            NoFollow
+            Follow
             ( long "follow"
                 <> short 'f'
                 <> help "Keep streaming new log lines as they are written"
@@ -83,26 +122,34 @@ logParser =
 statusParser :: Parser Command
 statusParser =
     Status
-        <$> switch
-            ( long "wait"
-                <> help "Block until the current build cycle completes"
-            )
-        <*> switch
-            ( long "json"
-                <> help "Output full build state as JSON"
-            )
-        <*> switch
-            ( long "verbose"
-                <> short 'v'
-                <> help "Print full GHC message body under each diagnostic"
-            )
-        <*> optional
-            ( option
-                auto
-                ( long "expand"
-                    <> metavar "N"
-                    <> help "Print full GHC message body for diagnostic #N"
-                )
+        <$> ( StatusOptions
+                <$> flag
+                    ShowCurrent
+                    WaitForBuild
+                    ( long "wait"
+                        <> help "Block until the current build cycle completes"
+                    )
+                <*> flag
+                    TextOutput
+                    JsonOutput
+                    ( long "json"
+                        <> help "Output full build state as JSON"
+                    )
+                <*> flag
+                    Concise
+                    Verbose
+                    ( long "verbose"
+                        <> short 'v'
+                        <> help "Print full GHC message body under each diagnostic"
+                    )
+                <*> optional
+                    ( option
+                        auto
+                        ( long "expand"
+                            <> metavar "N"
+                            <> help "Print full GHC message body for diagnostic #N"
+                        )
+                    )
             )
 
 

--- a/tricorder/src/Tricorder/CLI.hs
+++ b/tricorder/src/Tricorder/CLI.hs
@@ -1,0 +1,187 @@
+module Tricorder.CLI
+    ( showLog
+    , showSource
+    , showStatus
+    ) where
+
+import Data.Aeson (encode)
+import Data.Time.Format (defaultTimeLocale, formatTime)
+import Data.Time.LocalTime (getCurrentTimeZone, utcToLocalTime)
+import Effectful (IOE)
+import Effectful.Reader.Static (Reader, ask)
+
+import Data.ByteString.Lazy qualified as BSL
+
+import Atelier.Effects.Console (Console)
+import Atelier.Effects.Delay (Delay)
+import Atelier.Effects.File (File)
+import Atelier.Effects.FileSystem (FileSystem, doesFileExist, readFileLbs)
+import Atelier.Time (Millisecond)
+import Tricorder.Arguments
+    ( FollowMode (..)
+    , OutputFormat (..)
+    , StatusOptions (..)
+    , Verbosity (..)
+    , WaitMode (..)
+    )
+import Tricorder.BuildState
+    ( BuildPhase (..)
+    , BuildResult (..)
+    , BuildState (..)
+    , Diagnostic (..)
+    , Severity (..)
+    , TestOutcome (..)
+    , TestRun (..)
+    )
+import Tricorder.CLI.Render
+    ( diagnosticLineIndexed
+    , formatDuration
+    , renderSourceResults
+    )
+import Tricorder.Effects.UnixSocket (UnixSocket)
+import Tricorder.GhcPkg.Types (ModuleName)
+import Tricorder.Runtime (SocketPath (..))
+import Tricorder.Socket.Client
+    ( querySource
+    , queryStatus
+    , queryStatusWait
+    )
+
+import Atelier.Effects.Console qualified as Console
+import Atelier.Effects.Delay qualified as Delay
+import Atelier.Effects.File qualified as File
+
+
+showStatus
+    :: ( Console :> es
+       , File :> es
+       , IOE :> es
+       , Reader SocketPath :> es
+       , UnixSocket :> es
+       )
+    => StatusOptions -> Eff es ()
+showStatus opts = do
+    SocketPath sockPath <- ask
+    when (opts.wait == WaitForBuild && opts.format == TextOutput) $ do
+        current <- queryStatus sockPath
+        case current of
+            Right BuildState {phase = Building} -> Console.putStrLn "Building..."
+            Right BuildState {phase = Restarting} -> Console.putStrLn "Restarting..."
+            Right BuildState {phase = Testing _} -> Console.putStrLn "Testing..."
+            _ -> pure ()
+    result <-
+        case opts.wait of
+            WaitForBuild -> queryStatusWait sockPath
+            ShowCurrent -> queryStatus sockPath
+    case result of
+        Left err -> Console.putTextLn $ "Error: " <> err
+        Right state ->
+            case opts.format of
+                JsonOutput -> do
+                    Console.putStr $ BSL.toStrict $ encode state
+                    Console.putStrLn ""
+                TextOutput ->
+                    renderText opts.verbosity opts.expand state
+  where
+    renderText verbosity expand state = case state.phase of
+        Building -> Console.putStrLn "Building..."
+        Restarting -> Console.putStrLn "Restarting..."
+        Testing _ -> Console.putStrLn "Testing..."
+        Done r -> do
+            tz <- liftIO getCurrentTimeZone
+            case expand of
+                Just n ->
+                    case r.diagnostics !!? (n - 1) of
+                        Nothing ->
+                            Console.putTextLn
+                                $ "No diagnostic #"
+                                    <> show n
+                                    <> " (current build has "
+                                    <> show (length r.diagnostics)
+                                    <> ")"
+                        Just d -> do
+                            Console.putTextLn $ diagnosticLineIndexed n d
+                            Console.putText d.text
+                Nothing -> do
+                    let printDiag (i, d) = case verbosity of
+                            Verbose -> do
+                                Console.putTextLn $ diagnosticLineIndexed i d
+                                Console.putText d.text
+                            Concise ->
+                                Console.putTextLn $ diagnosticLineIndexed i d
+                    mapM_ printDiag (zip [1 ..] r.diagnostics)
+                    Console.putTextLn $ buildSummary tz r
+                    mapM_ (printTestRun verbosity) r.testRuns
+                    when (buildHasErrors r || testsFailed r) $ liftIO exitFailure
+
+    printTestRun verbosity tr = do
+        Console.putTextLn $ testRunSummary tr.target tr.outcome
+        when (verbosity == Verbose)
+            $ mapM_ (Console.putTextLn . ("  " <>) . toText) (lines tr.output)
+      where
+        testRunSummary t TestsRunning = t <> "  running..."
+        testRunSummary t TestsPassed = t <> "  passed"
+        testRunSummary t TestsFailed = t <> "  failed"
+        testRunSummary t (TestsError msg) = t <> "  error: " <> msg
+
+    buildHasErrors r = any ((== SError) . (.severity)) r.diagnostics
+    testsFailed r = any (notPassed . (.outcome)) r.testRuns
+      where
+        notPassed TestsPassed = False
+        notPassed TestsRunning = False
+        notPassed _ = True
+
+    buildSummary tz r =
+        let errs = length $ filter ((== SError) . (.severity)) r.diagnostics
+            warns = length $ filter ((== SWarning) . (.severity)) r.diagnostics
+            ts = toText $ "— " <> formatTime defaultTimeLocale "%H:%M:%S" (utcToLocalTime tz r.completedAt)
+            stats = toText $ "(" <> show r.moduleCount <> " modules, " <> formatDuration r.durationMs <> ")"
+        in  if null r.diagnostics then
+                "All good. " <> stats <> " " <> ts
+            else
+                show errs <> " error(s), " <> show warns <> " warning(s) " <> stats <> " " <> ts
+
+
+showLog
+    :: ( Console :> es
+       , Delay :> es
+       , File :> es
+       , FileSystem :> es
+       )
+    => Maybe FilePath -> FollowMode -> Eff es ()
+showLog mLogFile followMode = case mLogFile of
+    Nothing ->
+        Console.putStrLn "No log file configured. Add `log_file: /path/to/tricorder.log` to .tricorder.yaml"
+    Just path -> do
+        exists <- doesFileExist path
+        if not exists then
+            Console.putTextLn $ "Log file does not exist yet: " <> toText path
+        else case followMode of
+            Follow -> followLog path
+            NoFollow -> readFileLbs path >>= Console.putStr . BSL.toStrict
+  where
+    followLog path = File.withFile path ReadMode loop
+    loop h =
+        File.hIsEOF h >>= \case
+            True -> do
+                Delay.wait (200 :: Millisecond)
+                loop h
+            False -> do
+                File.hGetLine h >>= Console.putTextLn
+                loop h
+
+
+showSource
+    :: ( Console :> es
+       , File :> es
+       , Reader SocketPath :> es
+       , UnixSocket :> es
+       )
+    => [ModuleName]
+    -> Eff es ()
+showSource moduleNames = do
+    SocketPath sockPath <- ask
+    result <- querySource sockPath moduleNames
+    case result of
+        Left err -> Console.putTextLn $ "Error: " <> err
+        Right results -> renderSourceResults results

--- a/tricorder/src/Tricorder/CLI/Render.hs
+++ b/tricorder/src/Tricorder/CLI/Render.hs
@@ -1,4 +1,4 @@
-module Tricorder.Render
+module Tricorder.CLI.Render
     ( -- * Plain-text formatting
       diagnosticLine
     , diagnosticLineIndexed

--- a/tricorder/src/Tricorder/Daemon.hs
+++ b/tricorder/src/Tricorder/Daemon.hs
@@ -2,6 +2,7 @@ module Tricorder.Daemon
     ( runDaemon
     , startDaemon
     , stopDaemon
+    , waitForDaemon
     ) where
 
 import Effectful (IOE)
@@ -18,6 +19,7 @@ import Atelier.Effects.FileWatcher (FileWatcher)
 import Atelier.Effects.Log (Log)
 import Atelier.Effects.Monitoring.Tracing (Tracing)
 import Atelier.Effects.Posix.Daemons (Daemons)
+import Atelier.Time (Millisecond)
 import Tricorder.Config (Config (..))
 import Tricorder.Effects.BuildStore (BuildStore)
 import Tricorder.Effects.GhcPkg (GhcPkg)
@@ -26,7 +28,9 @@ import Tricorder.Effects.TestRunner (TestRunner)
 import Tricorder.Effects.UnixSocket (UnixSocket)
 import Tricorder.GhcPkg.Types (ModuleName, PackageId)
 import Tricorder.Runtime (PidFile, SocketPath (..))
+import Tricorder.Socket.Client (isDaemonRunning)
 
+import Atelier.Effects.Delay qualified as Delay
 import Atelier.Effects.Posix.Daemons qualified as Daemons
 import Tricorder.GhciSession qualified as GhciSession
 import Tricorder.Observability qualified as Observability
@@ -102,3 +106,11 @@ stopDaemon :: (Daemons :> es, Reader PidFile :> es) => Eff es ()
 stopDaemon = do
     pidFile <- ask
     Daemons.killAndWait pidFile
+
+
+-- | Poll until the daemon socket becomes connectable.
+waitForDaemon :: (Daemons :> es, Delay :> es, Reader PidFile :> es, UnixSocket :> es) => Eff es ()
+waitForDaemon = do
+    Delay.wait (200 :: Millisecond)
+    running <- isDaemonRunning
+    unless running waitForDaemon

--- a/tricorder/test/Unit/Tricorder/CLI/RenderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/CLI/RenderSpec.hs
@@ -1,4 +1,4 @@
-module Unit.Tricorder.RenderSpec (spec_Render) where
+module Unit.Tricorder.CLI.RenderSpec (spec_Render) where
 
 import Test.Hspec
 
@@ -6,7 +6,7 @@ import Tricorder.BuildState
     ( Diagnostic (..)
     , Severity (..)
     )
-import Tricorder.Render (diagnosticBlock)
+import Tricorder.CLI.Render (diagnosticBlock)
 
 
 spec_Render :: Spec


### PR DESCRIPTION
- Rename `Tricorder.Program` to `Tricorder`
- Create dedicated `Tricorder.CLI` and `Tricorder.CLI.Render` modules
- Get rid of boolean blindness in CLI arguments with dedicated flag-like types