### PR TITLE
fix: `tricorder stop` hangs

### DIFF
--- a/atelier/src/Atelier/Effects/Posix/Daemons.hs
+++ b/atelier/src/Atelier/Effects/Posix/Daemons.hs
@@ -3,14 +3,14 @@ module Atelier.Effects.Posix.Daemons
     , PidFile (..)
     , daemonize
     , isRunning
-    , killAndWait
+    , forceKillAndWait
     , runDaemons
     ) where
 
 import Data.Default (def)
 import Effectful (Effect, IOE, Limit (..), Persistence (..), UnliftStrategy (..))
 import Effectful.Dispatch.Dynamic (interpretWith, localUnliftIO)
-import Effectful.Exception (IOException, try)
+import Effectful.Exception (trySync)
 import Effectful.TH (makeEffect)
 
 import System.Posix.Daemon qualified as Daemons
@@ -22,9 +22,8 @@ data Daemons :: Effect where
     Daemonize :: PidFile -> m () -> Daemons m ()
     -- | Check whether a daemon is running for the provided PID file.
     IsRunning :: PidFile -> Daemons m Bool
-    -- | Kill the daemon associated with the provided PID file, waiting for it
-    -- to shut down.
-    KillAndWait :: PidFile -> Daemons m ()
+    -- | Kill the daemon associated with the provided PID file using `SIGKILL`.
+    ForceKillAndWait :: PidFile -> Daemons m (Either SomeException ())
 
 
 newtype PidFile = PidFile {getPidFile :: FilePath}
@@ -42,5 +41,5 @@ runDaemons act = do
                     $ unlift program
         IsRunning (PidFile pidFile) ->
             liftIO $ Daemons.isRunning pidFile
-        KillAndWait (PidFile pidFile) ->
-            void $ try @IOException $ liftIO $ Daemons.killAndWait pidFile
+        ForceKillAndWait (PidFile pidFile) ->
+            trySync $ liftIO $ Daemons.brutalKill pidFile

--- a/atelier/src/Atelier/Exception.hs
+++ b/atelier/src/Atelier/Exception.hs
@@ -1,8 +1,13 @@
 module Atelier.Exception
     ( isGracefulShutdown
+    , trySyncIO
+    , catchSyncIO
+    , isSyncException
     ) where
 
-import Effectful.Exception (SomeAsyncException)
+import Effectful.Exception (SomeAsyncException, isSyncException)
+
+import Control.Exception qualified as E
 
 
 -- | Determine if an exception represents a graceful shutdown (any async exception).
@@ -12,3 +17,17 @@ import Effectful.Exception (SomeAsyncException)
 -- or retry logic.
 isGracefulShutdown :: SomeException -> Bool
 isGracefulShutdown = isJust . fromException @SomeAsyncException
+
+
+-- | Like `Control.Exception.try`, but will only catch synchronous exceptions.
+trySyncIO :: IO a -> IO (Either SomeException a)
+trySyncIO f = withFrozenCallStack catchSyncIO (fmap Right f) (pure . Left)
+
+
+catchSyncIO :: (HasCallStack) => IO a -> (SomeException -> IO a) -> IO a
+catchSyncIO f g =
+    f `E.catch` \e ->
+        if isSyncException e then
+            g e
+        else
+            E.throwIO e

--- a/atelier/testing/Atelier/Testing/Database.hs
+++ b/atelier/testing/Atelier/Testing/Database.hs
@@ -5,7 +5,6 @@ module Atelier.Testing.Database
 where
 
 import Control.Concurrent (MVar, forkIO, modifyMVar, newEmptyMVar, newMVar, putMVar, takeMVar, threadDelay, tryPutMVar, withMVar)
-import Control.Exception (try)
 import Data.String.Conversions (cs)
 import Database.PostgreSQL.Simple.Options (Options (..))
 import Hasql.Session (Session, statement)
@@ -22,6 +21,7 @@ import Hasql.Decoders qualified as Decoders
 import Hasql.Pool qualified as Pool
 
 import Atelier.Effects.DB.Config (DBConfig (..), DBPools (..), PoolConfig (..), acquireDatabasePool, acquireDatabasePools)
