### PR TITLE
fix: ghci session is left orphaned when daemon exits abnormally

### DIFF
--- a/tricorder/src/Tricorder/Effects/GhciSession.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession.hs
@@ -1,9 +1,7 @@
 module Tricorder.Effects.GhciSession
     ( -- * Effect
       GhciSession
-    , startGhci
-    , reloadGhci
-    , stopGhci
+    , withGhci
 
       -- * Types
     , LoadResult (..)
@@ -18,8 +16,9 @@ module Tricorder.Effects.GhciSession
 
 import Control.Exception (throwIO)
 import Data.Char (isAlpha, isDigit, isSpace, toLower)
-import Effectful (Effect, IOE, withEffToIO)
-import Effectful.Dispatch.Dynamic (reinterpret)
+import Effectful (Effect, IOE, Limit (..), Persistence (..), UnliftStrategy (..), withEffToIO)
+import Effectful.Dispatch.Dynamic (interpret, localSeqLend, localSeqLift, localSeqUnlift, reinterpret)
+import Effectful.Exception (bracket)
 import Effectful.State.Static.Shared (State, evalState, get, put)
 import Effectful.TH (makeEffect)
 import Language.Haskell.Ghcid (Load (..))
@@ -31,7 +30,6 @@ import Data.List qualified as List
 import Data.Set qualified as Set
 import Language.Haskell.Ghcid qualified as Ghcid
 
-import Atelier.Effects.Conc (concStrat)
 import Atelier.Effects.Log (Log)
 import Atelier.Exception (trySyncIO)
 import Tricorder.BuildState (BuildPhase (..), BuildProgress (..), Diagnostic (..), Severity (..))
@@ -54,13 +52,11 @@ data LoadResult = LoadResult
 
 
 data GhciSession :: Effect where
-    -- | Start a new GHCi session. If a session is already running it is
-    -- stopped first. Returns the initial compilation messages with module count.
-    StartGhci :: Text -> FilePath -> GhciSession m LoadResult
-    -- | Send @:reload@ to the current session and return new messages with module count.
-    ReloadGhci :: GhciSession m LoadResult
-    -- | Stop the current session. No-op if no session is running.
-    StopGhci :: GhciSession m ()
+    -- | Start a new GHCi session and run the handler with that session active.
+    -- The handler is also provided an action to reload the GHCi session,
+    -- returning new messages with module counts. The GHCi session is closed
+    -- when the handler returns.
+    WithGhci :: Text -> FilePath -> (LoadResult -> m LoadResult -> m a) -> GhciSession m a
 
 
 makeEffect ''GhciSession
@@ -69,30 +65,32 @@ makeEffect ''GhciSession
 -- | Production interpreter backed by the real ghcid library.
 -- Manages the 'Ghcid.Ghci' handle via 'State'.
 runGhciSessionIO :: (BuildStore :> es, IOE :> es, Log :> es) => Eff (GhciSession : es) a -> Eff es a
-runGhciSessionIO = reinterpret (evalState (Nothing :: Maybe Ghcid.Ghci)) $ \_ -> \case
-    StartGhci cmd dir -> do
-        mOld <- get
-        whenJust mOld \old -> liftIO $ stopGhciSilently old
-        (ghci, loads) <- withEffToIO concStrat \unlift ->
-            Ghcid.startGhci (toString cmd) (Just dir) \_ line -> do
-                unlift $ Log.debug $ "GhciSession callback: " <> toText line
-                whenJust (parseProgress line) \(n, m) ->
-                    unlift do
-                        Log.debug $ "GhciSession: progress " <> show n <> "/" <> show m
-                        bs <- getState
-                        setPhase bs.buildId (Building (Just (BuildProgress {compiled = n, total = m})))
-        put (Just ghci)
-        liftIO $ collectResult ghci loads
-    ReloadGhci ->
-        get >>= \case
-            Nothing -> error "GhciSession: reloadGhci called before startGhci"
-            Just ghci -> liftIO do
-                loads <- Ghcid.reload ghci
-                collectResult ghci loads
-    StopGhci ->
-        get >>= \mGhci -> whenJust mGhci \ghci -> do
-            liftIO $ stopGhciSilently ghci
-            put (Nothing :: Maybe Ghcid.Ghci)
+runGhciSessionIO = interpret $ \env -> \case
+    WithGhci cmd dir handler -> do
+        let mkSession = withEffToIO (ConcUnlift Persistent Unlimited) \unlift -> do
+                Ghcid.startGhci (toString cmd) (Just dir) \_ line -> do
+                    unlift $ Log.debug $ "GhciSession callback: " <> toText line
+                    whenJust (parseProgress line) \(n, m) ->
+                        unlift do
+                            Log.debug $ "GhciSession: progress " <> show n <> "/" <> show m
+                            bs <- getState
+                            setPhase bs.buildId
+                                $ Building
+                                $ Just
+                                $ BuildProgress {compiled = n, total = m}
+
+            stopSession (ghci, _) =
+                liftIO $ stopGhciSilently ghci
+
+        bracket mkSession stopSession \(ghci, loads) ->
+            localSeqLend @'[IOE] env \lendIOE ->
+                localSeqUnlift env \unlift -> do
+                    initialLoadResult <- liftIO $ collectResult ghci loads
+                    unlift
+                        $ handler initialLoadResult
+                        $ lendIOE
+                        $ liftIO
+                        $ Ghcid.reload ghci >>= collectResult ghci
 
 
 -- | Scripted interpreter for testing.
@@ -104,7 +102,7 @@ runGhciSessionIO = reinterpret (evalState (Nothing :: Maybe Ghcid.Ghci)) $ \_ ->
 -- Requires 'IOE' so that 'Left' exceptions can be thrown into the effectful
 -- context, enabling tests of error-handling logic.
 runGhciSessionScripted :: forall es a. (IOE :> es) => [Either SomeException LoadResult] -> Eff (GhciSession : es) a -> Eff es a
-runGhciSessionScripted results = reinterpret (evalState results) $ \_ ->
+runGhciSessionScripted results = reinterpret (evalState results) $ \env ->
     let popResult :: Eff (State [Either SomeException LoadResult] : es) LoadResult
         popResult =
             get >>= \case
@@ -112,9 +110,11 @@ runGhciSessionScripted results = reinterpret (evalState results) $ \_ ->
                 Left ex : rest -> put rest >> liftIO (throwIO ex)
                 Right r : rest -> put rest >> pure r
     in  \case
-            StartGhci _ _ -> popResult
-            ReloadGhci -> popResult
-            StopGhci -> pure ()
+            WithGhci _ _ handler -> do
+                initial <- popResult
+                localSeqLift env \liftEff ->
+                    localSeqUnlift env \unlift ->
+                        unlift $ handler initial (liftEff popResult)
 
 
 stopGhciSilently :: Ghcid.Ghci -> IO ()

--- a/tricorder/src/Tricorder/GhciSession.hs
+++ b/tricorder/src/Tricorder/GhciSession.hs
@@ -14,20 +14,22 @@ import System.FilePath (isAbsolute, (</>))
 import Data.Map.Strict qualified as Map
 
 import Atelier.Component (Component (..), Listener, defaultComponent)
-import Atelier.Effects.Clock (Clock)
-import Atelier.Effects.Delay (Delay, wait)
+import Atelier.Effects.Clock (Clock, UTCTime)
+import Atelier.Effects.Delay (Delay)
 import Atelier.Effects.FileSystem (FileSystem, getCurrentDirectory)
 import Atelier.Effects.Log (Log)
 import Atelier.Exception (isGracefulShutdown)
 import Atelier.Time (Millisecond)
 import Tricorder.BuildState (BuildId (..), BuildPhase (..), BuildResult (..), ChangeKind (..), Diagnostic (..), Severity (..), TestOutcome (..), TestRun (..))
 import Tricorder.Config (Config (..), resolveCommand, resolveTestTargets, resolveWatchDirs)
-import Tricorder.Effects.BuildStore (BuildStore, setPhase, waitDirty)
+import Tricorder.Effects.BuildStore (BuildStore)
 import Tricorder.Effects.GhciSession (GhciSession, LoadResult (..))
 import Tricorder.Effects.TestRunner (TestRunner)
 
 import Atelier.Effects.Clock qualified as Clock
+import Atelier.Effects.Delay qualified as Delay
 import Atelier.Effects.Log qualified as Log
+import Tricorder.Effects.BuildStore qualified as BuildStore
 import Tricorder.Effects.GhciSession qualified as GhciSession
 import Tricorder.Effects.TestRunner qualified as TestRunner
 
@@ -100,8 +102,13 @@ component =
         }
 
 
