### PR TITLE
feat: add `test-results` command

### DIFF
--- a/.claude-plugin/tricorder/skills/tricorder/SKILL.md
+++ b/.claude-plugin/tricorder/skills/tricorder/SKILL.md
@@ -19,6 +19,9 @@ tricorder is a daemon-based GHCi build monitor. It exposes build state over a Un
 - `tricorder status --wait --json` — wait then output JSON
 - `tricorder status --verbose` / `-v` — print full GHC message body under each diagnostic
 - `tricorder status --expand <N>` — print the summary line and full GHC message body for diagnostic #N
+- `tricorder test-results` — show full output from the latest test run
+- `tricorder test-results --failed` — show output only from failed test suites
+- `tricorder test-results --wait` — block until the current build cycle completes, then show results
 - `tricorder source MODULE...` — print Haskell source for one or more installed modules (e.g. `tricorder source Data.Map.Strict`)
 - `tricorder ui` — auto-refreshing terminal display (for humans)
 
@@ -113,15 +116,46 @@ Each diagnostic in `diagnostics`:
 - `title` is the short summary (first line of the GHC message)
 - `text` contains the full GHC message body
 
+### Test results (`test-results`)
+
+The daemon runs configured test suites automatically after each clean build — **never run `cabal test` manually**. Use `tricorder test-results` to inspect what happened.
+
+Default output lists each suite with its outcome followed by full captured output:
+
+```
+test:my-tests  failed
+  <full test runner output>
+test:other-tests  passed
+  <full test runner output>
+```
+
+With `--failed`, only failing suites are shown. If all suites passed:
+
+```
+All passed.
+  test:my-tests
+  test:other-tests
+```
+
+With `--wait`, blocks until the current build and test cycle completes before printing results. Combine with `--failed` to get a compact failure report after editing:
+
+```
+tricorder test-results --wait --failed
+```
+
+**Exit code**: 1 when any shown test suite failed or errored, 0 otherwise.
+
 ## Workflow
 
 1. Edit source files
 2. Run `tricorder status --wait` — blocks until tricorder finishes recompiling
 3. If errors are shown, fix them and repeat
-4. `All good.` means the build is clean
+4. `All good.` means the build is clean; test suites run automatically if configured
+5. Run `tricorder test-results --wait --failed` to see any test failures
 
 ## Notes
 
 - The daemon is per-project, scoped by the current working directory
 - `tricorder status` auto-starts the daemon if it isn't running
+- Do not run `cabal test` manually — the daemon manages test execution after each clean build
 - Use `--json` only when you need to parse the full build state; the default text output is sufficient for most workflows

--- a/tricorder.cabal
+++ b/tricorder.cabal
@@ -39,6 +39,7 @@ library
       Tricorder.Socket.Protocol
       Tricorder.Socket.Server
       Tricorder.SourceLookup
+      Tricorder.TestOutput
       Tricorder.UI
       Tricorder.UI.Event
       Tricorder.UI.Misc
@@ -412,6 +413,7 @@ test-suite tricorder-test
       Unit.Tricorder.SocketSpec
       Unit.Tricorder.SourceLookupSpec
       Unit.Tricorder.SourceSpec
+      Unit.Tricorder.TestOutputSpec
       Unit.Tricorder.TestRunnerSpec
       Paths_tricorder
   autogen-modules:

--- a/tricorder/src/Tricorder.hs
+++ b/tricorder/src/Tricorder.hs
@@ -21,7 +21,7 @@ import Atelier.Effects.Monitoring.Tracing (Tracing)
 import Atelier.Effects.Posix.Daemons (Daemons)
 import Tricorder.Arguments (Command (..))
 import Tricorder.BuildState (BuildState (..), DaemonInfo (..))
-import Tricorder.CLI (showLog, showSource, showStatus)
+import Tricorder.CLI (showLog, showSource, showStatus, showTests)
 import Tricorder.Config (Config)
 import Tricorder.Daemon (startDaemon, stopDaemon, waitForDaemon)
 import Tricorder.Effects.Brick (Brick)
@@ -96,6 +96,12 @@ run =
                 Console.putStrLn "Stopped."
             else
                 showStatus opts
+        Test opts -> do
+            running <- isDaemonRunning
+            if not running then
+                Console.putStrLn "Stopped."
+            else
+                showTests opts
         Log followMode -> do
             running <- isDaemonRunning
             mLogFile <-

--- a/tricorder/src/Tricorder/Arguments.hs
+++ b/tricorder/src/Tricorder/Arguments.hs
@@ -3,6 +3,7 @@ module Tricorder.Arguments
     , FollowMode (..)
     , OutputFormat (..)
     , StatusOptions (..)
+    , TestOptions (..)
     , Verbosity (..)
     , WaitMode (..)
     , parseArguments
@@ -68,10 +69,17 @@ data StatusOptions = StatusOptions
     }
 
 
+data TestOptions = TestOptions
+    { failedOnly :: Bool
+    , wait :: WaitMode
+    }
+
+
 data Command
     = Start
     | Stop
     | Status StatusOptions
+    | Test TestOptions
     | UI
     | Log FollowMode
     | Source [ModuleName]