+import Atelier.Exception (trySyncIO)
 
 
 -- | Project-specific configuration for the temporary test database.
@@ -96,7 +96,7 @@ startSharedServer cfg = do
                             , databaseName = "postgres"
                             , pool = pool
                             }
-                setupResult <- try @SomeException $ do
+                setupResult <- trySyncIO $ do
                     templateName <- generateUniqueDatabaseName
                     adminPool <- acquireDatabasePool adminConfig
                     createDatabase adminPool templateName

--- a/tricorder/app/Main.hs
+++ b/tricorder/app/Main.hs
@@ -4,6 +4,7 @@ import Data.Default (def)
 import Effectful (runEff)
 import Effectful.Concurrent (runConcurrent)
 import Effectful.Reader.Static (runReader)
+import Effectful.Timeout (runTimeout)
 
 import Atelier.Effects.Cache (runCacheTtl)
 import Atelier.Effects.Clock (runClock)
@@ -38,6 +39,7 @@ import Tricorder.GhcPkg.Types qualified as GhcPkg
 main :: IO ()
 main =
     runEff
+        . runTimeout
         . runConcurrent
         . runConc
         . runBrickChan

--- a/tricorder/src/Tricorder.hs
+++ b/tricorder/src/Tricorder.hs
@@ -2,6 +2,9 @@ module Tricorder (run) where
 
 import Effectful (IOE)
 import Effectful.Reader.Static (Reader, ask, asks)
+import Effectful.Timeout (Timeout)
+
+import Data.Text qualified as T
 
 import Atelier.Effects.Cache (Cache)
 import Atelier.Effects.Clock (Clock)
@@ -34,7 +37,6 @@ import Tricorder.Socket.Client (isDaemonRunning, queryStatus)
 import Tricorder.UI (viewUi)
 
 import Atelier.Effects.Console qualified as Console
-import Atelier.Effects.FileSystem qualified as FileSystem
 import Tricorder.Observability qualified as Observability
 
 
@@ -64,6 +66,7 @@ run
        , Reader PidFile :> es
        , Reader SocketPath :> es
        , TestRunner :> es
+       , Timeout :> es
        , Tracing :> es
        , UnixSocket :> es
        )
@@ -77,11 +80,14 @@ run =
             else do
                 startDaemon
                 Console.putStrLn "Daemon started."
-        Stop -> do
-            stopDaemon
-            Console.putStrLn "Daemon stopped."
-            FileSystem.removeFile =<< asks getSocketPath
-            FileSystem.removeFile =<< asks getPidFile
+        Stop ->
+            stopDaemon >>= \case
+                Left reasons ->
+                    Console.putTextLn
+                        $ T.intercalate "\n"
+                        $ "Was unable to stop the daemon:" : reasons
+                Right result -> do
+                    Console.putTextLn result
         Status opts -> do
             running <- isDaemonRunning
             if not running then

--- a/tricorder/src/Tricorder/Daemon.hs
+++ b/tricorder/src/Tricorder/Daemon.hs
@@ -6,7 +6,10 @@ module Tricorder.Daemon
     ) where
 
 import Effectful (IOE)
+import Effectful.NonDet (OnEmptyPolicy (..), emptyEff, runNonDet)
 import Effectful.Reader.Static (Reader, ask)
+import Effectful.Timeout (Timeout, timeout)
+import Effectful.Writer.Static.Local (runWriter, tell)
 
 import Atelier.Component (runSystem)
 import Atelier.Effects.Cache (Cache)
@@ -14,6 +17,8 @@ import Atelier.Effects.Clock (Clock)
 import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.Debounce (Debounce)
 import Atelier.Effects.Delay (Delay)
+import Atelier.Effects.Exit (Exit)
+import Atelier.Effects.File (File)
 import Atelier.Effects.FileSystem (FileSystem)
 import Atelier.Effects.FileWatcher (FileWatcher)
 import Atelier.Effects.Log (Log)
