### PR TITLE
refactor: rename Config to Session

### DIFF
--- a/tricorder.cabal
+++ b/tricorder.cabal
@@ -35,6 +35,7 @@ library
       Tricorder.GhcPkg.Types
       Tricorder.Observability
       Tricorder.Runtime
+      Tricorder.Session
       Tricorder.Socket.Client
       Tricorder.Socket.Protocol
       Tricorder.Socket.Server
@@ -407,9 +408,9 @@ test-suite tricorder-test
       Unit.Tricorder.BuildStateSpec
       Unit.Tricorder.BuildStoreSpec
       Unit.Tricorder.CLI.RenderSpec
-      Unit.Tricorder.ConfigSpec
       Unit.Tricorder.GhciSessionSpec
       Unit.Tricorder.GhcPkgSpec
+      Unit.Tricorder.SessionSpec
       Unit.Tricorder.SocketSpec
       Unit.Tricorder.SourceLookupSpec
       Unit.Tricorder.SourceSpec

--- a/tricorder/app/Main.hs
+++ b/tricorder/app/Main.hs
@@ -21,7 +21,7 @@ import Atelier.Effects.Monitoring.Tracing (runTracingFromConfig)
 import Atelier.Effects.Posix.Daemons (runDaemons)
 import Tricorder.Arguments (runArguments)
 import Tricorder.BuildState (runDaemonInfo)
-import Tricorder.Config (runConfig)
+import Tricorder.Config (runLoadedConfig)
 import Tricorder.Effects.Brick (runBrick)
 import Tricorder.Effects.BrickChan (runBrickChan)
 import Tricorder.Effects.BuildStore (runBuildStore)
@@ -31,6 +31,7 @@ import Tricorder.Effects.Logging (runLogging)
 import Tricorder.Effects.TestRunner (runTestRunnerIO)
 import Tricorder.Effects.UnixSocket (runUnixSocketIO)
 import Tricorder.Runtime (runPidFile, runProjectRoot, runRuntimeDir, runSocketPath)
+import Tricorder.Session (runSession)
 
 import Atelier.Effects.Cache.Config qualified as CacheConfig
 import Tricorder qualified
@@ -55,7 +56,8 @@ main =
         . runRuntimeDir
         . runPidFile
         . runSocketPath
-        . runConfig
+        . runLoadedConfig
+        . runSession
         . runTracingFromConfig
         . runMetrics
         . runReader @CacheConfig.Config def

--- a/tricorder/src/Tricorder.hs
+++ b/tricorder/src/Tricorder.hs
@@ -22,7 +22,6 @@ import Atelier.Effects.Posix.Daemons (Daemons)
 import Tricorder.Arguments (Command (..))
 import Tricorder.BuildState (BuildState (..), DaemonInfo (..))
 import Tricorder.CLI (showLog, showSource, showStatus, showTests)
-import Tricorder.Config (Config)
 import Tricorder.Daemon (startDaemon, stopDaemon, waitForDaemon)
 import Tricorder.Effects.Brick (Brick)
 import Tricorder.Effects.BrickChan (BrickChan)
@@ -33,6 +32,7 @@ import Tricorder.Effects.TestRunner (TestRunner)
 import Tricorder.Effects.UnixSocket (UnixSocket)
 import Tricorder.GhcPkg.Types (ModuleName, PackageId)
 import Tricorder.Runtime (PidFile (..), SocketPath (..))
+import Tricorder.Session (Session)
 import Tricorder.Socket.Client (isDaemonRunning, queryStatus)
 import Tricorder.UI (viewUi)
 
@@ -61,9 +61,9 @@ run
        , IOE :> es
        , Log :> es
        , Reader Command :> es
-       , Reader Config :> es
        , Reader Observability.Config :> es
        , Reader PidFile :> es
+       , Reader Session :> es
        , Reader SocketPath :> es
        , TestRunner :> es
        , Timeout :> es