@@ -101,6 +109,7 @@ commandParser =
         ( command "start" (info (pure Start) (progDesc "Start the daemon (no-op if already running)"))
             <> command "stop" (info (pure Stop) (progDesc "Stop the daemon"))
             <> command "status" (info statusParser (progDesc "Print build diagnostics (--json for machine-readable output)"))
+            <> command "test-results" (info testParser (progDesc "Show output from the latest test run"))
             <> command "ui" (info (pure UI) (progDesc "Auto-refreshing terminal display"))
             <> command "log" (info logParser (progDesc "Show daemon log output"))
             <> command "source" (info sourceParser (progDesc "Print the Haskell source of one or more installed modules"))
@@ -149,6 +158,25 @@ statusParser =
                             <> metavar "N"
                             <> help "Print full GHC message body for diagnostic #N"
                         )
+                    )
+            )
+
+
+testParser :: Parser Command
+testParser =
+    Test
+        <$> ( TestOptions
+                <$> flag
+                    False
+                    True
+                    ( long "failed"
+                        <> help "Only show output from failed test suites"
+                    )
+                <*> flag
+                    ShowCurrent
+                    WaitForBuild
+                    ( long "wait"
+                        <> help "Block until the current build cycle completes"
                     )
             )
 

--- a/tricorder/src/Tricorder/BuildState.hs
+++ b/tricorder/src/Tricorder/BuildState.hs
@@ -6,6 +6,8 @@ module Tricorder.BuildState
     , BuildResult (..)
     , TestRun (..)
     , TestOutcome (..)
+    , TestCase (..)
+    , TestCaseOutcome (..)
     , DaemonInfo (..)
     , runDaemonInfo
     , Diagnostic (..)
@@ -75,10 +77,26 @@ data TestOutcome = TestsRunning | TestsPassed | TestsFailed | TestsError Text
     deriving anyclass (FromJSON, ToJSON)
 
 
+data TestCaseOutcome
+    = TestCasePassed
+    | TestCaseFailed Text
+    deriving stock (Eq, Generic, Show)
+    deriving anyclass (FromJSON, ToJSON)
+
+
+data TestCase = TestCase
+    { description :: Text
+    , outcome :: TestCaseOutcome
+    }
+    deriving stock (Eq, Generic, Show)
+    deriving anyclass (FromJSON, ToJSON)
+
+
 data TestRun = TestRun
     { target :: Text
     , outcome :: TestOutcome
     , output :: Text
+    , testCases :: [TestCase]
     }
     deriving stock (Eq, Generic, Show)
     deriving anyclass (FromJSON, ToJSON)

--- a/tricorder/src/Tricorder/BuildState.hs
+++ b/tricorder/src/Tricorder/BuildState.hs
@@ -5,7 +5,8 @@ module Tricorder.BuildState
     , BuildProgress (..)
     , BuildResult (..)
     , TestRun (..)
-    , TestOutcome (..)
+    , TestRunError (..)
+    , TestRunCompletion (..)
     , TestCase (..)
     , TestCaseOutcome (..)
     , DaemonInfo (..)
@@ -72,11 +73,6 @@ runDaemonInfo act = do
     runReader daemonInfo act
 
 
-data TestOutcome = TestsRunning | TestsPassed | TestsFailed | TestsError Text
-    deriving stock (Eq, Generic, Show)
-    deriving anyclass (FromJSON, ToJSON)
-
-
 data TestCaseOutcome
     = TestCasePassed
     | TestCaseFailed Text
@@ -92,12 +88,28 @@ data TestCase = TestCase
     deriving anyclass (FromJSON, ToJSON)
 
 
-data TestRun = TestRun
+data TestRunError = TestRunError
     { target :: Text
-    , outcome :: TestOutcome
+    , message :: Text
+    }
+    deriving stock (Eq, Generic, Show)
+    deriving anyclass (FromJSON, ToJSON)
+
+
+data TestRunCompletion = TestRunCompletion
+    { target :: Text
+    , passed :: Bool
     , output :: Text
     , testCases :: [TestCase]
     }
+    deriving stock (Eq, Generic, Show)
+    deriving anyclass (FromJSON, ToJSON)
+
+
+data TestRun
+    = TestRunning Text
+    | TestRunErrored TestRunError
+    | TestRunCompleted TestRunCompletion
     deriving stock (Eq, Generic, Show)
     deriving anyclass (FromJSON, ToJSON)
 

--- a/tricorder/src/Tricorder/CLI.hs
+++ b/tricorder/src/Tricorder/CLI.hs
@@ -2,6 +2,7 @@ module Tricorder.CLI
     ( showLog
     , showSource
     , showStatus
+    , showTests
     ) where
 
 import Data.Aeson (encode)
@@ -21,6 +22,7 @@ import Tricorder.Arguments
     ( FollowMode (..)
     , OutputFormat (..)
     , StatusOptions (..)
+    , TestOptions (..)
     , Verbosity (..)
     , WaitMode (..)
     )
@@ -157,6 +159,59 @@ showLog mLogFile followMode = case mLogFile of
         else case followMode of
             Follow -> followFile path Console.putStr
             NoFollow -> readFileLbs path >>= Console.putStr . BSL.toStrict