@@ -28,7 +33,7 @@ import Tricorder.Effects.TestRunner (TestRunner)
 import Tricorder.Effects.UnixSocket (UnixSocket)
 import Tricorder.GhcPkg.Types (ModuleName, PackageId)
 import Tricorder.Runtime (PidFile, SocketPath (..))
-import Tricorder.Socket.Client (isDaemonRunning)
+import Tricorder.Socket.Client (isDaemonRunning, requestShutdown)
 
 import Atelier.Effects.Delay qualified as Delay
 import Atelier.Effects.Posix.Daemons qualified as Daemons
@@ -48,6 +53,7 @@ runDaemon
        , Conc :> es
        , Debounce FilePath :> es
        , Delay :> es
+       , Exit :> es
        , FileSystem :> es
        , FileWatcher :> es
        , GhcPkg :> es
@@ -82,6 +88,7 @@ startDaemon
        , Daemons :> es
        , Debounce FilePath :> es
        , Delay :> es
+       , Exit :> es
        , FileSystem :> es
        , FileWatcher :> es
        , GhcPkg :> es
@@ -102,10 +109,59 @@ startDaemon = do
     Daemons.daemonize pidFile runDaemon
 
 
-stopDaemon :: (Daemons :> es, Reader PidFile :> es) => Eff es ()
+-- | Attempts to stop the daemon in progressively more forceful ways.
+-- 1. First attempts to make the daemon stop using the API.
+-- 2. Then attempts to stop the daemon by sending `SIGKILL` to its process.
+stopDaemon
+    :: forall es
+     . ( Daemons :> es
+       , Delay :> es
+       , File :> es
+       , Reader PidFile :> es
+       , Reader SocketPath :> es
+       , Timeout :> es
+       , UnixSocket :> es
+       )
+    => Eff es (Either [Text] Text)
 stopDaemon = do
+    SocketPath sockPath <- ask
     pidFile <- ask
-    Daemons.killAndWait pidFile
+    res <-
+        runWriter @[Text]
+            $ fmap rightToMaybe
+            $ runNonDet OnEmptyKeep
+            $ requestStop sockPath pidFile
+                <|> sendKill pidFile
+    case res of
+        (Just r, _) -> pure $ Right r
+        (Nothing, es) -> pure $ Left es
+  where
+    requestStop sockPath pidFile = do
+        timeout1second (requestShutdown sockPath) >>= \_ -> do
+            didStop <- fmap isJust $ timeout 3_000_000 $ waitForStop pidFile
+            if didStop then
+                pure "Daemon stopped."
+            else do
+                tell ["Daemon did not stop as requested."]
+                emptyEff
+
+    sendKill pidFile = do
+        timeout1second (Daemons.forceKillAndWait pidFile) >>= \case
+            Nothing -> pure "Daemon stopped with SIGKILL."
+            Just ex -> do
+                tell ["Daemon did not respond to SIGKILL: " <> show ex]
+                emptyEff
+
+    timeout1second = fmap (join . fmap rightToMaybe) . timeout 1_000_000
+
+    waitForStop :: forall es'. (Daemons :> es', Delay :> es') => PidFile -> Eff es' ()
+    waitForStop pidFile = fix \rec -> do
+        running <- Daemons.isRunning pidFile
+        if running then do
+            Delay.wait (500 :: Millisecond)
+            rec
+        else
+            pure ()
 
 
 -- | Poll until the daemon socket becomes connectable.

--- a/tricorder/src/Tricorder/Effects/GhcPkg.hs
+++ b/tricorder/src/Tricorder/Effects/GhcPkg.hs
@@ -9,7 +9,7 @@ module Tricorder.Effects.GhcPkg
 
 import Effectful (Effect, IOE)
 import Effectful.Dispatch.Dynamic (interpret, reinterpret)
-import Effectful.Exception (try)
+import Effectful.Exception (trySync)
 import Effectful.State.Static.Shared (evalState, get, put)
 import Effectful.TH (makeEffect)
 import System.Process.Typed (proc, readProcessStdout_)