--- a/tricorder/src/Tricorder/BuildState.hs
+++ b/tricorder/src/Tricorder/BuildState.hs
@@ -26,8 +26,8 @@ import Effectful.Reader.Static (Reader, ask, runReader)
 import System.FilePath (makeRelative)
 
 import Atelier.Effects.FileSystem (FileSystem)
-import Tricorder.Config (Config (..), resolveWatchDirs)
 import Tricorder.Runtime (ProjectRoot (..), SocketPath (..))
+import Tricorder.Session (Session (..), resolveWatchDirs)
 
 import Tricorder.Observability qualified as Observability
 
@@ -50,9 +50,9 @@ data DaemonInfo = DaemonInfo
 
 runDaemonInfo
     :: ( FileSystem :> es
-       , Reader Config :> es
        , Reader Observability.Config :> es
        , Reader ProjectRoot :> es
+       , Reader Session :> es
        , Reader SocketPath :> es
        )
     => Eff (Reader DaemonInfo : es) a -> Eff es a

--- a/tricorder/src/Tricorder/Config.hs
+++ b/tricorder/src/Tricorder/Config.hs
@@ -1,88 +1,28 @@
-module Tricorder.Config
-    ( Config (..)
-    , loadTricorderConfig
-    , resolveCommand
-    , resolveTargets
-    , resolveTestTargets
-    , resolveWatchDirs
-    , allComponentTargets
-    , sourceDirsForTarget
-    , runConfig
-    ) where
+module Tricorder.Config (LoadedConfig (..), runLoadedConfig) where
 
-import Data.Aeson (FromJSON)
-import Data.Default (Default (..))
-import Data.List (nub)
-import Distribution.PackageDescription.Parsec (parseGenericPackageDescriptionMaybe)
-import Distribution.Types.BuildInfo (hsSourceDirs)
-import Distribution.Types.CondTree (condTreeData)
-import Distribution.Types.Executable (buildInfo)
-import Distribution.Types.GenericPackageDescription
-    ( GenericPackageDescription
-    , condExecutables
-    , condLibrary
-    , condSubLibraries
-    , condTestSuites
-    , packageDescription
-    )
-import Distribution.Types.Library (libBuildInfo)
-import Distribution.Types.PackageDescription (package)
-import Distribution.Types.PackageId (pkgName)
-import Distribution.Types.PackageName (unPackageName)
-import Distribution.Types.TestSuite (testBuildInfo)
-import Distribution.Types.UnqualComponentName (mkUnqualComponentName, unUnqualComponentName)
-import Distribution.Utils.Path (getSymbolicPath)
 import Effectful.Reader.Static (Reader, ask, runReader)
-import System.FilePath (takeExtension, (</>))
+import System.FilePath ((</>))
 
 import Data.Aeson qualified as Aeson
 import Data.Aeson.KeyMap qualified as KM
-import Data.Text qualified as T
 import Data.Yaml qualified as Yaml
 
-import Atelier.Config (LoadedConfig (..), extractConfig)
-import Atelier.Effects.FileSystem (FileSystem, doesFileExist, listDirectory, readFileBs)
-import Atelier.Effects.Monitoring.Tracing (TracingConfig)
-import Atelier.Types.QuietSnake (QuietSnake (..))
-import Atelier.Types.WithDefaults (WithDefaults (..))
+import Atelier.Config (LoadedConfig (..))
+import Atelier.Effects.FileSystem (FileSystem)
 import Tricorder.Runtime (ProjectRoot (..))
 
-import Tricorder.Observability qualified as Observability
-
-
-data Config = Config
-    { command :: Maybe Text
-    , targets :: [Text]
-    , watchDirs :: [FilePath]
-    , testTargets :: Maybe [Text]
-    , outputFile :: Maybe FilePath
-    , replBuildDir :: FilePath
-    }
-    deriving stock (Eq, Generic, Show)
-    deriving (FromJSON) via WithDefaults (QuietSnake Config)
-
-
-instance Default Config where
-    def =
-        Config
-            { command = Nothing
-            , targets = []
-            , watchDirs = []
-            , testTargets = Nothing
-            , outputFile = Just "build.json"
-            , replBuildDir = "dist-newstyle/tricorder"
-            }
+import Atelier.Effects.FileSystem qualified as FileSystem
 
 
 -- | Load config from .tricorder.yaml in the project root.
 -- Falls back to empty config (all defaults) if the file is absent or cannot be parsed.
 loadTricorderConfig :: (FileSystem :> es) => FilePath -> Eff es LoadedConfig
 loadTricorderConfig projectRoot = do
