### PR TITLE
feat: track live build progress from GHCi output

### DIFF
--- a/tricorder/app/Main.hs
+++ b/tricorder/app/Main.hs
@@ -63,11 +63,11 @@ main =
         . runTestRunnerIO
         . runCacheTtl @GhcPkg.ModuleName @GhcPkg.PackageId
         . runCacheTtl @(GhcPkg.PackageId, GhcPkg.ModuleName) @Text
+        . runBuildStore
         . runGhciSessionIO
         . runFileWatcherIO
         . runDebounce
         . runGhcPkgIO
-        . runBuildStore
         . runArguments
         . runUnixSocketIO
         $ Tricorder.run

--- a/tricorder/src/Tricorder/BuildState.hs
+++ b/tricorder/src/Tricorder/BuildState.hs
@@ -2,6 +2,7 @@ module Tricorder.BuildState
     ( BuildId (..)
     , BuildState (..)
     , BuildPhase (..)
+    , BuildProgress (..)
     , BuildResult (..)
     , TestRun (..)
     , TestOutcome (..)
@@ -94,8 +95,16 @@ data BuildResult = BuildResult
     deriving anyclass (FromJSON, ToJSON)
 
 
+data BuildProgress = BuildProgress
+    { compiled :: Int
+    , total :: Int
+    }
+    deriving stock (Eq, Generic, Show)
+    deriving anyclass (FromJSON, ToJSON)
+
+
 data BuildPhase
-    = Building
+    = Building (Maybe BuildProgress)
     | Restarting
     | Testing BuildResult
     | Done BuildResult
@@ -143,7 +152,7 @@ instance ToJSON Severity where
 
 
 stateLabel :: BuildPhase -> Text
-stateLabel Building = "building"
+stateLabel (Building _) = "building"
 stateLabel Restarting = "restarting"
 stateLabel (Testing _) = "testing"
 stateLabel (Done result)
@@ -168,6 +177,6 @@ initialBuildState :: DaemonInfo -> BuildState
 initialBuildState di =
     BuildState
         { buildId = BuildId 0
-        , phase = Building
+        , phase = Building Nothing
         , daemonInfo = di
         }

--- a/tricorder/src/Tricorder/CLI.hs
+++ b/tricorder/src/Tricorder/CLI.hs
@@ -64,7 +64,7 @@ showStatus opts = do
     when (opts.wait == WaitForBuild && opts.format == TextOutput) $ do
         current <- queryStatus sockPath
         case current of
-            Right BuildState {phase = Building} -> Console.putStrLn "Building..."
+            Right BuildState {phase = Building _} -> Console.putStrLn "Building..."
             Right BuildState {phase = Restarting} -> Console.putStrLn "Restarting..."
             Right BuildState {phase = Testing _} -> Console.putStrLn "Testing..."
             _ -> pure ()
@@ -83,7 +83,7 @@ showStatus opts = do
                     renderText opts.verbosity opts.expand state
   where
     renderText verbosity expand state = case state.phase of
-        Building -> Console.putStrLn "Building..."
+        Building _ -> Console.putStrLn "Building..."
         Restarting -> Console.putStrLn "Restarting..."
         Testing _ -> Console.putStrLn "Testing..."
         Done r -> do

--- a/tricorder/src/Tricorder/Effects/BuildStore.hs
+++ b/tricorder/src/Tricorder/Effects/BuildStore.hs
@@ -85,7 +85,7 @@ runBuildStoreSTM eff = do
 
     isBuilding :: BuildState -> Bool
     isBuilding s = case s.phase of
-        Building -> True
+        Building _ -> True
         Restarting -> True
         Testing _ -> True
         Done _ -> False
@@ -111,7 +111,7 @@ runBuildStoreRef BuildStateRef {stateRef = ref, dirtyRef} =
   where
     isBuilding :: BuildState -> Bool
     isBuilding s = case s.phase of
-        Building -> True
+        Building _ -> True
         Restarting -> True
         Testing _ -> True
         Done _ -> False
@@ -163,7 +163,7 @@ runBuildStoreScripted states = reinterpret (evalState states) $ \_ -> \case
   where
     isBuilding :: BuildState -> Bool
     isBuilding s = case s.phase of
-        Building -> True
+        Building _ -> True
         Restarting -> True
         Testing _ -> True
         Done _ -> False

--- a/tricorder/src/Tricorder/Effects/GhciSession.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession.hs
@@ -18,7 +18,7 @@ module Tricorder.Effects.GhciSession
 
 import Control.Exception (throwIO)
 import Data.Char (isAlpha, isDigit, isSpace, toLower)
-import Effectful (Effect, IOE)
+import Effectful (Effect, IOE, withEffToIO)
 import Effectful.Dispatch.Dynamic (reinterpret)
 import Effectful.State.Static.Shared (State, evalState, get, put)
 import Effectful.TH (makeEffect)
@@ -30,9 +30,13 @@ import Data.List qualified as List
 import Data.Set qualified as Set
 import Language.Haskell.Ghcid qualified as Ghcid
 
+import Atelier.Effects.Conc (concStrat)
+import Atelier.Effects.Log (Log)
 import Atelier.Exception (trySyncIO)
-import Tricorder.BuildState (Diagnostic (..), Severity (..))
+import Tricorder.BuildState (BuildPhase (..), BuildProgress (..), Diagnostic (..), Severity (..))
+import Tricorder.Effects.BuildStore (BuildStore, getState, setPhase)
 
+import Atelier.Effects.Log qualified as Log
 import Tricorder.BuildState qualified as BuildState
 
 
@@ -63,12 +67,19 @@ makeEffect ''GhciSession
 
 -- | Production interpreter backed by the real ghcid library.
 -- Manages the 'Ghcid.Ghci' handle via 'State'.
-runGhciSessionIO :: (IOE :> es) => Eff (GhciSession : es) a -> Eff es a
+runGhciSessionIO :: (BuildStore :> es, IOE :> es, Log :> es) => Eff (GhciSession : es) a -> Eff es a
 runGhciSessionIO = reinterpret (evalState (Nothing :: Maybe Ghcid.Ghci)) $ \_ -> \case
     StartGhci cmd dir -> do
         mOld <- get
         whenJust mOld \old -> liftIO $ stopGhciSilently old
-        (ghci, loads) <- liftIO $ Ghcid.startGhci (toString cmd) (Just dir) (\_ _ -> pure ())
+        (ghci, loads) <- withEffToIO concStrat \unlift ->
+            Ghcid.startGhci (toString cmd) (Just dir) \_ line -> do
+                unlift $ Log.debug $ "GhciSession callback: " <> toText line
+                whenJust (parseProgress line) \(n, m) ->
+                    unlift do
+                        Log.debug $ "GhciSession: progress " <> show n <> "/" <> show m
+                        bs <- getState
+                        setPhase bs.buildId (Building (Just (BuildProgress {compiled = n, total = m})))
         put (Just ghci)
         liftIO $ collectResult ghci loads
     ReloadGhci ->
@@ -161,6 +172,29 @@ toRelative base path
     joinPath = List.foldr1 (</>)
 
 
+-- | Parse @"[N of M] Compiling ..."@ progress lines from GHCi output.
+--
+-- GHC pads the module index for alignment (e.g. @"[ 1 of 47]"@), so we
+-- extract the content between @[@ and @]@ before splitting on whitespace.
+parseProgress :: String -> Maybe (Int, Int)
+parseProgress line = do
+    rest <- List.stripPrefix "[" (dropWhile isSpace (stripAnsi line))
+    let (inside, after) = break (== ']') rest
+    guard (not (null after))
+    guard ("Compiling" `List.isPrefixOf` dropWhile isSpace (drop 1 after))
+    case words (toText inside) of
+        [nTxt, "of", mTxt] -> (,) <$> readMaybe (toString nTxt) <*> readMaybe (toString mTxt)
+        _ -> Nothing
+
+
+-- | Strip ANSI escape sequences of the form @ESC [ \<params\> \<letter\>@.
+stripAnsi :: String -> String
+stripAnsi [] = []
+stripAnsi ('\ESC' : '[' : rest) =
+    stripAnsi (drop 1 (dropWhile (not . isAlpha) rest))
+stripAnsi (c : rest) = c : stripAnsi rest
+
+
 -- | Extract a short human-readable title from ghcid's 'loadMessage'.
 --
 -- ghcid always places the GHCi header line (@"file:line:col: severity: rest"@) as
@@ -222,10 +256,3 @@ extractTitle (header : body) =
     isSourceLine s = case dropWhile (\c -> isDigit c || c == ' ') s of
         ('|' : _) -> True
         _ -> not (null s) && all (\c -> c `elem` ("^~_ " :: String)) s
-
-    -- Strip ANSI escape sequences of the form ESC [ <params> <letter>.
-    stripAnsi :: String -> String
-    stripAnsi [] = []
-    stripAnsi ('\ESC' : '[' : rest) =
-        stripAnsi (drop 1 (dropWhile (not . isAlpha) rest))
-    stripAnsi (c : rest) = c : stripAnsi rest

--- a/tricorder/src/Tricorder/GhciSession.hs
+++ b/tricorder/src/Tricorder/GhciSession.hs
@@ -119,7 +119,7 @@ sessionListener cmd projectRoot watchDirs testTargets = startSession (BuildId 1)
 
     startSession (BuildId n) = do
         Log.info $ "Starting GHCi session #" <> show n <> ": " <> cmd
-        setPhase (BuildId n) Building
+        setPhase (BuildId n) (Building Nothing)
         t0 <- Clock.currentTime
         result <- trySync $ GhciSession.startGhci cmd projectRoot
         Log.debug $ "GhciSession.startGhci returned (session #" <> show n <> ")"
@@ -154,7 +154,7 @@ sessionListener cmd projectRoot watchDirs testTargets = startSession (BuildId 1)
                 startSession nextId
             SourceChange -> do
                 Log.debug $ "GhciSession: dirty flag set, reloading"
-                setPhase (BuildId n) Building
+                setPhase (BuildId n) (Building Nothing)
                 t0 <- Clock.currentTime
                 result <- trySync GhciSession.reloadGhci
                 case result of

--- a/tricorder/src/Tricorder/Socket/Server.hs
+++ b/tricorder/src/Tricorder/Socket/Server.hs
@@ -154,7 +154,7 @@ respondWhenDone h = awaitResult >>= sendJson h
     awaitResult = do
         s <- getState
         case s.phase of
-            Building -> waitUntilDone
+            Building _ -> waitUntilDone
             Restarting -> waitUntilDone
             Testing _ -> waitUntilDone
             Done _ -> awaitBuildStart (5 :: Int) s
@@ -165,7 +165,7 @@ respondWhenDone h = awaitResult >>= sendJson h
         wait (50 :: Millisecond)
         s' <- getState
         case s'.phase of
-            Building -> waitUntilDone
+            Building _ -> waitUntilDone
             Restarting -> waitUntilDone
             Testing _ -> waitUntilDone
             Done _ -> awaitBuildStart (n - 1) s'

--- a/tricorder/src/Tricorder/UI/View.hs
+++ b/tricorder/src/Tricorder/UI/View.hs
@@ -32,6 +32,7 @@ import Data.Text qualified as T
 import Atelier.Effects.Clock (TimeZone)
 import Tricorder.BuildState
     ( BuildPhase (..)
+    , BuildProgress (..)
     , BuildResult (..)
     , BuildState (..)
     , DaemonInfo (..)
@@ -167,7 +168,8 @@ viewWatchDir dir = hBox [txt "- ", txt $ toText displayDir]
 
 viewBuildPhase :: TimeZone -> BuildPhase -> Widget Viewports
 viewBuildPhase tz = \case
-    Building -> warn $ txt "Building..."
+    Building Nothing -> warn $ txt "Building..."
+    Building (Just p) -> warn $ txt $ "Building (" <> show p.compiled <> "/" <> show p.total <> ")..."
     Restarting -> warn $ txt "Restarting..."
     Testing result -> vBoxSpaced 1 [viewBuildResult tz result, viewTestRuns result.testRuns]
     Done result -> vBoxSpaced 1 [viewBuildResult tz result, viewTestRuns result.testRuns]

--- a/tricorder/test/Unit/Tricorder/BuildStoreSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuildStoreSpec.hs
@@ -135,7 +135,7 @@ emptyDaemonInfo = DaemonInfo {targets = [], watchDirs = [], sockPath = "", logFi
 
 
 buildingAt :: Int -> BuildState
-buildingAt n = BuildState (BuildId n) Building emptyDaemonInfo
+buildingAt n = BuildState (BuildId n) (Building Nothing) emptyDaemonInfo
 
 
 doneAt :: Int -> BuildState


### PR DESCRIPTION
- Add `BuildProgress {compiled, total}` and make `Building` carry `Maybe BuildProgress`
- Parse `[N of M] Compiling ...` lines in the GhciSession callback
- Display progress in the UI as "Building (N/M)..."
- Reorder effect stack so `BuildStore` is available to `GhciSession`