@@ -62,7 +62,7 @@ runGhcPkgScripted script = reinterpret (evalState script) \_ -> \case
 -- | Run a process and return its stdout as 'Text', or 'Nothing' on any error.
 readProcessSafe :: (IOE :> es) => FilePath -> [String] -> Eff es (Maybe Text)
 readProcessSafe cmd args = do
-    result <- try @SomeException $ liftIO $ readProcessStdout_ (proc cmd args)
+    result <- trySync $ liftIO $ readProcessStdout_ (proc cmd args)
     pure $ case result of
         Left _ -> Nothing
         Right bs -> Just (decodeUtf8 (BSL.toStrict bs))

--- a/tricorder/src/Tricorder/Effects/GhciSession.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession.hs
@@ -16,7 +16,7 @@ module Tricorder.Effects.GhciSession
     , extractTitle
     ) where
 
-import Control.Exception (throwIO, try)
+import Control.Exception (throwIO)
 import Data.Char (isAlpha, isDigit, isSpace, toLower)
 import Effectful (Effect, IOE)
 import Effectful.Dispatch.Dynamic (reinterpret)
@@ -30,6 +30,7 @@ import Data.List qualified as List
 import Data.Set qualified as Set
 import Language.Haskell.Ghcid qualified as Ghcid
 
+import Atelier.Exception (trySyncIO)
 import Tricorder.BuildState (Diagnostic (..), Severity (..))
 
 import Tricorder.BuildState qualified as BuildState
@@ -105,7 +106,7 @@ runGhciSessionScripted results = reinterpret (evalState results) $ \_ ->
 
 
 stopGhciSilently :: Ghcid.Ghci -> IO ()
-stopGhciSilently ghci = void $ try @SomeException $ Ghcid.stopGhci ghci
+stopGhciSilently ghci = void $ trySyncIO $ Ghcid.stopGhci ghci
 
 
 collectResult :: Ghcid.Ghci -> [Load] -> IO LoadResult

--- a/tricorder/src/Tricorder/Effects/TestRunner.hs
+++ b/tricorder/src/Tricorder/Effects/TestRunner.hs
@@ -14,7 +14,7 @@ module Tricorder.Effects.TestRunner
 import Control.Exception (throwIO)
 import Effectful (Effect, IOE)
 import Effectful.Dispatch.Dynamic (interpretWith_, reinterpret)
-import Effectful.Exception (try)
+import Effectful.Exception (trySync)
 import Effectful.Reader.Static (Reader, ask)
 import Effectful.State.Static.Shared (State, evalState, get, put)
 import Effectful.TH (makeEffect)
@@ -45,7 +45,7 @@ runTestRunnerIO act = do
     ProjectRoot projectRoot <- ask
     interpretWith_ act \case
         RunTestSuite target -> do
-            result <- try @SomeException $ liftIO do
+            result <- trySync $ liftIO do
                 let config =
                         setStdin (byteStringInput ":main\n:quit\n")
                             $ setWorkingDir projectRoot

--- a/tricorder/src/Tricorder/Effects/UnixSocket.hs
+++ b/tricorder/src/Tricorder/Effects/UnixSocket.hs
@@ -16,7 +16,6 @@ module Tricorder.Effects.UnixSocket
     , SocketScript (..)
     ) where
 
-import Control.Exception (try)
 import Effectful (Effect, IOE)
 import Effectful.Dispatch.Dynamic (interpretWith, localSeqUnlift, reinterpret)
 import Effectful.Exception (finally)
@@ -38,6 +37,8 @@ import System.Directory (doesPathExist, removeFile)
 import System.IO (hClose, hGetLine, hPutStrLn, hSetEncoding, utf8)
 
 import Network.Socket qualified as Net
+
+import Atelier.Exception (trySyncIO)
 
 
 data UnixSocket :: Effect where
@@ -91,7 +92,7 @@ runUnixSocketIO eff = interpretWith eff \env -> \case
     SendLine h line -> liftIO $ hPutStrLn h (toString line) >> hFlush h
     CloseHandle h -> liftIO $ hClose h
     RemoveSocketFile path ->
-        liftIO $ void $ try @SomeException $ removeFile path
+        liftIO $ void $ trySyncIO $ removeFile path
     SocketFileExists path ->
         liftIO $ doesPathExist path
 