-    exists <- doesFileExist yamlPath
+    exists <- FileSystem.doesFileExist yamlPath
     if not exists then
         pure $ LoadedConfig (Aeson.Object KM.empty)
     else do
-        bs <- readFileBs yamlPath
+        bs <- FileSystem.readFileBs yamlPath
         pure . LoadedConfig $ case Yaml.decodeEither' @Aeson.Value bs of
             Left _ -> Aeson.Object KM.empty
             Right v -> v
@@ -90,132 +30,12 @@ loadTricorderConfig projectRoot = do
     yamlPath = projectRoot </> ".tricorder.yaml"
 
 
--- | Resolve the GHCi command, using config if set or autodetecting otherwise.
-resolveCommand :: (FileSystem :> es) => Config -> FilePath -> Eff es Text
-resolveCommand cfg projectRoot =
-    case cfg.command of
-        Just cmd -> pure cmd
-        Nothing -> detectCommand cfg.targets cfg.replBuildDir projectRoot
-
-
-detectCommand :: (FileSystem :> es) => [Text] -> FilePath -> FilePath -> Eff es Text
-detectCommand targets replBuildDir projectRoot = do
-    hasCabalProject <- doesFileExist (projectRoot </> "cabal.project")
-    cabalFiles <- filter (\f -> takeExtension f == ".cabal") <$> listDirectory projectRoot
-    hasStack <- doesFileExist (projectRoot </> "stack.yaml")
-    let targetStr = if null targets then "all" else unwords targets
-        buildDirFlag = "--builddir " <> toText replBuildDir <> " "
-    pure
-        $ if
-            | hasCabalProject -> "cabal repl --enable-multi-repl " <> buildDirFlag <> targetStr
-            | not (null cabalFiles) -> "cabal repl --enable-multi-repl " <> buildDirFlag <> targetStr
-            | hasStack -> "stack ghci " <> targetStr
-            | otherwise -> "cabal repl " <> buildDirFlag <> targetStr
-
-
--- | Resolve the directories to watch.
---
--- Priority:
--- 1. @watch_dirs@ from config, if non-empty (used as-is relative to project root)
--- 2. @hs-source-dirs@ inferred from cabal targets, if targets are set
--- 3. Falls back to @["."]@ (project root) if neither is available
-resolveWatchDirs :: (FileSystem :> es) => Config -> FilePath -> Eff es [FilePath]
-resolveWatchDirs cfg projectRoot =
-    case cfg.watchDirs of
-        dirs@(_ : _) -> pure (map (projectRoot </>) dirs)
-        [] -> resolveWatchDirsFromTargets cfg.targets projectRoot
-
-
-resolveWatchDirsFromTargets :: (FileSystem :> es) => [Text] -> FilePath -> Eff es [FilePath]
-resolveWatchDirsFromTargets [] _ = pure ["."]
-resolveWatchDirsFromTargets targets projectRoot = do
-    cabalFiles <- filter (\f -> takeExtension f == ".cabal") <$> listDirectory projectRoot
-    case cabalFiles of
-        [] -> pure ["."]
-        (cabalFile : _) -> do
-            contents <- readFileBs (projectRoot </> cabalFile)
-            case parseGenericPackageDescriptionMaybe contents of
-                Nothing -> pure ["."]
-                Just gpd ->
-                    let dirs = nub $ concatMap (sourceDirsForTarget gpd) targets
-                    in  pure $ if null dirs then ["."] else map (projectRoot </>) dirs
-
-
--- | Infer the effective targets to build and watch.
--- Returns the configured targets as-is, or auto-detects all components
--- from the .cabal file when no targets are configured.
-resolveTargets :: (FileSystem :> es) => [Text] -> FilePath -> Eff es [Text]
-resolveTargets targets@(_ : _) _ = pure targets
-resolveTargets [] projectRoot = do
-    cabalFiles <- filter (\f -> takeExtension f == ".cabal") <$> listDirectory projectRoot
-    case cabalFiles of
-        [] -> pure []
-        (cabalFile : _) -> do
-            contents <- readFileBs (projectRoot </> cabalFile)
-            pure $ maybe [] allComponentTargets (parseGenericPackageDescriptionMaybe contents)
-
-
-allComponentTargets :: GenericPackageDescription -> [Text]
-allComponentTargets gpd =
-    mainLibTargets
-        ++ subLibTargets
-        ++ exeTargets
-        ++ testTargets
-  where
-    mainPkgName = toText $ unPackageName . pkgName . package . packageDescription $ gpd
-    mainLibTargets = maybe [] (const ["lib:" <> mainPkgName]) (condLibrary gpd)
-    subLibTargets = map (\(n, _) -> "lib:" <> toText (unUnqualComponentName n)) (condSubLibraries gpd)
-    exeTargets = map (\(n, _) -> "exe:" <> toText (unUnqualComponentName n)) (condExecutables gpd)
-    testTargets = map (\(n, _) -> "test:" <> toText (unUnqualComponentName n)) (condTestSuites gpd)
-
-
-sourceDirsForTarget :: GenericPackageDescription -> Text -> [FilePath]
-sourceDirsForTarget gpd target =
-    map getSymbolicPath $ case T.splitOn ":" target of
-        ["lib", ""] ->
-            maybe [] (libDirs . condTreeData) (condLibrary gpd)
-        ["lib", name] ->
-            let ucn = mkUnqualComponentName (toString name)
-                mainLibName = unPackageName . pkgName . package . packageDescription $ gpd
-            in  if toString name == mainLibName then
-                    maybe [] (libDirs . condTreeData) (condLibrary gpd)
-                else
-                    concatMap (libDirs . condTreeData . snd) $ filter ((== ucn) . fst) (condSubLibraries gpd)
-        ["test", name] ->
-            let ucn = mkUnqualComponentName (toString name)
-            in  concatMap (testDirs . condTreeData . snd) $ filter ((== ucn) . fst) (condTestSuites gpd)
-        ["exe", name] ->
-            let ucn = mkUnqualComponentName (toString name)
-            in  concatMap (exeDirs . condTreeData . snd) $ filter ((== ucn) . fst) (condExecutables gpd)
-        _ -> []
-  where
-    libDirs = hsSourceDirs . libBuildInfo
-    testDirs = hsSourceDirs . testBuildInfo
-    exeDirs = hsSourceDirs . buildInfo
-
-
--- | Resolve which test suites to run after a clean build.
---
--- When 'testTargets' is set in config, those suites are used directly.
--- Otherwise, all @test:@ components in 'targets' are inferred.
-resolveTestTargets :: Config -> [Text]
-resolveTestTargets cfg = case cfg.testTargets of
-    Just explicit -> explicit
-    Nothing -> filter ("test:" `T.isPrefixOf`) cfg.targets
-
-
-runConfig
+runLoadedConfig
     :: ( FileSystem :> es
-       , HasCallStack
        , Reader ProjectRoot :> es
        )
