### PR TITLE
fix: metrics server port conflict no longer crashes daemon

### DIFF
--- a/tricorder/src/Tricorder/Observability.hs
+++ b/tricorder/src/Tricorder/Observability.hs
@@ -7,13 +7,19 @@ module Tricorder.Observability
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Default (Default (..))
 import Effectful (IOE)
+import Effectful.Exception (IOException, try)
 import Effectful.Reader.Static (Reader, ask)
 
-import Atelier.Component (Component (..), defaultComponent)
+import Atelier.Component (Component (..), Trigger, defaultComponent)
+import Atelier.Effects.Delay (Delay)
+import Atelier.Effects.Log (Log)
 import Atelier.Effects.Monitoring.Tracing (TracingConfig)
+import Atelier.Time (Millisecond)
 import Atelier.Types.QuietSnake (QuietSnake (..))
 import Atelier.Types.WithDefaults (WithDefaults (..))
 
+import Atelier.Effects.Delay qualified as Delay
+import Atelier.Effects.Log qualified as Log
 import Atelier.Effects.Monitoring.Metrics.Server qualified as Server
 
 
@@ -43,7 +49,7 @@ instance Default Config where
     def = Config {metrics = def, logFile = Nothing, tracing = def}
 
 
-component :: (IOE :> es, Reader Config :> es) => Component es
+component :: (Delay :> es, IOE :> es, Log :> es, Reader Config :> es) => Component es
 component =
     defaultComponent
         { name = "Observability"
@@ -51,7 +57,17 @@ component =
             cfg <- ask @Config
             pure
                 $ if cfg.metrics.enabled then
-                    [liftIO $ forever $ Server.runMetricsServer cfg.metrics.port]
+                    [metricsServerTrigger cfg.metrics.port]
                 else
                     []
         }
+
+
+metricsServerTrigger :: (Delay :> es, IOE :> es, Log :> es) => Int -> Trigger es
+metricsServerTrigger port = do
+    result <- try @IOException $ liftIO $ Server.runMetricsServer port
+    case result of
+        Right () -> pure ()
+        Left e ->
+            Log.warn $ "Metrics server on port " <> show port <> " failed to start: " <> show e
+    forever $ Delay.wait (3_600_000 :: Millisecond)


### PR DESCRIPTION
Catch `IOException` in the metrics server trigger so that `EADDRINUSE` (or any other bind failure) is logged as a warning and the daemon continues running without a metrics endpoint, rather than propagating the exception and killing the daemon.

- Prevents the second daemon from crashing when two projects share the same `metrics.port` in their configs
- Logs a warning via the `Log` effect so the failure is visible in the log file