--- a/tricorder/src/Tricorder/GhciSession.hs
+++ b/tricorder/src/Tricorder/GhciSession.hs
@@ -7,7 +7,7 @@ module Tricorder.GhciSession
 
 import Control.Monad (foldM)
 import Data.Time (diffUTCTime)
-import Effectful.Exception (throwIO, try)
+import Effectful.Exception (throwIO, trySync)
 import Effectful.Reader.Static (Reader, ask)
 import System.FilePath (isAbsolute, (</>))
 
@@ -121,7 +121,7 @@ sessionListener cmd projectRoot watchDirs testTargets = startSession (BuildId 1)
         Log.info $ "Starting GHCi session #" <> show n <> ": " <> cmd
         setPhase (BuildId n) Building
         t0 <- Clock.currentTime
-        result <- try @SomeException $ GhciSession.startGhci cmd projectRoot
+        result <- trySync $ GhciSession.startGhci cmd projectRoot
         Log.debug $ "GhciSession.startGhci returned (session #" <> show n <> ")"
         case result of
             Left ex -> do
@@ -150,18 +150,18 @@ sessionListener cmd projectRoot watchDirs testTargets = startSession (BuildId 1)
             CabalChange -> do
                 Log.info "Cabal file changed; restarting GHCi session"
                 setPhase (BuildId n) Restarting
-                void $ try @SomeException GhciSession.stopGhci
+                void $ trySync GhciSession.stopGhci
                 startSession nextId
             SourceChange -> do
                 Log.debug $ "GhciSession: dirty flag set, reloading"
                 setPhase (BuildId n) Building
                 t0 <- Clock.currentTime
-                result <- try @SomeException GhciSession.reloadGhci
+                result <- trySync GhciSession.reloadGhci
                 case result of
                     Left ex -> do
                         when (isGracefulShutdown ex) $ throwIO ex
                         Log.warn "GHCi session died; restarting"
-                        void $ try @SomeException GhciSession.stopGhci
+                        void $ trySync GhciSession.stopGhci
                         startSession nextId
                     Right loadResult -> do
                         t1 <- Clock.currentTime

--- a/tricorder/src/Tricorder/Socket/Client.hs
+++ b/tricorder/src/Tricorder/Socket/Client.hs
@@ -4,6 +4,7 @@ module Tricorder.Socket.Client
     , queryWatch
     , querySource
     , queryDiagnostic
+    , requestShutdown
     , isDaemonRunning
     ) where
 
@@ -88,6 +89,16 @@ queryDiagnostic sockPath idx = withConnection sockPath \h -> do
     case eitherDecode (BSL.fromStrict (encodeUtf8 (toText line))) of
         Left err -> pure $ Left (toText err)
         Right d -> pure $ Right d
+
+
+requestShutdown :: (File :> es, UnixSocket :> es) => FilePath -> Eff es (Either Text ())
+requestShutdown sockPath = withConnection sockPath \h -> do
+    sendQuery h Quit
+    line <- File.hGetLine h
+    if eitherDecode (BSL.fromStrict (encodeUtf8 line)) == Right True then
+        pure $ Right ()
+    else
+        pure $ Left "Failed to request shutdown"
 
 
 isDaemonRunning :: (Daemons :> es, Reader PidFile :> es) => Eff es Bool

--- a/tricorder/src/Tricorder/Socket/Protocol.hs
+++ b/tricorder/src/Tricorder/Socket/Protocol.hs
@@ -25,6 +25,7 @@ data Query
     | Watch
     | Source [ModuleName]
     | DiagnosticAt DiagnosticQuery
+    | Quit
     deriving stock (Eq, Generic, Show)
     deriving anyclass (FromJSON, ToJSON)
 

--- a/tricorder/src/Tricorder/Socket/Server.hs
+++ b/tricorder/src/Tricorder/Socket/Server.hs
@@ -1,7 +1,7 @@
 module Tricorder.Socket.Server (component, SocketRemoved (..)) where
 
 import Data.Aeson (ToJSON, decode, encode)