-    => Eff (Reader Config : Reader Observability.Config : Reader TracingConfig : es) a
-    -> Eff es a
-runConfig act = do
+    => Eff (Reader LoadedConfig : es) a -> Eff es a
+runLoadedConfig act = do
     ProjectRoot projectRoot <- ask
-    loadedCfg <- loadTricorderConfig projectRoot
-    let cfg = extractConfig @"session" loadedCfg
-        obsCfg = extractConfig @"observability" loadedCfg
-    effectiveTargets <- resolveTargets cfg.targets projectRoot
-    let cfg' = cfg {targets = effectiveTargets}
-    runReader obsCfg.tracing $ runReader obsCfg $ runReader cfg' act
+    cfg <- loadTricorderConfig projectRoot
+    runReader cfg act

--- a/tricorder/src/Tricorder/Daemon.hs
+++ b/tricorder/src/Tricorder/Daemon.hs
@@ -25,7 +25,6 @@ import Atelier.Effects.Log (Log)
 import Atelier.Effects.Monitoring.Tracing (Tracing)
 import Atelier.Effects.Posix.Daemons (Daemons)
 import Atelier.Time (Millisecond)
-import Tricorder.Config (Config (..))
 import Tricorder.Effects.BuildStore (BuildStore)
 import Tricorder.Effects.GhcPkg (GhcPkg)
 import Tricorder.Effects.GhciSession (GhciSession)
