### PR TITLE
feat: add Atelier.Effects.Exit effect

### DIFF
--- a/atelier/prelude/Prelude.hs
+++ b/atelier/prelude/Prelude.hs
@@ -18,7 +18,6 @@ module Prelude
 
       -- * Reexports from Relude.Lifted
     , module Relude.Lifted.Env
-    , module Relude.Lifted.Exit
     , module Relude.Lifted.File
     , module Relude.Lifted.Handle
     , module Relude.Lifted.Terminal
@@ -70,7 +69,6 @@ import Relude.Print
 import Relude.String
 
 -- From Relude.Lifted, we don't want Relude.Lifted.Concurrent.
-import Relude.Lifted.Exit
 import Relude.Lifted.Env hiding (lookupEnv)
 import Relude.Lifted.File
 import Relude.Lifted.Terminal

--- a/atelier/src/Atelier/Effects/Exit.hs
+++ b/atelier/src/Atelier/Effects/Exit.hs
@@ -1,0 +1,46 @@
+module Atelier.Effects.Exit
+    ( -- * Effect
+      Exit
+    , exitWith
+    , exitSuccess
+    , exitFailure
+
+      -- * Interpreters
+    , runExit
+    , runExitNoOp
+    ) where
+
+import Effectful (Effect, IOE)
+import Effectful.Dispatch.Dynamic (interpret_, reinterpret_)
+import Effectful.Error.Static (runErrorNoCallStack, throwError)
+import Effectful.TH (makeEffect)
+import System.Exit (ExitCode (..))
+
+import System.Exit qualified as IO
+
+
+data Exit :: Effect where
+    ExitWith :: ExitCode -> Exit m a
+
+
+makeEffect ''Exit
+
+
+exitSuccess :: (Exit :> es) => Eff es a
+exitSuccess = exitWith ExitSuccess
+
+
+exitFailure :: (Exit :> es) => Eff es a
+exitFailure = exitWith (ExitFailure 1)
+
+
+runExit :: (IOE :> es) => Eff (Exit : es) a -> Eff es a
+runExit = interpret_ \(ExitWith code) -> liftIO (IO.exitWith code)
+
+
+-- | Exit interpreter that captures exit calls instead of terminating the process.
+-- Returns 'Left' the exit code if the action exited, 'Right' the result otherwise.
+-- Useful in unit tests.
+runExitNoOp :: Eff (Exit : es) a -> Eff es (Either ExitCode a)
+runExitNoOp =
+    reinterpret_ (runErrorNoCallStack @ExitCode) \(ExitWith code) -> throwError code

--- a/tricorder.cabal
+++ b/tricorder.cabal
@@ -121,6 +121,7 @@ library atelier
       Atelier.Effects.Debounce
       Atelier.Effects.Delay
       Atelier.Effects.Env
+      Atelier.Effects.Exit
       Atelier.Effects.File
       Atelier.Effects.FileSystem
       Atelier.Effects.FileWatcher

--- a/tricorder/app/Main.hs
+++ b/tricorder/app/Main.hs
@@ -11,6 +11,7 @@ import Atelier.Effects.Conc (runConc)
 import Atelier.Effects.Console (runConsole)
 import Atelier.Effects.Debounce (runDebounce)
 import Atelier.Effects.Delay (runDelay)
+import Atelier.Effects.Exit (runExit)
 import Atelier.Effects.File (runFile)
 import Atelier.Effects.FileSystem (runFileSystemIO)
 import Atelier.Effects.FileWatcher (runFileWatcherIO)
@@ -42,6 +43,7 @@ main =
         . runBrickChan
         . runBrick
         . runConsole
+        . runExit
         . runClock
         . runTracingNoOp
         . runDelay

--- a/tricorder/src/Tricorder.hs
+++ b/tricorder/src/Tricorder.hs
@@ -9,6 +9,7 @@ import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.Console (Console)
 import Atelier.Effects.Debounce (Debounce)
 import Atelier.Effects.Delay (Delay)
+import Atelier.Effects.Exit (Exit)
 import Atelier.Effects.File (File)
 import Atelier.Effects.FileSystem (FileSystem)
 import Atelier.Effects.FileWatcher (FileWatcher)
@@ -49,6 +50,7 @@ run
        , Daemons :> es
        , Debounce FilePath :> es
        , Delay :> es
+       , Exit :> es
        , File :> es
        , FileSystem :> es
        , FileWatcher :> es

--- a/tricorder/src/Tricorder/CLI.hs
+++ b/tricorder/src/Tricorder/CLI.hs
@@ -6,14 +6,15 @@ module Tricorder.CLI
 
 import Data.Aeson (encode)
 import Data.Time.Format (defaultTimeLocale, formatTime)
-import Data.Time.LocalTime (getCurrentTimeZone, utcToLocalTime)
-import Effectful (IOE)
+import Data.Time.LocalTime (utcToLocalTime)
 import Effectful.Reader.Static (Reader, ask)
 
 import Data.ByteString.Lazy qualified as BSL
 
+import Atelier.Effects.Clock (Clock, currentTimeZone)
 import Atelier.Effects.Console (Console)
 import Atelier.Effects.Delay (Delay)
+import Atelier.Effects.Exit (Exit, exitFailure)
 import Atelier.Effects.File (File)
 import Atelier.Effects.FileSystem (FileSystem, doesFileExist, readFileLbs)
 import Atelier.Time (Millisecond)
@@ -53,9 +54,10 @@ import Atelier.Effects.File qualified as File
 
 
 showStatus
-    :: ( Console :> es
+    :: ( Clock :> es
+       , Console :> es
+       , Exit :> es
        , File :> es
-       , IOE :> es
        , Reader SocketPath :> es
        , UnixSocket :> es
        )
@@ -88,7 +90,7 @@ showStatus opts = do
         Restarting -> Console.putStrLn "Restarting..."
         Testing _ -> Console.putStrLn "Testing..."
         Done r -> do
-            tz <- liftIO getCurrentTimeZone
+            tz <- currentTimeZone
             case expand of
                 Just n ->
                     case r.diagnostics !!? (n - 1) of
@@ -112,7 +114,7 @@ showStatus opts = do
                     mapM_ printDiag (zip [1 ..] r.diagnostics)
                     Console.putTextLn $ buildSummary tz r
                     mapM_ (printTestRun verbosity) r.testRuns
-                    when (buildHasErrors r || testsFailed r) $ liftIO exitFailure
+                    when (buildHasErrors r || testsFailed r) exitFailure
 
     printTestRun verbosity tr = do
         Console.putTextLn $ testRunSummary tr.target tr.outcome


### PR DESCRIPTION
- Introduce `Exit` effect with `exitWith`, `exitSuccess`, `exitFailure`
- Provide `runExit` (real IO) and `runExitNoOp` (captures exit for tests)
- Remove `Relude.Lifted.Exit` from the Atelier prelude
- Replace `IOE` + `liftIO exitFailure` in `Tricorder.CLI` with `Exit`