### PR TITLE
fix: tricorder log fails when daemon holds log file lock

### DIFF
--- a/atelier/src/Atelier/Effects/FileSystem.hs
+++ b/atelier/src/Atelier/Effects/FileSystem.hs
@@ -1,7 +1,9 @@
 module Atelier.Effects.FileSystem
     ( FileSystem (..)
     , readFileBs
+    , readFileLbsFrom
     , readFileLbs
+    , followFile
     , doesFileExist
     , doesPathExist
     , listDirectory
@@ -14,19 +16,28 @@ module Atelier.Effects.FileSystem
     , runFileSystemNoOp
     ) where
 
+import Control.Exception (bracket)
 import Effectful (Effect, IOE)
 import Effectful.Dispatch.Dynamic (interpret_)
 import Effectful.TH (makeEffect)
 import System.Environment (lookupEnv)
+import System.Posix.Types (FileOffset)
 
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
 import System.Directory qualified as Dir
+import System.Posix.IO qualified as Posix
+
+import Atelier.Effects.Delay (Delay)
+import Atelier.Effects.Posix.IO (readFdFrom)
+import Atelier.Time (Millisecond)
+
+import Atelier.Effects.Delay qualified as Delay
 
 
 data FileSystem :: Effect where
     ReadFileBs :: FilePath -> FileSystem m ByteString
-    ReadFileLbs :: FilePath -> FileSystem m LBS.ByteString
+    ReadFileLbsFrom :: FilePath -> FileOffset -> FileSystem m LBS.ByteString
     DoesFileExist :: FilePath -> FileSystem m Bool
     DoesPathExist :: FilePath -> FileSystem m Bool
     ListDirectory :: FilePath -> FileSystem m [FilePath]
@@ -40,10 +51,35 @@ data FileSystem :: Effect where
 makeEffect ''FileSystem
 
 
+readFileLbs :: (FileSystem :> es) => FilePath -> Eff es LBS.ByteString
+readFileLbs path = readFileLbsFrom path 0
+
+
+-- | Follow a file as it grows, calling @onChunk@ with each new chunk of
+-- content. Polls every 200ms. Does not return.
+followFile
+    :: (Delay :> es, FileSystem :> es)
+    => FilePath
+    -> (ByteString -> Eff es ())
+    -> Eff es a
+followFile path onChunk = go 0
+  where
+    go offset = do
+        newContent <- readFileLbsFrom path offset
+        if LBS.null newContent then pure () else onChunk (LBS.toStrict newContent)
+        Delay.wait (200 :: Millisecond)
+        go (offset + fromIntegral (LBS.length newContent))
+
+
 runFileSystemIO :: (IOE :> es) => Eff (FileSystem : es) a -> Eff es a
 runFileSystemIO = interpret_ $ \case
     ReadFileBs path -> liftIO $ BS.readFile path
-    ReadFileLbs path -> liftIO $ LBS.readFile path
+    ReadFileLbsFrom path offset ->
+        liftIO
+            $ bracket
+                (Posix.openFd path Posix.ReadOnly Posix.defaultFileFlags)
+                Posix.closeFd
+                (readFdFrom offset)
     DoesFileExist path -> liftIO $ Dir.doesFileExist path
     DoesPathExist path -> liftIO $ Dir.doesPathExist path
     ListDirectory path -> liftIO $ Dir.listDirectory path
@@ -57,7 +93,7 @@ runFileSystemIO = interpret_ $ \case
 runFileSystemNoOp :: Eff (FileSystem : es) a -> Eff es a
 runFileSystemNoOp = interpret_ $ \case
     ReadFileBs _ -> pure mempty
-    ReadFileLbs _ -> pure mempty
+    ReadFileLbsFrom _ _ -> pure mempty
     DoesFileExist _ -> pure False
     DoesPathExist _ -> pure False
     ListDirectory _ -> pure []