@@ -33,6 +32,7 @@ import Tricorder.Effects.TestRunner (TestRunner)
 import Tricorder.Effects.UnixSocket (UnixSocket)
 import Tricorder.GhcPkg.Types (ModuleName, PackageId)
 import Tricorder.Runtime (PidFile, SocketPath (..))
+import Tricorder.Session (Session (..))
 import Tricorder.Socket.Client (isDaemonRunning, requestShutdown)
 
 import Atelier.Effects.Delay qualified as Delay
@@ -60,8 +60,8 @@ runDaemon
        , GhciSession :> es
        , IOE :> es
        , Log :> es
-       , Reader Config :> es
        , Reader Observability.Config :> es
+       , Reader Session :> es
        , Reader SocketPath :> es
        , TestRunner :> es
        , Tracing :> es
@@ -95,9 +95,9 @@ startDaemon
        , GhciSession :> es
        , IOE :> es
        , Log :> es
-       , Reader Config :> es
        , Reader Observability.Config :> es
        , Reader PidFile :> es
+       , Reader Session :> es
        , Reader SocketPath :> es
        , TestRunner :> es
        , Tracing :> es

--- a/tricorder/src/Tricorder/GhciSession.hs
+++ b/tricorder/src/Tricorder/GhciSession.hs
@@ -20,11 +20,19 @@ import Atelier.Effects.FileSystem (FileSystem, getCurrentDirectory)
 import Atelier.Effects.Log (Log)
 import Atelier.Exception (isGracefulShutdown)
 import Atelier.Time (Millisecond)
-import Tricorder.BuildState (BuildId (..), BuildPhase (..), BuildResult (..), ChangeKind (..), Diagnostic (..), Severity (..), TestRun (..))
-import Tricorder.Config (Config (..), resolveCommand, resolveTestTargets, resolveWatchDirs)
+import Tricorder.BuildState
+    ( BuildId (..)
+    , BuildPhase (..)
+    , BuildResult (..)
+    , ChangeKind (..)
+    , Diagnostic (..)
+    , Severity (..)
+    , TestRun (..)
+    )
 import Tricorder.Effects.BuildStore (BuildStore)
 import Tricorder.Effects.GhciSession (GhciSession, LoadResult (..))
 import Tricorder.Effects.TestRunner (TestRunner)
+import Tricorder.Session (Session (..), resolveCommand, resolveTestTargets, resolveWatchDirs)
 
 import Atelier.Effects.Clock qualified as Clock
 import Atelier.Effects.Delay qualified as Delay
@@ -83,7 +91,7 @@ component
        , FileSystem :> es
        , GhciSession :> es
        , Log :> es
-       , Reader Config :> es
+       , Reader Session :> es
        , TestRunner :> es
        )
     => Component es