+
+
+showTests
+    :: ( Console :> es
+       , Exit :> es
+       , File :> es
+       , Reader SocketPath :> es
+       , UnixSocket :> es
+       )
+    => TestOptions -> Eff es ()
+showTests opts = do
+    SocketPath sockPath <- ask
+    result <-
+        case opts.wait of
+            WaitForBuild -> queryStatusWait sockPath
+            ShowCurrent -> queryStatus sockPath
+    case result of
+        Left err -> Console.putTextLn $ "Error: " <> err
+        Right state ->
+            case state.phase of
+                Building _ -> Console.putStrLn "Build in progress, no test results yet."
+                Restarting -> Console.putStrLn "Daemon restarting, no test results yet."
+                Testing r -> renderTestRuns r
+                Done r -> renderTestRuns r
+  where
+    renderTestRuns r =
+        let runs =
+                if opts.failedOnly then
+                    filter (isFailed . (.outcome)) r.testRuns
+                else
+                    r.testRuns
+        in  if null r.testRuns then
+                Console.putStrLn "No test results."
+            else
+                if null runs then do
+                    Console.putStrLn "All passed."
+                    mapM_ (Console.putTextLn . ("  " <>) . (.target)) r.testRuns
+                else do
+                    mapM_ printTestOutput runs
+                    when (any (isFailed . (.outcome)) runs) exitFailure
+
+    isFailed TestsPassed = False
+    isFailed TestsRunning = False
+    isFailed _ = True
+
+    printTestOutput tr = do
+        Console.putTextLn $ tr.target <> "  " <> outcomeLabel tr.outcome
+        mapM_ (Console.putTextLn . ("  " <>) . toText) (lines tr.output)
+      where
+        outcomeLabel TestsRunning = "running..."
+        outcomeLabel TestsPassed = "passed"
+        outcomeLabel TestsFailed = "failed"
+        outcomeLabel (TestsError msg) = "error: " <> msg
 
 
 showSource

--- a/tricorder/src/Tricorder/CLI.hs
+++ b/tricorder/src/Tricorder/CLI.hs
@@ -35,8 +35,9 @@ import Tricorder.BuildState
     , Severity (..)
     , TestCase (..)
     , TestCaseOutcome (..)
-    , TestOutcome (..)
     , TestRun (..)
+    , TestRunCompletion (..)
+    , TestRunError (..)
     )
 import Tricorder.CLI.Render
     ( diagnosticLineIndexed
@@ -119,21 +120,21 @@ showStatus opts = do
                     when (buildHasErrors r || testsFailed r) exitFailure
 
     printTestRun verbosity tr = do
-        Console.putTextLn $ testRunSummary tr.target tr.outcome
-        when (verbosity == Verbose)
-            $ mapM_ (Console.putTextLn . ("  " <>) . toText) (lines tr.output)
-      where
-        testRunSummary t TestsRunning = t <> "  running..."
-        testRunSummary t TestsPassed = t <> "  passed"
-        testRunSummary t TestsFailed = t <> "  failed"
-        testRunSummary t (TestsError msg) = t <> "  error: " <> msg
+        Console.putTextLn $ case tr of
+            TestRunning t -> t <> "  running..."
+            TestRunErrored e -> e.target <> "  error: " <> e.message
+            TestRunCompleted c -> c.target <> "  " <> if c.passed then "passed" else "failed"
+        when (verbosity == Verbose) $ case tr of
+            TestRunCompleted c ->
+                mapM_ (Console.putTextLn . ("  " <>) . toText) (lines c.output)
+            _ -> pure ()
 
     buildHasErrors r = any ((== SError) . (.severity)) r.diagnostics
-    testsFailed r = any (notPassed . (.outcome)) r.testRuns
+    testsFailed r = any isFailedRun r.testRuns
       where
-        notPassed TestsPassed = False
-        notPassed TestsRunning = False
-        notPassed _ = True
+        isFailedRun (TestRunCompleted c) = not c.passed
+        isFailedRun (TestRunErrored _) = True
+        isFailedRun (TestRunning _) = False
 
     buildSummary tz r =
         let errs = length $ filter ((== SError) . (.severity)) r.diagnostics
@@ -190,7 +191,7 @@ showTests opts = do
     renderTestRuns r =
         let runs =
                 if opts.failedOnly then
-                    filter (isFailed . (.outcome)) r.testRuns
+                    filter isFailed r.testRuns
                 else
                     r.testRuns
         in  if null r.testRuns then
@@ -198,40 +199,44 @@ showTests opts = do
             else
                 if null runs then do
                     Console.putStrLn "All passed."
-                    mapM_ (Console.putTextLn . ("  " <>) . (.target)) r.testRuns
+                    mapM_ (Console.putTextLn . ("  " <>) . testRunTarget) r.testRuns
                 else do
                     mapM_ printTestOutput runs
-                    when (any (isFailed . (.outcome)) runs) exitFailure
+                    when (any isFailed runs) exitFailure
 
-    isFailed TestsPassed = False
-    isFailed TestsRunning = False
-    isFailed _ = True
+    isFailed (TestRunCompleted c) = not c.passed
+    isFailed (TestRunErrored _) = True
+    isFailed (TestRunning _) = False
 
-    printTestOutput tr = do
-        Console.putTextLn $ tr.target <> "  " <> outcomeLabel tr.outcome
-        if opts.failedOnly then
-            if null tr.testCases then do
-                Console.putTextLn "  (unrecognised test runner format — showing full output)"
-                mapM_ (Console.putTextLn . ("  " <>)) (stripGhciNoise (lines tr.output))
+    testRunTarget (TestRunning t) = t
+    testRunTarget (TestRunErrored e) = e.target
+    testRunTarget (TestRunCompleted c) = c.target
+
+    printTestOutput tr = case tr of
+        TestRunning t ->
+            Console.putTextLn $ t <> "  running..."
+        TestRunErrored e ->
+            Console.putTextLn $ e.target <> "  error: " <> e.message
+        TestRunCompleted c -> do
+            Console.putTextLn $ c.target <> "  " <> if c.passed then "passed" else "failed"
+            if opts.failedOnly then
+                if null c.testCases then do
+                    Console.putTextLn "  (unrecognised test runner format — showing full output)"
+                    mapM_ (Console.putTextLn . ("  " <>)) (stripGhciNoise (lines c.output))
+                else
+                    mapM_ printFailedCase (filter isCaseFailed c.testCases)
             else
-                mapM_ printFailedCase (filter isCaseFailed tr.testCases)
-        else
-            mapM_ (Console.putTextLn . ("  " <>)) (stripGhciNoise (lines tr.output))
-      where
-        outcomeLabel TestsRunning = "running..."
-        outcomeLabel TestsPassed = "passed"
-        outcomeLabel TestsFailed = "failed"
-        outcomeLabel (TestsError msg) = "error: " <> msg
+                mapM_ (Console.putTextLn . ("  " <>)) (stripGhciNoise (lines c.output))
 
-        isCaseFailed (TestCase _ (TestCaseFailed _)) = True
-        isCaseFailed _ = False
+    isCaseFailed (TestCase _ (TestCaseFailed _)) = True
+    isCaseFailed _ = False
 
-        printFailedCase tc = do
-            Console.putTextLn $ "  " <> tc.description
-            case tc.outcome of
-                TestCaseFailed details ->
-                    mapM_ (Console.putTextLn . ("    " <>)) (T.lines details)
-                TestCasePassed -> pure ()
+    printFailedCase tc = do
+        Console.putTextLn $ "  " <> tc.description
+        case tc.outcome of
+            TestCaseFailed details ->
+                mapM_ (Console.putTextLn . ("    " <>)) (T.lines details)
+            TestCasePassed -> pure ()
 
     stripGhciNoise ls =
         case dropWhile (not . T.isPrefixOf "ghci> ") ls of

--- a/tricorder/src/Tricorder/CLI.hs
+++ b/tricorder/src/Tricorder/CLI.hs
@@ -11,6 +11,7 @@ import Data.Time.LocalTime (utcToLocalTime)
 import Effectful.Reader.Static (Reader, ask)
 
 import Data.ByteString.Lazy qualified as BSL
+import Data.Text qualified as T
 
 import Atelier.Effects.Clock (Clock, currentTimeZone)
 import Atelier.Effects.Console (Console)
@@ -32,6 +33,8 @@ import Tricorder.BuildState
     , BuildState (..)
     , Diagnostic (..)
     , Severity (..)
+    , TestCase (..)
+    , TestCaseOutcome (..)
     , TestOutcome (..)
     , TestRun (..)
     )