-import Effectful.Exception (finally)
+import Effectful.Exception (IOException, finally)
 import Effectful.Reader.Static (Reader, ask)
 
 import Data.ByteString.Lazy qualified as BSL
@@ -10,6 +10,7 @@ import Atelier.Component (Component (..), Trigger, defaultComponent)
 import Atelier.Effects.Cache (Cache)
 import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.Delay (Delay, wait)
+import Atelier.Effects.Exit (Exit, exitSuccess)
 import Atelier.Effects.FileSystem (FileSystem)
 import Atelier.Effects.Log (Log)
 import Atelier.Time (Millisecond)
@@ -30,6 +31,7 @@ import Tricorder.Socket.Protocol (DiagnosticQuery (..), ErrorResponse (..), Quer
 import Tricorder.SourceLookup (ModuleName, PackageId, lookupModuleSource)
 
 import Atelier.Effects.Conc qualified as Conc
+import Atelier.Effects.Log qualified as Log
 
 
 data SocketRemoved = SocketRemoved
@@ -45,6 +47,7 @@ component
        , Cache ModuleName PackageId :> es
        , Conc :> es
        , Delay :> es
+       , Exit :> es
        , FileSystem :> es
        , GhcPkg :> es
        , Log :> es
@@ -68,6 +71,7 @@ acceptTrigger
        , Cache ModuleName PackageId :> es
        , Conc :> es
        , Delay :> es
+       , Exit :> es
        , FileSystem :> es
        , GhcPkg :> es
        , Log :> es
@@ -80,7 +84,8 @@ acceptTrigger = do
     sock <- bindSocket sockPath
     forever do
         h <- acceptHandle sock
-        void $ Conc.forkTry @SomeException $ handleConnection h `finally` closeHandle h
+        void $ Conc.forkTry @IOException do
+            handleConnection h `finally` closeHandle h
 
 
 handleConnection
@@ -88,6 +93,7 @@ handleConnection
        , Cache (PackageId, ModuleName) Text :> es
        , Cache ModuleName PackageId :> es
        , Delay :> es
+       , Exit :> es
        , FileSystem :> es
        , GhcPkg :> es
        , Log :> es
@@ -107,6 +113,7 @@ dispatch
        , Cache (PackageId, ModuleName) Text :> es
        , Cache ModuleName PackageId :> es
        , Delay :> es
+       , Exit :> es
        , FileSystem :> es
        , GhcPkg :> es
        , Log :> es
@@ -121,6 +128,14 @@ dispatch query h = case query of
     Watch -> watchStream h
     Source moduleNames -> respondSource moduleNames h
     DiagnosticAt dq -> respondDiagnostic dq.index h
+    Quit -> quit h
+
+
+quit :: (Exit :> es, Log :> es, UnixSocket :> es) => Handle -> Eff es ()
+quit h = do
+    sendJson h True
+    Log.info "Shutting down."
+    exitSuccess
 
 
 respondOnce :: (BuildStore :> es, UnixSocket :> es) => Handle -> Eff es ()


### PR DESCRIPTION
Read this and weep:
[Effectful.Exception's section on catching exceptions' warning about async exceptions](https://hackage-content.haskell.org/package/effectful-core-2.6.1.0/docs/Effectful-Exception.html#g:2).

We must take care not to catch asynchronous exceptions unless we
specifically _know for certain_ that that is what we want. From
henceforth, use `Effectful.Exception.trySync` and
`Atelier.Exception.trySyncIO` to catch `SomeException`, unless you
_know_ that you want to specifically catch asynchronous exceptions as
well. If you are unsure whether you want to catch asynchronous
exceptions or not, you probably don't. Err on the side of caution, and
try catching only synchronous exceptions first. Catching asynchronous
exceptions should only really be done in very specific circumstances,
like for cleaning up resources, and should probably rethrow the async
exception afterwards in most situations.

In a future PR, we should aim to surface the known exceptions thrown by
various `IO` actions and expose them as `Effectful.Error.Static.Error`
(or equivalent) effects.

Closes https://github.com/atelier-hub/tricorder/issues/43