@@ -91,7 +99,7 @@ component =
     defaultComponent
         { name = "GhciSession"
         , listeners = do
-            cfg <- ask @Config
+            cfg <- ask @Session
             projectRoot <- getCurrentDirectory
             cmd <- resolveCommand cfg projectRoot
             watchDirs <- resolveWatchDirs cfg projectRoot

--- a/tricorder/src/Tricorder/Session.hs
+++ b/tricorder/src/Tricorder/Session.hs
@@ -1,0 +1,202 @@
+module Tricorder.Session
+    ( Session (..)
+    , resolveCommand
+    , resolveTargets
+    , resolveTestTargets
+    , resolveWatchDirs
+    , allComponentTargets
+    , sourceDirsForTarget
+    , runSession
+    ) where
+
+import Data.Aeson (FromJSON)
+import Data.Default (Default (..))
+import Data.List (nub)
+import Distribution.PackageDescription.Parsec (parseGenericPackageDescriptionMaybe)
+import Distribution.Types.BuildInfo (hsSourceDirs)
+import Distribution.Types.CondTree (condTreeData)
+import Distribution.Types.Executable (buildInfo)
+import Distribution.Types.GenericPackageDescription
+    ( GenericPackageDescription
+    , condExecutables
+    , condLibrary
+    , condSubLibraries
+    , condTestSuites
+    , packageDescription
+    )
+import Distribution.Types.Library (libBuildInfo)
+import Distribution.Types.PackageDescription (package)
+import Distribution.Types.PackageId (pkgName)
+import Distribution.Types.PackageName (unPackageName)
+import Distribution.Types.TestSuite (testBuildInfo)
+import Distribution.Types.UnqualComponentName (mkUnqualComponentName, unUnqualComponentName)
+import Distribution.Utils.Path (getSymbolicPath)
+import Effectful.Reader.Static (Reader, ask, runReader)
+import System.FilePath (takeExtension, (</>))
+
+import Data.Text qualified as T
+
+import Atelier.Config (LoadedConfig, extractConfig)
+import Atelier.Effects.FileSystem (FileSystem, doesFileExist, listDirectory, readFileBs)
+import Atelier.Effects.Monitoring.Tracing (TracingConfig)
+import Atelier.Types.QuietSnake (QuietSnake (..))
+import Atelier.Types.WithDefaults (WithDefaults (..))
+import Tricorder.Runtime (ProjectRoot (..))
+
+import Tricorder.Observability qualified as Observability
+
+
+data Session = Session
+    { command :: Maybe Text
+    , targets :: [Text]
+    , watchDirs :: [FilePath]
+    , testTargets :: Maybe [Text]
+    , outputFile :: Maybe FilePath
+    , replBuildDir :: FilePath
+    }
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON) via WithDefaults (QuietSnake Session)
+
+
+instance Default Session where
+    def =
+        Session
+            { command = Nothing
+            , targets = []
+            , watchDirs = []
+            , testTargets = Nothing
+            , outputFile = Just "build.json"
+            , replBuildDir = "dist-newstyle/tricorder"
+            }
+
+
+-- | Resolve the GHCi command, using config if set or autodetecting otherwise.
+resolveCommand :: (FileSystem :> es) => Session -> FilePath -> Eff es Text
+resolveCommand cfg projectRoot =
+    case cfg.command of
+        Just cmd -> pure cmd
+        Nothing -> detectCommand cfg.targets cfg.replBuildDir projectRoot
+
+
+detectCommand :: (FileSystem :> es) => [Text] -> FilePath -> FilePath -> Eff es Text
+detectCommand targets replBuildDir projectRoot = do
+    hasCabalProject <- doesFileExist (projectRoot </> "cabal.project")
+    cabalFiles <- filter (\f -> takeExtension f == ".cabal") <$> listDirectory projectRoot
+    hasStack <- doesFileExist (projectRoot </> "stack.yaml")
+    let targetStr = if null targets then "all" else unwords targets
+        buildDirFlag = "--builddir " <> toText replBuildDir <> " "
+    pure
+        $ if
+            | hasCabalProject -> "cabal repl --enable-multi-repl " <> buildDirFlag <> targetStr
+            | not (null cabalFiles) -> "cabal repl --enable-multi-repl " <> buildDirFlag <> targetStr
+            | hasStack -> "stack ghci " <> targetStr
+            | otherwise -> "cabal repl " <> buildDirFlag <> targetStr
+
+
+-- | Resolve the directories to watch.
+--
+-- Priority:
+-- 1. @watch_dirs@ from config, if non-empty (used as-is relative to project root)
+-- 2. @hs-source-dirs@ inferred from cabal targets, if targets are set
+-- 3. Falls back to @["."]@ (project root) if neither is available
+resolveWatchDirs :: (FileSystem :> es) => Session -> FilePath -> Eff es [FilePath]
+resolveWatchDirs cfg projectRoot =
+    case cfg.watchDirs of
+        dirs@(_ : _) -> pure (map (projectRoot </>) dirs)
+        [] -> resolveWatchDirsFromTargets cfg.targets projectRoot
+
+
+resolveWatchDirsFromTargets :: (FileSystem :> es) => [Text] -> FilePath -> Eff es [FilePath]
+resolveWatchDirsFromTargets [] _ = pure ["."]
+resolveWatchDirsFromTargets targets projectRoot = do
+    cabalFiles <- filter (\f -> takeExtension f == ".cabal") <$> listDirectory projectRoot
+    case cabalFiles of
+        [] -> pure ["."]
+        (cabalFile : _) -> do
+            contents <- readFileBs (projectRoot </> cabalFile)
+            case parseGenericPackageDescriptionMaybe contents of
+                Nothing -> pure ["."]
+                Just gpd ->
+                    let dirs = nub $ concatMap (sourceDirsForTarget gpd) targets
+                    in  pure $ if null dirs then ["."] else map (projectRoot </>) dirs
+
+
+-- | Infer the effective targets to build and watch.
+-- Returns the configured targets as-is, or auto-detects all components
+-- from the .cabal file when no targets are configured.
+resolveTargets :: (FileSystem :> es) => [Text] -> FilePath -> Eff es [Text]
+resolveTargets targets@(_ : _) _ = pure targets
+resolveTargets [] projectRoot = do
+    cabalFiles <- filter (\f -> takeExtension f == ".cabal") <$> listDirectory projectRoot
+    case cabalFiles of
+        [] -> pure []
+        (cabalFile : _) -> do
+            contents <- readFileBs (projectRoot </> cabalFile)
+            pure $ maybe [] allComponentTargets (parseGenericPackageDescriptionMaybe contents)
+
+
+allComponentTargets :: GenericPackageDescription -> [Text]
+allComponentTargets gpd =
+    mainLibTargets
+        ++ subLibTargets
+        ++ exeTargets
+        ++ testTargets
+  where
+    mainPkgName = toText $ unPackageName . pkgName . package . packageDescription $ gpd
+    mainLibTargets = maybe [] (const ["lib:" <> mainPkgName]) (condLibrary gpd)
+    subLibTargets = map (\(n, _) -> "lib:" <> toText (unUnqualComponentName n)) (condSubLibraries gpd)
+    exeTargets = map (\(n, _) -> "exe:" <> toText (unUnqualComponentName n)) (condExecutables gpd)
+    testTargets = map (\(n, _) -> "test:" <> toText (unUnqualComponentName n)) (condTestSuites gpd)
+
+
+sourceDirsForTarget :: GenericPackageDescription -> Text -> [FilePath]
+sourceDirsForTarget gpd target =
+    map getSymbolicPath $ case T.splitOn ":" target of
+        ["lib", ""] ->
+            maybe [] (libDirs . condTreeData) (condLibrary gpd)
+        ["lib", name] ->
+            let ucn = mkUnqualComponentName (toString name)
+                mainLibName = unPackageName . pkgName . package . packageDescription $ gpd
+            in  if toString name == mainLibName then
+                    maybe [] (libDirs . condTreeData) (condLibrary gpd)
+                else
+                    concatMap (libDirs . condTreeData . snd) $ filter ((== ucn) . fst) (condSubLibraries gpd)
+        ["test", name] ->
+            let ucn = mkUnqualComponentName (toString name)
+            in  concatMap (testDirs . condTreeData . snd) $ filter ((== ucn) . fst) (condTestSuites gpd)
+        ["exe", name] ->
+            let ucn = mkUnqualComponentName (toString name)
+            in  concatMap (exeDirs . condTreeData . snd) $ filter ((== ucn) . fst) (condExecutables gpd)
+        _ -> []
+  where
+    libDirs = hsSourceDirs . libBuildInfo
+    testDirs = hsSourceDirs . testBuildInfo
+    exeDirs = hsSourceDirs . buildInfo
+
+
+-- | Resolve which test suites to run after a clean build.
+--
+-- When 'testTargets' is set in config, those suites are used directly.
+-- Otherwise, all @test:@ components in 'targets' are inferred.
+resolveTestTargets :: Session -> [Text]
+resolveTestTargets cfg = case cfg.testTargets of
+    Just explicit -> explicit
+    Nothing -> filter ("test:" `T.isPrefixOf`) cfg.targets
+
+
+runSession
+    :: ( FileSystem :> es
+       , HasCallStack
+       , Reader LoadedConfig :> es
+       , Reader ProjectRoot :> es
+       )
+    => Eff (Reader Session : Reader Observability.Config : Reader TracingConfig : es) a
+    -> Eff es a
+runSession act = do
+    ProjectRoot projectRoot <- ask
+    loadedCfg <- ask
+    let cfg = extractConfig @"session" loadedCfg
+        obsCfg = extractConfig @"observability" loadedCfg
+    effectiveTargets <- resolveTargets cfg.targets projectRoot
+    let cfg' = cfg {targets = effectiveTargets}
+    runReader obsCfg.tracing $ runReader obsCfg $ runReader cfg' act