@@ -206,12 +209,39 @@ showTests opts = do
 
     printTestOutput tr = do
         Console.putTextLn $ tr.target <> "  " <> outcomeLabel tr.outcome
-        mapM_ (Console.putTextLn . ("  " <>) . toText) (lines tr.output)
+        if opts.failedOnly then
+            if null tr.testCases then do
+                Console.putTextLn "  (unrecognised test runner format — showing full output)"
+                mapM_ (Console.putTextLn . ("  " <>)) (stripGhciNoise (lines tr.output))
+            else
+                mapM_ printFailedCase (filter isCaseFailed tr.testCases)
+        else
+            mapM_ (Console.putTextLn . ("  " <>)) (stripGhciNoise (lines tr.output))
       where
         outcomeLabel TestsRunning = "running..."
         outcomeLabel TestsPassed = "passed"
         outcomeLabel TestsFailed = "failed"
         outcomeLabel (TestsError msg) = "error: " <> msg
+
+        isCaseFailed (TestCase _ (TestCaseFailed _)) = True
+        isCaseFailed _ = False
+
+        printFailedCase tc = do
+            Console.putTextLn $ "  " <> tc.description
+            case tc.outcome of
+                TestCaseFailed details ->
+                    mapM_ (Console.putTextLn . ("    " <>)) (T.lines details)
+                TestCasePassed -> pure ()
+
+    stripGhciNoise ls =
+        case dropWhile (not . T.isPrefixOf "ghci> ") ls of
+            [] -> ls
+            _ : afterPrompt -> reverse $ dropWhile isGhciNoiseLine $ reverse afterPrompt
+
+    isGhciNoiseLine l =
+        T.isPrefixOf "ghci>" l
+            || l == "Leaving GHCi."
+            || T.isPrefixOf "*** Exception: " l
 
 
 showSource

--- a/tricorder/src/Tricorder/CLI.hs
+++ b/tricorder/src/Tricorder/CLI.hs
@@ -185,24 +185,23 @@ showTests opts = do
             case state.phase of
                 Building _ -> Console.putStrLn "Build in progress, no test results yet."
                 Restarting -> Console.putStrLn "Daemon restarting, no test results yet."
-                Testing r -> renderTestRuns r
-                Done r -> renderTestRuns r
+                Testing r -> renderTestRuns r.testRuns
+                Done r -> renderTestRuns r.testRuns
   where