+data SessionContinuation
+    = Restart BuildId
+
+
 sessionListener
-    :: ( BuildStore :> es
+    :: forall es
+     . ( BuildStore :> es
        , Clock :> es
        , Delay :> es
        , GhciSession :> es
@@ -113,56 +120,51 @@ sessionListener
     -> [FilePath]
     -> [Text]
     -> Listener es
-sessionListener cmd projectRoot watchDirs testTargets = startSession (BuildId 1)
+sessionListener cmd projectRoot watchDirs testTargets = initSession (BuildId 1)
   where
-    filterDiags = filterToWatchDirs projectRoot watchDirs
-
-    startSession (BuildId n) = do
+    initSession (BuildId n) = do
         Log.info $ "Starting GHCi session #" <> show n <> ": " <> cmd
-        setPhase (BuildId n) (Building Nothing)
+        BuildStore.setPhase (BuildId n) $ Building Nothing
         t0 <- Clock.currentTime
-        result <- trySync $ GhciSession.startGhci cmd projectRoot
-        Log.debug $ "GhciSession.startGhci returned (session #" <> show n <> ")"
-        case result of
+        res <- trySync $ GhciSession.withGhci cmd projectRoot \initialLoad@LoadResult {diagnostics = msgs} reload -> do
+            t1 <- Clock.currentTime
+            let filteredMsgs = filterDiags msgs
+                partialResult = loadResultToBuildResult projectRoot watchDirs t0 t1 initialLoad
+                accumulated = Map.fromListWith (++) [(d.file, [d]) | d <- filteredMsgs]
+            Log.info $ "GHCi started (session #" <> show n <> "): " <> show (length filteredMsgs) <> " diagnostics"
+            testRuns <- runTestsIfClean testTargets (BuildId n) partialResult
+            BuildStore.setPhase (BuildId n) $ Done partialResult {testRuns}
+            Log.debug $ "Build state updated to Done (session #" <> show n <> ")"
+            loopSession reload (BuildId (n + 1)) accumulated
+        case res of
             Left ex -> do
-                when (isGracefulShutdown ex) $ throwIO ex
-                Log.err $ "Failed to start GHCi (session #" <> show n <> "): " <> show ex
-                -- Brief pause before retry to avoid tight restart loop
-                wait (2_000 :: Millisecond)
-                startSession (BuildId n)
-            Right LoadResult {moduleCount, diagnostics = msgs} -> do
-                t1 <- Clock.currentTime
-                let filteredMsgs = filterDiags msgs
-                Log.info $ "GHCi started (session #" <> show n <> "): " <> show (length filteredMsgs) <> " diagnostics"
-                let durationMs = round (realToFrac (diffUTCTime t1 t0) * 1000 :: Double) :: Int
-                    accumulated = Map.fromListWith (++) [(d.file, [d]) | d <- filteredMsgs]
-                    partialResult = BuildResult {completedAt = t1, durationMs, moduleCount, diagnostics = filteredMsgs, testRuns = []}
-                testRuns <- runTestsIfClean (BuildId n) partialResult
-                setPhase (BuildId n) (Done partialResult {testRuns})
-                Log.debug $ "Build state updated to Done (session #" <> show n <> ")"
-                listenLoop (BuildId (n + 1)) accumulated
+                Log.err $ "Failed to start GHCi (session #" <> show n <> "):" <> show ex
+                Delay.wait (2_000 :: Millisecond)
+                initSession (BuildId n)
+            Right (Restart nextId) ->
+                initSession nextId
 
-    listenLoop (BuildId n) accumulated = do
+    loopSession :: Eff es LoadResult -> BuildId -> Map FilePath [Diagnostic] -> Eff es SessionContinuation
+    loopSession reload (BuildId n) accumulated = do
         Log.debug $ "GhciSession: waiting for dirty flag (build #" <> show n <> ")"
-        changeKind <- waitDirty
+        changeKind <- BuildStore.waitDirty
         let nextId = BuildId (n + 1)
         case changeKind of
             CabalChange -> do
                 Log.info "Cabal file changed; restarting GHCi session"
-                setPhase (BuildId n) Restarting
-                void $ trySync GhciSession.stopGhci
-                startSession nextId
+                BuildStore.setPhase (BuildId n) Restarting
+                pure $ Restart nextId
             SourceChange -> do
                 Log.debug $ "GhciSession: dirty flag set, reloading"
-                setPhase (BuildId n) (Building Nothing)
+                BuildStore.setPhase (BuildId n) $ Building Nothing
                 t0 <- Clock.currentTime
-                result <- trySync GhciSession.reloadGhci
+                -- TODO: Do better error handling here, or push it up the call tree.
+                result <- Right <$> reload
                 case result of
                     Left ex -> do
                         when (isGracefulShutdown ex) $ throwIO ex
                         Log.warn "GHCi session died; restarting"
-                        void $ trySync GhciSession.stopGhci
-                        startSession nextId
+                        pure $ Restart nextId
                     Right loadResult -> do
                         t1 <- Clock.currentTime
                         let filteredResult =
@@ -175,29 +177,41 @@ sessionListener cmd projectRoot watchDirs testTargets = startSession (BuildId 1)
                             newAccumulated = mergeDiagnostics accumulated filteredResult
                             allMsgs = concat (Map.elems newAccumulated)
                         let partialResult = BuildResult {completedAt = t1, durationMs, moduleCount = loadResult.moduleCount, diagnostics = allMsgs, testRuns = []}
-                        testRuns <- runTestsIfClean (BuildId n) partialResult
-                        setPhase (BuildId n) (Done partialResult {testRuns})
-                        listenLoop nextId newAccumulated
+                        testRuns <- runTestsIfClean testTargets (BuildId n) partialResult
+                        BuildStore.setPhase (BuildId n) $ Done partialResult {testRuns}
+                        loopSession reload nextId newAccumulated
 
-    -- Run all configured test suites if the build has no errors.
-    -- Transitions to 'Testing' phase while suites are running.
-    runTestsIfClean
-        :: (BuildStore :> es, Log :> es, TestRunner :> es)
-        => BuildId -> BuildResult -> Eff es [TestRun]
-    runTestsIfClean bid partialResult
-        | not (null testTargets) && not (any (\d -> d.severity == SError) partialResult.diagnostics) = do
-            let pendingRun t = TestRun {target = t, outcome = TestsRunning, output = ""}
-            setPhase bid (Testing partialResult {testRuns = map pendingRun testTargets})
-            Log.info $ "Running " <> show (length testTargets) <> " test suite(s)"
-            foldM
-                ( \done target -> do
-                    Log.info $ "Running tests: " <> target
-                    result <- TestRunner.runTestSuite target
-                    let remaining = drop (length done + 1) testTargets
-                        runs = done ++ [result] ++ map pendingRun remaining
-                    setPhase bid (Testing partialResult {testRuns = runs})
-                    pure (done ++ [result])
-                )
-                []
-                testTargets
-        | otherwise = pure []
+    filterDiags = filterToWatchDirs projectRoot watchDirs
+
+
+-- Run all configured test suites if the build has no errors.
+-- Transitions to 'Testing' phase while suites are running.
+runTestsIfClean
+    :: (BuildStore :> es, Log :> es, TestRunner :> es)
+    => [Text] -> BuildId -> BuildResult -> Eff es [TestRun]
+runTestsIfClean testTargets bid partialResult
+    | not (null testTargets) && not (any (\d -> d.severity == SError) partialResult.diagnostics) = do
+        let pendingRun t = TestRun {target = t, outcome = TestsRunning, output = ""}
+        BuildStore.setPhase bid (Testing partialResult {testRuns = map pendingRun testTargets})
+        Log.info $ "Running " <> show (length testTargets) <> " test suite(s)"
+        foldM
+            ( \done target -> do
+                Log.info $ "Running tests: " <> target
+                result <- TestRunner.runTestSuite target
+                let remaining = drop (length done + 1) testTargets
+                    runs = done ++ [result] ++ map pendingRun remaining
+                BuildStore.setPhase bid (Testing partialResult {testRuns = runs})
+                pure (done ++ [result])
+            )
+            []
+            testTargets
+    | otherwise = pure []
+
+
+loadResultToBuildResult :: FilePath -> [FilePath] -> UTCTime -> UTCTime -> LoadResult -> BuildResult
+loadResultToBuildResult projectRoot watchDirs t0 t1 LoadResult {moduleCount, diagnostics = msgs} = do
+    BuildResult {completedAt = t1, durationMs, moduleCount, diagnostics = filteredMsgs, testRuns = []}
+  where
+    filterDiags = filterToWatchDirs projectRoot watchDirs
+    durationMs = round (realToFrac (diffUTCTime t1 t0) * 1000 :: Double) :: Int
+    filteredMsgs = filterDiags msgs

--- a/tricorder/test/Unit/Tricorder/GhciSessionSpec.hs
+++ b/tricorder/test/Unit/Tricorder/GhciSessionSpec.hs
@@ -20,10 +20,8 @@ import Tricorder.Effects.GhciSession
     ( GhciSession
     , LoadResult (..)
     , extractTitle
-    , reloadGhci
     , runGhciSessionScripted
-    , startGhci
-    , stopGhci
+    , withGhci
     )
 import Tricorder.Effects.TestRunner (TestRunner, runTestRunnerScripted)
 import Tricorder.GhciSession (filterToWatchDirs, mergeDiagnostics, sessionListener)
@@ -44,57 +42,54 @@ spec_GhciSession = do
 
 testScripted :: Spec
 testScripted = do
-    describe "startGhci" do
-        it "returns scripted messages" do
-            LoadResult {diagnostics = msgs} <-
-                runScripted [simpleResult [errMsg]]
-                    $ startGhci "cabal repl" "/"
-            msgs `shouldBe` [errMsg]
+    describe "withGhci" do
+        describe "initial load" do
+            it "returns scripted messages" do
+                LoadResult {diagnostics = msgs} <-
+                    runScripted [simpleResult [errMsg]]
+                        $ withGhci "cabal repl" "/" \initial _ -> pure initial
+                msgs `shouldBe` [errMsg]
 
-        it "returns empty list when scripted result has no messages" do
-            LoadResult {diagnostics = msgs} <-
-                runScripted [simpleResult []]
-                    $ startGhci "cabal repl" "/"
-            msgs `shouldBe` []
+            it "returns empty list when scripted result has no messages" do
+                LoadResult {diagnostics = msgs} <-
+                    runScripted [simpleResult []]
+                        $ withGhci "cabal repl" "/" \initial _ -> pure initial
+                msgs `shouldBe` []
 
-        it "throws when scripted result is Left" do
-            result <-
-                runScripted [Left (toException boom)]
-                    $ try @ErrorCall
-                    $ startGhci "cabal repl" "/"
-            result `shouldBe` Left boom
+            it "throws when scripted result is Left" do
+                result <-
+                    runScripted [Left (toException boom)]
+                        $ try @ErrorCall
+                        $ withGhci "cabal repl" "/" \initial _ -> pure initial
+                result `shouldBe` Left boom
 
-    describe "reloadGhci" do
-        it "returns scripted messages" do
-            LoadResult {diagnostics = msgs} <- runScripted [simpleResult [warnMsg]] reloadGhci
-            msgs `shouldBe` [warnMsg]
+        describe "reloading" do
+            it "returns scripted messages" do
+                LoadResult {diagnostics = msgs} <-
+                    runScripted [simpleResult [warnMsg], simpleResult [errMsg]]
+                        $ withGhci "cabal repl" "/" \_ reload -> reload
+                msgs `shouldBe` [errMsg]
 
-        it "throws when scripted result is Left" do
-            result <-
-                runScripted [Left (toException boom)]
-                    $ try @ErrorCall reloadGhci
-            result `shouldBe` Left boom
-
-    describe "stopGhci" do
-        it "is always a no-op and does not consume from the queue" do
-            LoadResult {diagnostics = msgs} <- runScripted [simpleResult [errMsg]] do
-                stopGhci
-                startGhci "cabal repl" "/"
-            msgs `shouldBe` [errMsg]
+            it "throws when scripted result is Left" do
+                result <-
+                    runScripted [Left (toException boom)]
+                        $ try @ErrorCall
+                        $ withGhci "cabal repl" "/" \_ reload -> reload
+                result `shouldBe` Left boom
 
     describe "sequencing" do
         it "consumes results in order across mixed operations" do
             (a, b) <- runScripted [simpleResult [errMsg], simpleResult [warnMsg]] do
-                LoadResult {diagnostics = a} <- startGhci "cabal repl" "/"
-                LoadResult {diagnostics = b} <- reloadGhci
-                pure (a, b)
+                withGhci "cabal repl" "/" \LoadResult {diagnostics = a} reload -> do
+                    LoadResult {diagnostics = b} <- reload
+                    pure (a, b)
             a `shouldBe` [errMsg]
             b `shouldBe` [warnMsg]
 
         it "recover scenario: error then success" do
             result <- runScripted [Left (toException boom), simpleResult []] do
-                r1 <- try @ErrorCall $ startGhci "cabal repl" "/"
-                LoadResult {diagnostics = r2} <- startGhci "cabal repl" "/"
+                r1 <- try @ErrorCall $ withGhci "cabal repl" "/" \i _ -> pure i
+                LoadResult {diagnostics = r2} <- withGhci "cabal repl" "/" \i _ -> pure i
                 pure (r1, r2)
             fst result `shouldSatisfy` isLeft
             snd result `shouldBe` []


### PR DESCRIPTION
This PR introduces bracketing around the GHCi session to ensure it is properly cleaned up in the event of an error.