--- a/tricorder/src/Tricorder/Watcher.hs
+++ b/tricorder/src/Tricorder/Watcher.hs
@@ -10,8 +10,8 @@ import Atelier.Effects.Debounce (Debounce)
 import Atelier.Effects.FileSystem (FileSystem, getCurrentDirectory)
 import Atelier.Effects.FileWatcher (FileWatcher, Watch, containing, dirExt, dirWhere, excluding, watchFilePathsDebounced)
 import Tricorder.BuildState (ChangeKind (..))
-import Tricorder.Config (Config (..), resolveWatchDirs)
 import Tricorder.Effects.BuildStore (BuildStore, markDirty)
+import Tricorder.Session (Session (..), resolveWatchDirs)
 
 
 -- | Watcher component.
@@ -23,14 +23,14 @@ component
        , Debounce FilePath :> es
        , FileSystem :> es
        , FileWatcher :> es
-       , Reader Config :> es
+       , Reader Session :> es
        )
     => Component es
 component =
     defaultComponent
         { name = "Watcher"
         , triggers = do
-            cfg <- ask @Config
+            cfg <- ask @Session
             projectRoot <- getCurrentDirectory
             dirs <- resolveWatchDirs cfg projectRoot
             let watches = sourceWatches dirs <> cabalWatches projectRoot

--- a/tricorder/test/Unit/Tricorder/SessionSpec.hs
+++ b/tricorder/test/Unit/Tricorder/SessionSpec.hs
@@ -1,15 +1,15 @@
-module Unit.Tricorder.ConfigSpec (spec_Config) where
+module Unit.Tricorder.SessionSpec (spec_Session) where
 
 import Data.Default (Default (..))
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescriptionMaybe)
 import Distribution.Types.GenericPackageDescription (GenericPackageDescription)
 import Test.Hspec
 
-import Tricorder.Config (Config (..), allComponentTargets, resolveTestTargets, sourceDirsForTarget)
+import Tricorder.Session (Session (..), allComponentTargets, resolveTestTargets, sourceDirsForTarget)
 
 
-spec_Config :: Spec
-spec_Config = do
+spec_Session :: Spec
+spec_Session = do
     describe "resolveTestTargets" testResolveTestTargets
     describe "sourceDirsForTarget" do
         describe "lib:" do


### PR DESCRIPTION
It's been a bit confusing to me, until I started working to separate the effect stacks of the daemon and the CLI, that the `Config` record is used so sparingly. Seems that is because it is _only_ used by the daemon, and contains configuration that pertains to a given session/repo. As such, I suggest we rename this record to `Session` (or any better suggestion you might have) to better distinguish it from "configuration for everything" (which is currently in `Tricorder.Runtime`.)