-    renderTestRuns r =
-        let runs =
-                if opts.failedOnly then
-                    filter isFailed r.testRuns
-                else
-                    r.testRuns
-        in  if null r.testRuns then
-                Console.putStrLn "No test results."
+    renderTestRuns [] = Console.putStrLn "No test results."
+    renderTestRuns testRuns
+        | null runs = do
+            Console.putStrLn "All passed."
+            mapM_ (Console.putTextLn . ("  " <>) . testRunTarget) testRuns
+        | otherwise = do
+            mapM_ printTestOutput runs
+            when (any isFailed runs) exitFailure
+      where
+        runs =
+            if opts.failedOnly then
+                filter isFailed testRuns
             else
-                if null runs then do
-                    Console.putStrLn "All passed."
-                    mapM_ (Console.putTextLn . ("  " <>) . testRunTarget) r.testRuns
-                else do
-                    mapM_ printTestOutput runs
-                    when (any isFailed runs) exitFailure
+                testRuns
 
     isFailed (TestRunCompleted c) = not c.passed
     isFailed (TestRunErrored _) = True

--- a/tricorder/src/Tricorder/Effects/TestRunner.hs
+++ b/tricorder/src/Tricorder/Effects/TestRunner.hs
@@ -26,6 +26,7 @@ import Data.Text qualified as T
 
 import Tricorder.BuildState (TestOutcome (..), TestRun (..))
 import Tricorder.Runtime (ProjectRoot (..))
+import Tricorder.TestOutput (parseHspecOutput)
 
 
 data TestRunner :: Effect where
@@ -54,10 +55,10 @@ runTestRunnerIO act = do
                 pure (out, err)
             pure $ case result of
                 Left ex ->
-                    TestRun {target, outcome = TestsError (show ex :: Text), output = ""}
+                    TestRun {target, outcome = TestsError (show ex :: Text), output = "", testCases = []}
                 Right (out, err) ->
                     let output = decodeUtf8 (BSL.toStrict out) <> decodeUtf8 (BSL.toStrict err)
-                    in  TestRun {target, outcome = detectOutcome output, output}
+                    in  TestRun {target, outcome = detectOutcome output, output, testCases = parseHspecOutput output}
 
 
 -- | Scripted interpreter for testing.

--- a/tricorder/src/Tricorder/Effects/TestRunner.hs
+++ b/tricorder/src/Tricorder/Effects/TestRunner.hs
@@ -8,6 +8,7 @@ module Tricorder.Effects.TestRunner
     , runTestRunnerScripted
 
       -- * Parsing utilities
+    , GhciOutcome (..)
     , detectOutcome
     ) where
 
@@ -24,7 +25,7 @@ import Data.ByteString.Lazy qualified as BSL
 import Data.List qualified as List
 import Data.Text qualified as T
 
-import Tricorder.BuildState (TestOutcome (..), TestRun (..))
+import Tricorder.BuildState (TestRun (..), TestRunCompletion (..), TestRunError (..))
 import Tricorder.Runtime (ProjectRoot (..))
 import Tricorder.TestOutput (parseHspecOutput)
 
@@ -55,10 +56,20 @@ runTestRunnerIO act = do
                 pure (out, err)
             pure $ case result of
                 Left ex ->
-                    TestRun {target, outcome = TestsError (show ex :: Text), output = "", testCases = []}
+                    TestRunErrored $ TestRunError {target, message = show ex}
                 Right (out, err) ->
                     let output = decodeUtf8 (BSL.toStrict out) <> decodeUtf8 (BSL.toStrict err)
-                    in  TestRun {target, outcome = detectOutcome output, output, testCases = parseHspecOutput output}
+                    in  case detectOutcome output of
+                            GhciCrashed msg ->
+                                TestRunErrored $ TestRunError {target, message = msg}
+                            outcome ->
+                                TestRunCompleted
+                                    $ TestRunCompletion
+                                        { target
+                                        , passed = outcome == GhciPassed
+                                        , output
+                                        , testCases = parseHspecOutput output
+                                        }
 
 
 -- | Scripted interpreter for testing.
@@ -82,6 +93,13 @@ runTestRunnerScripted results = reinterpret (evalState results) $ \_ ->
             RunTestSuite _ -> popResult
 
 
+data GhciOutcome
+    = GhciPassed
+    | GhciFailed
+    | GhciCrashed Text
+    deriving stock (Eq, Show)
+
+
 -- | Detect the test outcome from raw GHCi output.
 --
 -- All major test frameworks (@hspec@, @tasty@, @HUnit@) call
@@ -89,19 +107,19 @@ runTestRunnerScripted results = reinterpret (evalState results) $ \_ ->
 -- matching @*** Exception: ExitSuccess@ (pass) or
 -- @*** Exception: ExitFailure N@ (fail). Any other @*** Exception:@ line
 -- means the runner crashed. Absence of an exception line is treated as pass.
-detectOutcome :: Text -> TestOutcome
+detectOutcome :: Text -> GhciOutcome
 detectOutcome output =
     case List.find ("*** Exception: " `T.isPrefixOf`) (T.lines output) of
-        Nothing -> TestsPassed
+        Nothing -> GhciPassed
         Just line ->
             case T.stripPrefix "*** Exception: " line of
-                Nothing -> TestsPassed
+                Nothing -> GhciPassed
                 Just rest ->
                     let r = T.strip rest
                     in  if r == "ExitSuccess" then