--- a/atelier/src/Atelier/Effects/Posix/IO.hs
+++ b/atelier/src/Atelier/Effects/Posix/IO.hs
@@ -1,0 +1,69 @@
+-- |
+--
+-- GHC's 'System.IO.openFile' and 'System.IO.withFile' participate in an
+-- advisory file-locking protocol built on @flock(2)@:
+--
+--   * Write\/append mode acquires an exclusive lock (@LOCK_EX@).
+--   * Read mode acquires a shared lock (@LOCK_SH@).
+--
+-- Because these locks are advisory, processes that do not call @flock@ can
+-- always read or write the file freely. GHC's own runtime, however, refuses
+-- to open a file for reading while another GHC process holds an exclusive
+-- lock on it — even if the underlying read would be perfectly safe - and
+-- throws @resource busy (file is locked)@.
+--
+-- This is a problem when a long-lived daemon holds a file open in append mode
+-- and a short-lived client process wants to read that file. Using 'readFdAll',
+-- the client opens the file via @open(2)@ without ever calling @flock@,
+-- matching the behaviour of standard Unix tools like @cat@ and @tail@.
+module Atelier.Effects.Posix.IO
+    ( readFdAll
+    , readFdFrom
+    ) where
+
+import Foreign.Marshal.Alloc (allocaBytes)
+import Foreign.Ptr (castPtr)
+import System.IO (SeekMode (..))
+import System.Posix.Types (Fd, FileOffset)
+
+import Data.ByteString qualified as BS
+import Data.ByteString.Builder qualified as Builder
+import Data.ByteString.Lazy qualified as LBS
+import System.Posix.IO qualified as Posix
+
+
+-- | Read the entire contents of a file descriptor into a lazy 'LBS.ByteString'
+-- without acquiring any file lock.
+--
+-- The file is read in chunks via @read(2)@ (@'Posix.fdReadBuf'@) until EOF.
+-- The caller retains ownership of the 'Fd' and is responsible for closing it;
+-- this function does not close the descriptor after reading.
+--
+-- Typical use via 'Control.Exception.bracket':
+--
+-- @
+-- result <- bracket
+--     (Posix.openFd path Posix.ReadOnly Posix.defaultFileFlags)
+--     Posix.closeFd
+--     readFdAll
+-- @
+readFdAll :: Fd -> IO LBS.ByteString
+readFdAll fd = Builder.toLazyByteString <$> go mempty
+  where
+    chunkSize = 65536 :: Int
+    go acc = do
+        chunk <- allocaBytes chunkSize \ptr -> do
+            n <- Posix.fdReadBuf fd (castPtr ptr) (fromIntegral chunkSize)
+            BS.packCStringLen (castPtr ptr, fromIntegral n)
+        if BS.null chunk then
+            return acc
+        else
+            go (acc <> Builder.byteString chunk)
+
+
+-- | Seek to @offset@ and read the remainder of a file descriptor into a lazy
+-- 'LBS.ByteString' without acquiring any file lock.
+readFdFrom :: FileOffset -> Fd -> IO LBS.ByteString
+readFdFrom offset fd = do
+    _ <- Posix.fdSeek fd AbsoluteSeek offset
+    readFdAll fd

--- a/tricorder.cabal
+++ b/tricorder.cabal
@@ -131,6 +131,7 @@ library atelier
       Atelier.Effects.Monitoring.Tracing
       Atelier.Effects.Monitoring.Tracing.Provider
       Atelier.Effects.Posix.Daemons
+      Atelier.Effects.Posix.IO
       Atelier.Effects.Publishing
       Atelier.Effects.Tally
       Atelier.Effects.UUID

--- a/tricorder/src/Tricorder/CLI.hs
+++ b/tricorder/src/Tricorder/CLI.hs
@@ -15,8 +15,7 @@ import Data.ByteString.Lazy qualified as BSL
 import Atelier.Effects.Console (Console)
 import Atelier.Effects.Delay (Delay)
 import Atelier.Effects.File (File)
-import Atelier.Effects.FileSystem (FileSystem, doesFileExist, readFileLbs)
-import Atelier.Time (Millisecond)
+import Atelier.Effects.FileSystem (FileSystem, doesFileExist, followFile, readFileLbs)
 import Tricorder.Arguments
     ( FollowMode (..)
     , OutputFormat (..)
@@ -48,8 +47,6 @@ import Tricorder.Socket.Client
     )
 
 import Atelier.Effects.Console qualified as Console
-import Atelier.Effects.Delay qualified as Delay
-import Atelier.Effects.File qualified as File
 
 
 showStatus
@@ -145,7 +142,6 @@ showStatus opts = do
 showLog
     :: ( Console :> es
        , Delay :> es
-       , File :> es
        , FileSystem :> es
        )
     => Maybe FilePath -> FollowMode -> Eff es ()
@@ -157,18 +153,8 @@ showLog mLogFile followMode = case mLogFile of
         if not exists then
             Console.putTextLn $ "Log file does not exist yet: " <> toText path
         else case followMode of
-            Follow -> followLog path
+            Follow -> followFile path Console.putStr
             NoFollow -> readFileLbs path >>= Console.putStr . BSL.toStrict
-  where
-    followLog path = File.withFile path ReadMode loop
-    loop h =
-        File.hIsEOF h >>= \case
-            True -> do
-                Delay.wait (200 :: Millisecond)
-                loop h
-            False -> do
-                File.hGetLine h >>= Console.putTextLn
-                loop h
 
 
 showSource

--- a/tricorder/test/Unit/Tricorder/SourceLookupSpec.hs
+++ b/tricorder/test/Unit/Tricorder/SourceLookupSpec.hs
@@ -114,7 +114,7 @@ barHtml = "<html><body><pre id=\"src\"><span>module</span> Bar <span>where</span
 runFileSystemScripted :: Map FilePath LByteString -> Eff (FileSystem : es) a -> Eff es a
 runFileSystemScripted files = interpret_ \case
     DoesFileExist path -> pure $ Map.member path files
-    ReadFileLbs path -> pure $ fromMaybe "" (Map.lookup path files)
+    ReadFileLbsFrom path _ -> pure $ fromMaybe "" (Map.lookup path files)
     _ -> error "FileSystemScripted: unexpected operation"
 
 


### PR DESCRIPTION
The daemon keeps the log file open in append mode, which causes GHC's advisory locking to block any read attempt from the client process.

Fix by reading the log file via raw POSIX file descriptors (`open(2)` + `read(2)`) instead of `System.IO`, bypassing the `flock`-based locking entirely:

- Add `Atelier.Effects.Posix.IO` with `readFdAll` and `readFdFrom`
- Replace the `ReadFileLbs` effect constructor with `ReadFileLbsFrom path offset`, backed by `fdSeek` + `readFdAll`
- Keep `readFileLbs` as a helper over `readFileLbsFrom path 0`
- Update `followFile` to seek directly to the current offset, avoiding re-reading already-seen bytes on each poll