-                            TestsPassed
+                            GhciPassed
                         else
                             if "ExitFailure" `T.isPrefixOf` r then
-                                TestsFailed
+                                GhciFailed
                             else
-                                TestsError r
+                                GhciCrashed r

--- a/tricorder/src/Tricorder/GhciSession.hs
+++ b/tricorder/src/Tricorder/GhciSession.hs
@@ -20,7 +20,7 @@ import Atelier.Effects.FileSystem (FileSystem, getCurrentDirectory)
 import Atelier.Effects.Log (Log)
 import Atelier.Exception (isGracefulShutdown)
 import Atelier.Time (Millisecond)
-import Tricorder.BuildState (BuildId (..), BuildPhase (..), BuildResult (..), ChangeKind (..), Diagnostic (..), Severity (..), TestOutcome (..), TestRun (..))
+import Tricorder.BuildState (BuildId (..), BuildPhase (..), BuildResult (..), ChangeKind (..), Diagnostic (..), Severity (..), TestRun (..))
 import Tricorder.Config (Config (..), resolveCommand, resolveTestTargets, resolveWatchDirs)
 import Tricorder.Effects.BuildStore (BuildStore)
 import Tricorder.Effects.GhciSession (GhciSession, LoadResult (..))
@@ -191,7 +191,7 @@ runTestsIfClean
     => [Text] -> BuildId -> BuildResult -> Eff es [TestRun]
 runTestsIfClean testTargets bid partialResult
     | not (null testTargets) && not (any (\d -> d.severity == SError) partialResult.diagnostics) = do
-        let pendingRun t = TestRun {target = t, outcome = TestsRunning, output = "", testCases = []}
+        let pendingRun = TestRunning
         BuildStore.setPhase bid (Testing partialResult {testRuns = map pendingRun testTargets})
         Log.info $ "Running " <> show (length testTargets) <> " test suite(s)"
         foldM

--- a/tricorder/src/Tricorder/GhciSession.hs
+++ b/tricorder/src/Tricorder/GhciSession.hs
@@ -191,7 +191,7 @@ runTestsIfClean
     => [Text] -> BuildId -> BuildResult -> Eff es [TestRun]
 runTestsIfClean testTargets bid partialResult
     | not (null testTargets) && not (any (\d -> d.severity == SError) partialResult.diagnostics) = do
-        let pendingRun t = TestRun {target = t, outcome = TestsRunning, output = ""}
+        let pendingRun t = TestRun {target = t, outcome = TestsRunning, output = "", testCases = []}
         BuildStore.setPhase bid (Testing partialResult {testRuns = map pendingRun testTargets})
         Log.info $ "Running " <> show (length testTargets) <> " test suite(s)"
         foldM

--- a/tricorder/src/Tricorder/TestOutput.hs
+++ b/tricorder/src/Tricorder/TestOutput.hs
@@ -1,0 +1,31 @@
+module Tricorder.TestOutput (parseHspecOutput) where
+
+import Data.Text qualified as T
+
+import Tricorder.BuildState (TestCase (..), TestCaseOutcome (..))
+
+
+-- | Parse hspec output into individual test case results.
+--
+-- Recognises lines ending with @OK@ or @FAIL@ (right-aligned, space-padded).
+-- For failing tests, collects the indented detail lines that follow as the
+-- failure message.
+parseHspecOutput :: Text -> [TestCase]
+parseHspecOutput = go . T.lines
+  where
+    go [] = []
+    go (l : ls)
+        | T.isSuffixOf "OK" (T.stripEnd l) =
+            TestCase {description = extractDesc "OK" l, outcome = TestCasePassed}
+                : go ls
+        | T.isSuffixOf "FAIL" (T.stripEnd l) =
+            let (detailLines, rest) = span (\dl -> indentOf dl > indentOf l) ls
+                details = T.intercalate "\n" $ filter (not . T.null) $ map T.strip detailLines
+            in  TestCase {description = extractDesc "FAIL" l, outcome = TestCaseFailed details}
+                    : go rest
+        | otherwise = go ls
+
+    extractDesc suffix l =
+        T.strip $ T.dropEnd (T.length suffix) $ T.stripEnd l
+
+    indentOf = T.length . T.takeWhile (== ' ')

--- a/tricorder/src/Tricorder/UI/View.hs
+++ b/tricorder/src/Tricorder/UI/View.hs
@@ -37,8 +37,9 @@ import Tricorder.BuildState
     , DaemonInfo (..)
     , Diagnostic (..)
     , Severity (..)
-    , TestOutcome (..)
     , TestRun (..)
+    , TestRunCompletion (..)
+    , TestRunError (..)
     )
 import Tricorder.UI.Event (viewKeybindings)
 import Tricorder.UI.Misc (emphasis, err, hBoxSpaced, ok, subtle, vBoxSpaced, warn)
@@ -251,14 +252,10 @@ viewTestRuns runs = vBox $ viewTestRun <$> runs
 
 
 viewTestRun :: TestRun -> Widget n
-viewTestRun tr = hBox [txt tr.target, txt "  ", viewTestOutcome tr.outcome]
-
-
-viewTestOutcome :: TestOutcome -> Widget n
-viewTestOutcome TestsRunning = warn $ txt "running..."
-viewTestOutcome TestsPassed = ok $ txt "passed"
-viewTestOutcome TestsFailed = err $ txt "failed"
-viewTestOutcome (TestsError msg) = hBox [err $ txt "error:", txt msg]
+viewTestRun (TestRunning t) = hBox [txt t, txt "  ", warn $ txt "running..."]
+viewTestRun (TestRunErrored e) = hBox [txt e.target, txt "  ", err $ txt "error: ", txt e.message]
+viewTestRun (TestRunCompleted c) =
+    hBox [txt c.target, txt "  ", if c.passed then ok (txt "passed") else err (txt "failed")]
 
 
 viewTimestamp :: TimeZone -> UTCTime -> Widget n

--- a/tricorder/test/Unit/Tricorder/TestOutputSpec.hs
+++ b/tricorder/test/Unit/Tricorder/TestOutputSpec.hs
@@ -1,0 +1,69 @@
+module Unit.Tricorder.TestOutputSpec (spec_TestOutput) where
+
+import Test.Hspec
+
+import Tricorder.BuildState (TestCase (..), TestCaseOutcome (..))
+import Tricorder.TestOutput (parseHspecOutput)
+
+
+spec_TestOutput :: Spec
+spec_TestOutput = do
+    describe "parseHspecOutput" do
+        it "returns empty list for empty output" do
+            parseHspecOutput "" `shouldBe` []
+
+        it "parses a passing test" do
+            let output = "  foo\n    bar baz:                                      OK\n"
+            parseHspecOutput output
+                `shouldBe` [TestCase {description = "bar baz:", outcome = TestCasePassed}]
+
+        it "parses a failing test" do
+            let output = "  foo\n    bar baz:                                      FAIL\n"
+            parseHspecOutput output
+                `shouldBe` [TestCase {description = "bar baz:", outcome = TestCaseFailed ""}]
+
+        it "captures failure details" do
+            let output =
+                    "    a test:                                            FAIL\n"
+                        <> "      expected: 1\n"
+                        <> "       but got: 2\n"
+                        <> "    another test:                                       OK\n"
+            parseHspecOutput output
+                `shouldBe` [ TestCase
+                                { description = "a test:"
+                                , outcome = TestCaseFailed "expected: 1\nbut got: 2"
+                                }
+                           , TestCase {description = "another test:", outcome = TestCasePassed}
+                           ]
+
+        it "stops collecting details when indentation returns to test level" do
+            let output =
+                    "    failing:                                           FAIL\n"
+                        <> "      detail line\n"
+                        <> "    passing:                                          OK\n"
+            let cases = parseHspecOutput output
+            length cases `shouldBe` 2
+            case cases of
+                (c : _) -> c.outcome `shouldBe` TestCaseFailed "detail line"
+                [] -> expectationFailure "expected at least one test case"
+
+        it "skips group header lines" do
+            let output =
+                    "  MyModule\n"
+                        <> "    someFunction\n"
+                        <> "      does the thing:                                  OK\n"
+            parseHspecOutput output
+                `shouldBe` [TestCase {description = "does the thing:", outcome = TestCasePassed}]
+
+        it "parses mixed passing and failing tests" do
+            let output =
+                    "  Suite\n"
+                        <> "    passes:                                            OK\n"
+                        <> "    fails:                                             FAIL\n"
+                        <> "      reason\n"
+                        <> "    also passes:                                       OK\n"
+            parseHspecOutput output
+                `shouldBe` [ TestCase {description = "passes:", outcome = TestCasePassed}
+                           , TestCase {description = "fails:", outcome = TestCaseFailed "reason"}
+                           , TestCase {description = "also passes:", outcome = TestCasePassed}
+                           ]

--- a/tricorder/test/Unit/Tricorder/TestRunnerSpec.hs
+++ b/tricorder/test/Unit/Tricorder/TestRunnerSpec.hs
@@ -114,11 +114,11 @@ boom = ErrorCall "simulated process crash"
 
 
 passingRun :: TestRun
-passingRun = TestRun {target = "test:foo", outcome = TestsPassed, output = "2 examples, 0 failures\n"}
+passingRun = TestRun {target = "test:foo", outcome = TestsPassed, output = "2 examples, 0 failures\n", testCases = []}
 
 
 failingRun :: TestRun
-failingRun = TestRun {target = "test:bar", outcome = TestsFailed, output = "1 example, 1 failure\n"}
+failingRun = TestRun {target = "test:bar", outcome = TestsFailed, output = "1 example, 1 failure\n", testCases = []}
 
 
 runScripted :: [Either SomeException TestRun] -> Eff '[TestRunner, IOE] a -> IO a

--- a/tricorder/test/Unit/Tricorder/TestRunnerSpec.hs
+++ b/tricorder/test/Unit/Tricorder/TestRunnerSpec.hs
@@ -5,9 +5,10 @@ import Effectful (IOE, runEff)
 import Effectful.Exception (try)
 import Test.Hspec
 
-import Tricorder.BuildState (TestOutcome (..), TestRun (..))
+import Tricorder.BuildState (TestRun (..), TestRunCompletion (..))
 import Tricorder.Effects.TestRunner
-    ( TestRunner
+    ( GhciOutcome (..)
+    , TestRunner
     , detectOutcome
     , runTestRunnerScripted
     , runTestSuite
@@ -28,42 +29,42 @@ testDetectOutcome :: Spec
 testDetectOutcome = do
     describe "no exception line" do
         it "treats empty output as pass" do
-            detectOutcome "" `shouldBe` TestsPassed
+            detectOutcome "" `shouldBe` GhciPassed
 
         it "treats output with no exception as pass" do
-            detectOutcome "2 examples, 0 failures\n" `shouldBe` TestsPassed
+            detectOutcome "2 examples, 0 failures\n" `shouldBe` GhciPassed
 
         it "does not match 'ExitSuccess' without the exception prefix" do
-            detectOutcome "ExitSuccess\n" `shouldBe` TestsPassed
+            detectOutcome "ExitSuccess\n" `shouldBe` GhciPassed
 
     describe "ExitSuccess" do
         it "detects ExitSuccess as pass" do
-            detectOutcome "*** Exception: ExitSuccess\n" `shouldBe` TestsPassed
+            detectOutcome "*** Exception: ExitSuccess\n" `shouldBe` GhciPassed
 
         it "detects ExitSuccess anywhere in output" do
             detectOutcome "All tests passed\n*** Exception: ExitSuccess\n"
-                `shouldBe` TestsPassed
+                `shouldBe` GhciPassed
 
     describe "ExitFailure" do
         it "detects ExitFailure 1 as fail" do
             detectOutcome "1 failure\n*** Exception: ExitFailure 1\n"
-                `shouldBe` TestsFailed
+                `shouldBe` GhciFailed
 
         it "detects ExitFailure with any exit code as fail" do
-            detectOutcome "*** Exception: ExitFailure 42\n" `shouldBe` TestsFailed
+            detectOutcome "*** Exception: ExitFailure 42\n" `shouldBe` GhciFailed
 
         it "detects ExitFailure anywhere in output" do
             detectOutcome "Some output\n*** Exception: ExitFailure 1\nMore output\n"
-                `shouldBe` TestsFailed
+                `shouldBe` GhciFailed
 
     describe "other exception" do
         it "classifies unknown exception as error with message" do
             detectOutcome "*** Exception: SomeException \"oops\"\n"
-                `shouldBe` TestsError "SomeException \"oops\""
+                `shouldBe` GhciCrashed "SomeException \"oops\""
 
         it "trims trailing whitespace from the error message" do
             detectOutcome "*** Exception: Crashed  \n"
-                `shouldBe` TestsError "Crashed"
+                `shouldBe` GhciCrashed "Crashed"
 
 
 --------------------------------------------------------------------------------
@@ -114,11 +115,25 @@ boom = ErrorCall "simulated process crash"
 
 
 passingRun :: TestRun
-passingRun = TestRun {target = "test:foo", outcome = TestsPassed, output = "2 examples, 0 failures\n", testCases = []}
+passingRun =
+    TestRunCompleted
+        $ TestRunCompletion
+            { target = "test:foo"
+            , passed = True
+            , output = "2 examples, 0 failures\n"
+            , testCases = []
+            }
 
 
 failingRun :: TestRun
-failingRun = TestRun {target = "test:bar", outcome = TestsFailed, output = "1 example, 1 failure\n", testCases = []}
+failingRun =
+    TestRunCompleted
+        $ TestRunCompletion
+            { target = "test:bar"
+            , passed = False
+            , output = "1 example, 1 failure\n"
+            , testCases = []
+            }
 
 
 runScripted :: [Either SomeException TestRun] -> Eff '[TestRunner, IOE] a -> IO a


### PR DESCRIPTION
## Summary

Adds a new `tricorder test-results` command for inspecting the output of the latest test run without going through the full `status` output.

### New command

```
tricorder test-results [--failed] [--wait]
```

- **Default**: shows the full captured output for every test suite in the latest build, with GHCi/cabal startup noise stripped.
- **`--failed`**: shows only failing test suites; within each suite, shows individual failing test cases with their descriptions and failure details (parsed from hspec output). Falls back to full suite output with a warning for unrecognised runner formats.
- **`--wait`**: blocks until the current build and test cycle completes before printing results, matching the behaviour of `status --wait`.
- **Exit code**: 1 when any shown test suite failed or errored, 0 otherwise.

### Example output — `--failed`

```
test:tricorder-test  failed
  includes the one-liner prefix for an error:
    "E Foo.hs:10 type mismatch" does not contain "E Foo.hs:10 deliberate failure"
    Use -p '/includes the one-liner prefix for an error/' to rerun this test only.
```

When all suites passed (common use with `--wait --failed`):

```
All passed.
  test:my-tests
  test:other-tests
```

## Implementation notes

- **`Tricorder.TestOutput`** — new module with `parseHspecOutput`, which recognises right-aligned `OK`/`FAIL` lines in hspec output and collects indented failure detail lines. Returns `[]` for unrecognised formats (the `--failed` path detects this and falls back gracefully).
- **`BuildState.TestRun`** — extended with `testCases :: [TestCase]`, populated at capture time in `TestRunner`. `TestCase` and `TestCaseOutcome` are fully serialised (JSON), so the structured data is available everywhere downstream: `status --json`, the UI, and future commands.
- **GHCi noise stripping** — the full output path strips the cabal build profile, `[N of M] Compiling` lines, and the GHCi prompt/exit lines before display.
- **Skill doc** — `SKILL.md` updated with the new command, flag descriptions, example workflow step, and an explicit note not to run `cabal test` manually.
