### PR TITLE
refactor: parse more complex configuration values in Session

### DIFF
--- a/atelier/src/Atelier/Effects/FileSystem.hs
+++ b/atelier/src/Atelier/Effects/FileSystem.hs
@@ -14,17 +14,22 @@ module Atelier.Effects.FileSystem
     , getXdgRuntimeDir
     , runFileSystemIO
     , runFileSystemNoOp
+    , runFileSystemState
     ) where
 
 import Control.Exception (bracket)
 import Effectful (Effect, IOE)
 import Effectful.Dispatch.Dynamic (interpret_)
+import Effectful.Exception (throwIO)
+import Effectful.State.Static.Shared (State, gets, modify)
 import Effectful.TH (makeEffect)
 import System.Environment (lookupEnv)
-import System.Posix.Types (FileOffset)
+import System.IO.Error (userError)
+import System.Posix.Types (COff (..), FileOffset)
 
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as LBS
+import Data.Map.Strict qualified as M
 import System.Directory qualified as Dir
 import System.Posix.IO qualified as Posix
 
@@ -101,4 +106,32 @@ runFileSystemNoOp = interpret_ $ \case
     RemoveFile _ -> pure ()
     CanonicalizePath path -> pure path
     GetCurrentDirectory -> pure "."
+    GetXdgRuntimeDir -> pure "/tmp"
+
+
+-- | Run `FileSystem` effect backed by a `State` effect with a `Map`. The keys
+-- of the `Map` are treated as file names. Only the `dirname` of files are
+-- counted as existing directories.
+runFileSystemState
+    :: (State (Map FilePath ByteString) :> es)
+    => Eff (FileSystem : es) a -> Eff es a
+runFileSystemState = interpret_ \case
+    ReadFileBs fp ->
+        maybe (throwIO $ userError "No such file") pure
+            =<< gets (M.lookup fp)
+    ReadFileLbsFrom fp (COff offset) -> do
+        contents <-
+            maybe (throwIO $ userError "No such file") pure
+                =<< gets (M.lookup fp)
+        pure
+            . toLazy
+            . BS.drop (fromIntegral offset)
+            $ contents
+    DoesFileExist fp -> gets $ M.member fp
+    DoesPathExist fp -> gets $ any (\p -> fp `isPrefixOf` p && fp /= p) . M.keys
+    ListDirectory fp -> gets $ filter (\p -> fp `isPrefixOf` p && fp /= p) . M.keys
+    CreateDirectoryIfMissing _ _ -> pure ()
+    RemoveFile fp -> modify $ M.delete fp
+    CanonicalizePath fp -> pure fp
+    GetCurrentDirectory -> pure "/"
     GetXdgRuntimeDir -> pure "/tmp"

--- a/atelier/test/Unit/Atelier/Effects/FileSystemSpec.hs
+++ b/atelier/test/Unit/Atelier/Effects/FileSystemSpec.hs
@@ -1,0 +1,138 @@
+module Unit.Atelier.Effects.FileSystemSpec (spec_FileSystem) where
+
+import Control.Exception (evaluate)
+import Effectful (runPureEff)
+import Effectful.State.Static.Shared (State, evalState)
+import Test.Hspec (Spec, anyIOException, describe, it, shouldBe, shouldThrow)
+
+import Data.ByteString.Lazy qualified as LBS
+import Data.Map.Strict qualified as M
+
+import Atelier.Effects.FileSystem
+
+
+spec_FileSystem :: Spec
+spec_FileSystem = describe "runFileSystemState" testFileSystemState
+
+
+testFileSystemState :: Spec
+testFileSystemState = do
+    describe "readFileBs" do
+        it "reads bytes of a file present in the state" do
+            run (M.singleton "/a" "hello") (readFileBs "/a")
+                `shouldBe` "hello"
+
+        it "errors when the file is absent" do
+            evaluate (run M.empty (readFileBs "/missing"))
+                `shouldThrow` anyIOException
+
+    describe "readFileLbs" do
+        it "reads the entire file as lazy bytes" do
+            run (M.singleton "/a" "hello") (readFileLbs "/a")
+                `shouldBe` ("hello" :: LBS.ByteString)
+
+        it "errors when the file is absent" do
+            evaluate (run M.empty (readFileLbs "/missing"))
+                `shouldThrow` anyIOException
+
+    describe "readFileLbsFrom" do
+        it "returns full content when offset is 0" do
+            run (M.singleton "/a" "hello") (readFileLbsFrom "/a" 0)
+                `shouldBe` ("hello" :: LBS.ByteString)
+
+        it "skips the leading bytes up to the given offset" do
+            run (M.singleton "/a" "hello") (readFileLbsFrom "/a" 2)
+                `shouldBe` ("llo" :: LBS.ByteString)
+
+        it "returns empty when offset equals the file length" do
+            run (M.singleton "/a" "hello") (readFileLbsFrom "/a" 5)
+                `shouldBe` ("" :: LBS.ByteString)
+
+        it "errors when the file is absent" do
+            evaluate (run M.empty (readFileLbsFrom "/missing" 0))
+                `shouldThrow` anyIOException
+
+    describe "doesFileExist" do
+        it "returns True for a key present in the state" do
+            run (M.singleton "/a" "") (doesFileExist "/a")
+                `shouldBe` True
+
+        it "returns False when the key is absent" do
+            run M.empty (doesFileExist "/a")
+                `shouldBe` False
+
+    describe "doesPathExist" do
+        it "returns True when a key with the path as a string prefix exists" do
+            run (M.singleton "/dir/file" "") (doesPathExist "/dir")
+                `shouldBe` True
+
+        it "returns False when no key shares the prefix" do
+            run M.empty (doesPathExist "/dir")
+                `shouldBe` False
+
+        it "returns False for an exact-match key with no children" do
+            run (M.singleton "/dir" "") (doesPathExist "/dir")
+                `shouldBe` False
+
+    describe "listDirectory" do
+        it "returns all keys that start with the given path" do
+            let fs = M.fromList [("/dir/a", ""), ("/dir/b", ""), ("/other/c", "")]
+            sort (run fs (listDirectory "/dir"))
+                `shouldBe` ["/dir/a", "/dir/b"]
+
+        it "returns empty list when no keys share the prefix" do
+            run M.empty (listDirectory "/dir")
+                `shouldBe` []
+
+        it "excludes an exact-match key" do
+            let fs = M.fromList [("/dir", ""), ("/dir/a", "")]
+            run fs (listDirectory "/dir")
+                `shouldBe` ["/dir/a"]
+
+    describe "removeFile" do
+        it "removes the file from the state" do
+            let result = run (M.singleton "/a" "x") do
+                    removeFile "/a"
+                    doesFileExist "/a"
+            result `shouldBe` False
+
+        it "leaves other files unaffected" do
+            let result = run (M.fromList [("/a", "x"), ("/b", "y")]) do
+                    removeFile "/a"
+                    doesFileExist "/b"
+            result `shouldBe` True
+
+        it "is a no-op when the file is absent" do
+            let result = run M.empty do
+                    removeFile "/missing"
+                    doesFileExist "/missing"
+            result `shouldBe` False
+
+    describe "createDirectoryIfMissing" do
+        it "is a no-op — does not add any entries to the state" do
+            let result = run M.empty do
+                    createDirectoryIfMissing True "/new/dir"
+                    doesPathExist "/new/dir"
+            result `shouldBe` False
+
+    describe "canonicalizePath" do
+        it "returns the path unchanged" do
+            run M.empty (canonicalizePath "/some/./path")
+                `shouldBe` "/some/./path"
+
+    describe "getCurrentDirectory" do
+        it "returns /" do
+            run M.empty getCurrentDirectory
+                `shouldBe` "/"
+
+    describe "getXdgRuntimeDir" do
+        it "returns /tmp" do
+            run M.empty getXdgRuntimeDir
+                `shouldBe` "/tmp"
+
+
+run
+    :: Map FilePath ByteString
+    -> Eff '[FileSystem, State (Map FilePath ByteString)] a
+    -> a
+run fs = runPureEff . evalState fs . runFileSystemState

--- a/tricorder.cabal
+++ b/tricorder.cabal
@@ -382,6 +382,7 @@ test-suite atelier-test
       Unit.Atelier.Effects.ConsoleSpec
       Unit.Atelier.Effects.DebounceSpec
       Unit.Atelier.Effects.DelaySpec
+      Unit.Atelier.Effects.FileSystemSpec
       Unit.Atelier.Effects.FileWatcherSpec
       Unit.Atelier.Effects.LogSpec
       Unit.Atelier.Effects.PublishingSpec

--- a/tricorder/src/Tricorder/BuildState.hs
+++ b/tricorder/src/Tricorder/BuildState.hs
@@ -25,9 +25,8 @@ import Effectful.Concurrent.STM (TVar)
 import Effectful.Reader.Static (Reader, ask, runReader)
 import System.FilePath (makeRelative)
 
-import Atelier.Effects.FileSystem (FileSystem)
 import Tricorder.Runtime (ProjectRoot (..), SocketPath (..))
-import Tricorder.Session (Session (..), resolveWatchDirs)
+import Tricorder.Session (Session (..))
 
 import Tricorder.Observability qualified as Observability
 
@@ -49,23 +48,21 @@ data DaemonInfo = DaemonInfo
 
 
 runDaemonInfo
-    :: ( FileSystem :> es
-       , Reader Observability.Config :> es
+    :: ( Reader Observability.Config :> es
        , Reader ProjectRoot :> es
        , Reader Session :> es
        , Reader SocketPath :> es
        )
     => Eff (Reader DaemonInfo : es) a -> Eff es a
 runDaemonInfo act = do
-    cfg <- ask
+    session <- ask @Session
     obsCfg <- ask @Observability.Config
     ProjectRoot projectRoot <- ask
     SocketPath sockPath <- ask
-    watchDirs <- resolveWatchDirs cfg projectRoot
     let daemonInfo =
             DaemonInfo
-                { targets = cfg.targets
-                , watchDirs = map (makeRelative projectRoot) watchDirs
+                { targets = session.targets
+                , watchDirs = map (makeRelative projectRoot) session.watchDirs
                 , sockPath
                 , logFile = obsCfg.logFile
                 , metricsPort = if obsCfg.metrics.enabled then Just obsCfg.metrics.port else Nothing

--- a/tricorder/src/Tricorder/Effects/GhciSession.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession.hs
@@ -34,6 +34,7 @@ import Atelier.Effects.Log (Log)
 import Atelier.Exception (trySyncIO)
 import Tricorder.BuildState (BuildPhase (..), BuildProgress (..), Diagnostic (..), Severity (..))
 import Tricorder.Effects.BuildStore (BuildStore, getState, setPhase)
+import Tricorder.Runtime (ProjectRoot (..))
 
 import Atelier.Effects.Log qualified as Log
 import Tricorder.BuildState qualified as BuildState
@@ -56,7 +57,7 @@ data GhciSession :: Effect where
     -- The handler is also provided an action to reload the GHCi session,
     -- returning new messages with module counts. The GHCi session is closed
     -- when the handler returns.
-    WithGhci :: Text -> FilePath -> (LoadResult -> m LoadResult -> m a) -> GhciSession m a
+    WithGhci :: Text -> ProjectRoot -> (LoadResult -> m LoadResult -> m a) -> GhciSession m a
 
 
 makeEffect ''GhciSession
@@ -66,7 +67,7 @@ makeEffect ''GhciSession
 -- Manages the 'Ghcid.Ghci' handle via 'State'.
 runGhciSessionIO :: (BuildStore :> es, IOE :> es, Log :> es) => Eff (GhciSession : es) a -> Eff es a
 runGhciSessionIO = interpret $ \env -> \case
-    WithGhci cmd dir handler -> do
+    WithGhci cmd (ProjectRoot dir) handler -> do
         let mkSession = withEffToIO (ConcUnlift Persistent Unlimited) \unlift -> do
                 Ghcid.startGhci (toString cmd) (Just dir) \_ line -> do
                     unlift $ Log.debug $ "GhciSession callback: " <> toText line

--- a/tricorder/src/Tricorder/GhciSession.hs
+++ b/tricorder/src/Tricorder/GhciSession.hs
@@ -16,7 +16,6 @@ import Data.Map.Strict qualified as Map
 import Atelier.Component (Component (..), Listener, defaultComponent)
 import Atelier.Effects.Clock (Clock, UTCTime)
 import Atelier.Effects.Delay (Delay)
-import Atelier.Effects.FileSystem (FileSystem, getCurrentDirectory)
 import Atelier.Effects.Log (Log)
 import Atelier.Exception (isGracefulShutdown)
 import Atelier.Time (Millisecond)
@@ -32,7 +31,8 @@ import Tricorder.BuildState
 import Tricorder.Effects.BuildStore (BuildStore)
 import Tricorder.Effects.GhciSession (GhciSession, LoadResult (..))
 import Tricorder.Effects.TestRunner (TestRunner)
-import Tricorder.Session (Session (..), resolveCommand, resolveTestTargets, resolveWatchDirs)
+import Tricorder.Runtime (ProjectRoot (..))
+import Tricorder.Session (Session (..))
 
 import Atelier.Effects.Clock qualified as Clock
 import Atelier.Effects.Delay qualified as Delay
@@ -61,9 +61,9 @@ mergeDiagnostics prev LoadResult {compiledFiles, diagnostics} =
 -- those with mangled filenames produced by the C preprocessor (e.g.
 -- @"In file included from ..."@) are dropped here, before they can enter the
 -- accumulation map where they would be impossible to evict.
-filterToWatchDirs :: FilePath -> [FilePath] -> [Diagnostic] -> [Diagnostic]
-filterToWatchDirs _ [] diags = diags
-filterToWatchDirs projectRoot watchDirs diags =
+filterToWatchDirs :: ProjectRoot -> Session -> [Diagnostic] -> [Diagnostic]
+filterToWatchDirs _ (Session {watchDirs = []}) diags = diags
+filterToWatchDirs (ProjectRoot projectRoot) (Session {watchDirs}) diags =
     filter (isUnderAnyWatchDir . (.file)) diags
   where
     absWatchDirs = map toAbsWd watchDirs
@@ -88,9 +88,9 @@ component
     :: ( BuildStore :> es
        , Clock :> es
        , Delay :> es
-       , FileSystem :> es
        , GhciSession :> es
        , Log :> es
+       , Reader ProjectRoot :> es
        , Reader Session :> es
        , TestRunner :> es
        )
@@ -99,14 +99,11 @@ component =
     defaultComponent
         { name = "GhciSession"
         , listeners = do
-            cfg <- ask @Session
-            projectRoot <- getCurrentDirectory
-            cmd <- resolveCommand cfg projectRoot
-            watchDirs <- resolveWatchDirs cfg projectRoot
-            let testTargets = resolveTestTargets cfg
-            Log.debug $ "GhciSession.component: resolved command = " <> cmd
-            Log.debug $ "GhciSession.component: projectRoot = " <> toText projectRoot
-            pure [sessionListener cmd projectRoot watchDirs testTargets]
+            session <- ask @Session
+            projectRoot <- ask
+            Log.debug $ "GhciSession.component: resolved command = " <> session.command
+            Log.debug $ "GhciSession.component: projectRoot = " <> toText (getProjectRoot projectRoot)
+            pure [sessionListener session projectRoot]
         }
 
 
@@ -123,24 +120,22 @@ sessionListener
        , Log :> es
        , TestRunner :> es
        )
-    => Text
-    -> FilePath
-    -> [FilePath]
-    -> [Text]
+    => Session
+    -> ProjectRoot
     -> Listener es
-sessionListener cmd projectRoot watchDirs testTargets = initSession (BuildId 1)
+sessionListener session projectRoot = initSession (BuildId 1)
   where
     initSession (BuildId n) = do
-        Log.info $ "Starting GHCi session #" <> show n <> ": " <> cmd
+        Log.info $ "Starting GHCi session #" <> show n <> ": " <> session.command
         BuildStore.setPhase (BuildId n) $ Building Nothing
         t0 <- Clock.currentTime
-        res <- trySync $ GhciSession.withGhci cmd projectRoot \initialLoad@LoadResult {diagnostics = msgs} reload -> do
+        res <- trySync $ GhciSession.withGhci session.command projectRoot \initialLoad@LoadResult {diagnostics = msgs} reload -> do
             t1 <- Clock.currentTime
             let filteredMsgs = filterDiags msgs
-                partialResult = loadResultToBuildResult projectRoot watchDirs t0 t1 initialLoad
+                partialResult = loadResultToBuildResult projectRoot session t0 t1 initialLoad
                 accumulated = Map.fromListWith (++) [(d.file, [d]) | d <- filteredMsgs]
             Log.info $ "GHCi started (session #" <> show n <> "): " <> show (length filteredMsgs) <> " diagnostics"
-            testRuns <- runTestsIfClean testTargets (BuildId n) partialResult
+            testRuns <- runTestsIfClean session (BuildId n) partialResult
             BuildStore.setPhase (BuildId n) $ Done partialResult {testRuns}
             Log.debug $ "Build state updated to Done (session #" <> show n <> ")"
             loopSession reload (BuildId (n + 1)) accumulated
@@ -185,19 +180,19 @@ sessionListener cmd projectRoot watchDirs testTargets = initSession (BuildId 1)
                             newAccumulated = mergeDiagnostics accumulated filteredResult
                             allMsgs = concat (Map.elems newAccumulated)
                         let partialResult = BuildResult {completedAt = t1, durationMs, moduleCount = loadResult.moduleCount, diagnostics = allMsgs, testRuns = []}
-                        testRuns <- runTestsIfClean testTargets (BuildId n) partialResult
+                        testRuns <- runTestsIfClean session (BuildId n) partialResult
                         BuildStore.setPhase (BuildId n) $ Done partialResult {testRuns}
                         loopSession reload nextId newAccumulated
 
-    filterDiags = filterToWatchDirs projectRoot watchDirs
+    filterDiags = filterToWatchDirs projectRoot session
 
 
 -- Run all configured test suites if the build has no errors.
 -- Transitions to 'Testing' phase while suites are running.
 runTestsIfClean
     :: (BuildStore :> es, Log :> es, TestRunner :> es)
-    => [Text] -> BuildId -> BuildResult -> Eff es [TestRun]
-runTestsIfClean testTargets bid partialResult
+    => Session -> BuildId -> BuildResult -> Eff es [TestRun]
+runTestsIfClean (Session {testTargets}) bid partialResult
     | not (null testTargets) && not (any (\d -> d.severity == SError) partialResult.diagnostics) = do
         let pendingRun = TestRunning
         BuildStore.setPhase bid (Testing partialResult {testRuns = map pendingRun testTargets})
@@ -216,10 +211,10 @@ runTestsIfClean testTargets bid partialResult
     | otherwise = pure []
 
 
-loadResultToBuildResult :: FilePath -> [FilePath] -> UTCTime -> UTCTime -> LoadResult -> BuildResult
-loadResultToBuildResult projectRoot watchDirs t0 t1 LoadResult {moduleCount, diagnostics = msgs} = do
+loadResultToBuildResult :: ProjectRoot -> Session -> UTCTime -> UTCTime -> LoadResult -> BuildResult
+loadResultToBuildResult projectRoot session t0 t1 LoadResult {moduleCount, diagnostics = msgs} = do
     BuildResult {completedAt = t1, durationMs, moduleCount, diagnostics = filteredMsgs, testRuns = []}
   where
-    filterDiags = filterToWatchDirs projectRoot watchDirs
+    filterDiags = filterToWatchDirs projectRoot session
     durationMs = round (realToFrac (diffUTCTime t1 t0) * 1000 :: Double) :: Int
     filteredMsgs = filterDiags msgs

--- a/tricorder/src/Tricorder/Session.hs
+++ b/tricorder/src/Tricorder/Session.hs
@@ -1,12 +1,13 @@
 module Tricorder.Session
     ( Session (..)
+    , Config (..)
+    , runSession
     , resolveCommand
     , resolveTargets
+    , allComponentTargets
     , resolveTestTargets
     , resolveWatchDirs
-    , allComponentTargets
     , sourceDirsForTarget
-    , runSession
     ) where
 
 import Data.Aeson (FromJSON)
@@ -44,6 +45,28 @@ import Tricorder.Runtime (ProjectRoot (..))
 
 
 data Session = Session
+    { command :: Text
+    , targets :: [Text]
+    , testTargets :: [Text]
+    , watchDirs :: [FilePath]
+    , outputFile :: Maybe FilePath
+    , replBuildDir :: FilePath
+    }
+
+
+instance Default Session where
+    def =
+        Session
+            { command = ""
+            , targets = []
+            , testTargets = []
+            , watchDirs = []
+            , outputFile = Nothing
+            , replBuildDir = "/tmp"
+            }
+
+
+data Config = Config
     { command :: Maybe Text
     , targets :: [Text]
     , watchDirs :: [FilePath]
@@ -52,12 +75,12 @@ data Session = Session
     , replBuildDir :: FilePath
     }
     deriving stock (Eq, Generic, Show)
-    deriving (FromJSON) via WithDefaults (QuietSnake Session)
+    deriving (FromJSON) via WithDefaults (QuietSnake Config)
 
 
-instance Default Session where
+instance Default Config where
     def =
-        Session
+        Config
             { command = Nothing
             , targets = []
             , watchDirs = []
@@ -68,24 +91,24 @@ instance Default Session where
 
 
 -- | Resolve the GHCi command, using config if set or autodetecting otherwise.
-resolveCommand :: (FileSystem :> es) => Session -> FilePath -> Eff es Text
-resolveCommand cfg projectRoot =
+resolveCommand :: (FileSystem :> es) => ProjectRoot -> Config -> Eff es Text
+resolveCommand projectRoot cfg =
     case cfg.command of
         Just cmd -> pure cmd
         Nothing -> detectCommand cfg.targets cfg.replBuildDir projectRoot
 
 
-detectCommand :: (FileSystem :> es) => [Text] -> FilePath -> FilePath -> Eff es Text
-detectCommand targets replBuildDir projectRoot = do
+detectCommand :: (FileSystem :> es) => [Text] -> FilePath -> ProjectRoot -> Eff es Text
+detectCommand targets replBuildDir (ProjectRoot projectRoot) = do
     hasCabalProject <- doesFileExist (projectRoot </> "cabal.project")
     cabalFiles <- filter (\f -> takeExtension f == ".cabal") <$> listDirectory projectRoot
     hasStack <- doesFileExist (projectRoot </> "stack.yaml")
     let targetStr = if null targets then "all" else unwords targets
         buildDirFlag = "--builddir " <> toText replBuildDir <> " "
     pure
-        $ if
-            | hasCabalProject -> "cabal repl --enable-multi-repl " <> buildDirFlag <> targetStr
-            | not (null cabalFiles) -> "cabal repl --enable-multi-repl " <> buildDirFlag <> targetStr
+        if
+            | hasCabalProject || not (null cabalFiles) ->
+                "cabal repl --enable-multi-repl " <> buildDirFlag <> targetStr
             | hasStack -> "stack ghci " <> targetStr
             | otherwise -> "cabal repl " <> buildDirFlag <> targetStr
 
@@ -96,17 +119,17 @@ detectCommand targets replBuildDir projectRoot = do
 -- 1. @watch_dirs@ from config, if non-empty (used as-is relative to project root)
 -- 2. @hs-source-dirs@ inferred from cabal targets, if targets are set
 -- 3. Falls back to @["."]@ (project root) if neither is available
-resolveWatchDirs :: (FileSystem :> es) => Session -> FilePath -> Eff es [FilePath]
-resolveWatchDirs cfg projectRoot =
+resolveWatchDirs :: (FileSystem :> es) => ProjectRoot -> Config -> Eff es [FilePath]
+resolveWatchDirs projectRoot cfg =
     case cfg.watchDirs of
-        dirs@(_ : _) -> pure (map (projectRoot </>) dirs)
+        dirs@(_ : _) -> pure $ map (coerce projectRoot </>) dirs
         [] -> resolveWatchDirsFromTargets cfg.targets projectRoot
 
 
-resolveWatchDirsFromTargets :: (FileSystem :> es) => [Text] -> FilePath -> Eff es [FilePath]
+resolveWatchDirsFromTargets :: (FileSystem :> es) => [Text] -> ProjectRoot -> Eff es [FilePath]
 resolveWatchDirsFromTargets [] _ = pure ["."]
-resolveWatchDirsFromTargets targets projectRoot = do
-    cabalFiles <- filter (\f -> takeExtension f == ".cabal") <$> listDirectory projectRoot
+resolveWatchDirsFromTargets targets (ProjectRoot projectRoot) = do
+    cabalFiles <- filter ((== ".cabal") . takeExtension) <$> listDirectory projectRoot
     case cabalFiles of
         [] -> pure ["."]
         (cabalFile : _) -> do
@@ -116,34 +139,6 @@ resolveWatchDirsFromTargets targets projectRoot = do
                 Just gpd ->
                     let dirs = nub $ concatMap (sourceDirsForTarget gpd) targets
                     in  pure $ if null dirs then ["."] else map (projectRoot </>) dirs
-
-
--- | Infer the effective targets to build and watch.
--- Returns the configured targets as-is, or auto-detects all components
--- from the .cabal file when no targets are configured.
-resolveTargets :: (FileSystem :> es) => [Text] -> FilePath -> Eff es [Text]
-resolveTargets targets@(_ : _) _ = pure targets
-resolveTargets [] projectRoot = do
-    cabalFiles <- filter (\f -> takeExtension f == ".cabal") <$> listDirectory projectRoot
-    case cabalFiles of
-        [] -> pure []
-        (cabalFile : _) -> do
-            contents <- readFileBs (projectRoot </> cabalFile)
-            pure $ maybe [] allComponentTargets (parseGenericPackageDescriptionMaybe contents)
-
-
-allComponentTargets :: GenericPackageDescription -> [Text]
-allComponentTargets gpd =
-    mainLibTargets
-        ++ subLibTargets
-        ++ exeTargets
-        ++ testTargets
-  where
-    mainPkgName = toText $ unPackageName . pkgName . package . packageDescription $ gpd
-    mainLibTargets = maybe [] (const ["lib:" <> mainPkgName]) (condLibrary gpd)
-    subLibTargets = map (\(n, _) -> "lib:" <> toText (unUnqualComponentName n)) (condSubLibraries gpd)
-    exeTargets = map (\(n, _) -> "exe:" <> toText (unUnqualComponentName n)) (condExecutables gpd)
-    testTargets = map (\(n, _) -> "test:" <> toText (unUnqualComponentName n)) (condTestSuites gpd)
 
 
 sourceDirsForTarget :: GenericPackageDescription -> Text -> [FilePath]
@@ -171,11 +166,39 @@ sourceDirsForTarget gpd target =
     exeDirs = hsSourceDirs . buildInfo
 
 
+-- | Infer the effective targets to build and watch.
+-- Returns the configured targets as-is, or auto-detects all components
+-- from the .cabal file when no targets are configured.
+resolveTargets :: (FileSystem :> es) => ProjectRoot -> [Text] -> Eff es [Text]
+resolveTargets _ targets@(_ : _) = pure targets
+resolveTargets (ProjectRoot projectRoot) [] = do
+    cabalFiles <- filter (\f -> takeExtension f == ".cabal") <$> listDirectory projectRoot
+    case cabalFiles of
+        [] -> pure []
+        (cabalFile : _) -> do
+            contents <- readFileBs (projectRoot </> cabalFile)
+            pure $ maybe [] allComponentTargets (parseGenericPackageDescriptionMaybe contents)
+
+
+allComponentTargets :: GenericPackageDescription -> [Text]
+allComponentTargets gpd =
+    mainLibTargets
+        ++ subLibTargets
+        ++ exeTargets
+        ++ testTargets
+  where
+    mainPkgName = toText $ unPackageName . pkgName . package . packageDescription $ gpd
+    mainLibTargets = maybe [] (const ["lib:" <> mainPkgName]) (condLibrary gpd)
+    subLibTargets = map (\(n, _) -> "lib:" <> toText (unUnqualComponentName n)) (condSubLibraries gpd)
+    exeTargets = map (\(n, _) -> "exe:" <> toText (unUnqualComponentName n)) (condExecutables gpd)
+    testTargets = map (\(n, _) -> "test:" <> toText (unUnqualComponentName n)) (condTestSuites gpd)
+
+
 -- | Resolve which test suites to run after a clean build.
 --
 -- When 'testTargets' is set in config, those suites are used directly.
 -- Otherwise, all @test:@ components in 'targets' are inferred.
-resolveTestTargets :: Session -> [Text]
+resolveTestTargets :: Config -> [Text]
 resolveTestTargets cfg = case cfg.testTargets of
     Just explicit -> explicit
     Nothing -> filter ("test:" `T.isPrefixOf`) cfg.targets
@@ -190,9 +213,20 @@ runSession
     => Eff (Reader Session : es) a
     -> Eff es a
 runSession act = do
-    ProjectRoot projectRoot <- ask
+    projectRoot <- ask @ProjectRoot
     loadedCfg <- ask
-    let cfg = extractConfig @"session" loadedCfg
-    effectiveTargets <- resolveTargets cfg.targets projectRoot
-    let cfg' = cfg {targets = effectiveTargets}
-    runReader cfg' act
+    let cfgFile = extractConfig @"session" @Config loadedCfg
+    effectiveTargets <- resolveTargets projectRoot cfgFile.targets
+    command <- resolveCommand projectRoot cfgFile
+    watchDirs <- resolveWatchDirs projectRoot cfgFile
+    let testTargets = resolveTestTargets cfgFile
+        cfg =
+            Session
+                { targets = effectiveTargets
+                , command
+                , watchDirs
+                , testTargets
+                , outputFile = cfgFile.outputFile
+                , replBuildDir = cfgFile.replBuildDir
+                }
+    runReader cfg act

--- a/tricorder/src/Tricorder/Watcher.hs
+++ b/tricorder/src/Tricorder/Watcher.hs
@@ -7,11 +7,19 @@ import System.FilePath (takeExtension, takeFileName)
 
 import Atelier.Component (Component (..), defaultComponent)
 import Atelier.Effects.Debounce (Debounce)
-import Atelier.Effects.FileSystem (FileSystem, getCurrentDirectory)
-import Atelier.Effects.FileWatcher (FileWatcher, Watch, containing, dirExt, dirWhere, excluding, watchFilePathsDebounced)
+import Atelier.Effects.FileWatcher
+    ( FileWatcher
+    , Watch
+    , containing
+    , dirExt
+    , dirWhere
+    , excluding
+    , watchFilePathsDebounced
+    )
 import Tricorder.BuildState (ChangeKind (..))
 import Tricorder.Effects.BuildStore (BuildStore, markDirty)
-import Tricorder.Session (Session (..), resolveWatchDirs)
+import Tricorder.Runtime (ProjectRoot (..))
+import Tricorder.Session (Session (..))
 
 
 -- | Watcher component.
@@ -21,8 +29,8 @@ import Tricorder.Session (Session (..), resolveWatchDirs)
 component
     :: ( BuildStore :> es
        , Debounce FilePath :> es
-       , FileSystem :> es
        , FileWatcher :> es
+       , Reader ProjectRoot :> es
        , Reader Session :> es
        )
     => Component es
@@ -30,22 +38,21 @@ component =
     defaultComponent
         { name = "Watcher"
         , triggers = do
-            cfg <- ask @Session
-            projectRoot <- getCurrentDirectory
-            dirs <- resolveWatchDirs cfg projectRoot
-            let watches = sourceWatches dirs <> cabalWatches projectRoot
+            session <- ask @Session
+            projectRoot <- ask
+            let watches = sourceWatches session <> cabalWatches projectRoot
             pure
                 [ watchFilePathsDebounced watches (markDirty . changeKindFor)
                 ]
         }
 
 
-sourceWatches :: [FilePath] -> [Watch]
-sourceWatches dirs = map (\d -> dirExt d ".hs" `excluding` containing "dist-newstyle") dirs
+sourceWatches :: Session -> [Watch]
+sourceWatches = map (\d -> dirExt d ".hs" `excluding` containing "dist-newstyle") . (.watchDirs)
 
 
-cabalWatches :: FilePath -> [Watch]
-cabalWatches projectRoot = [dirWhere projectRoot isCabalFile]
+cabalWatches :: ProjectRoot -> [Watch]
+cabalWatches (ProjectRoot projectRoot) = [dirWhere projectRoot isCabalFile]
 
 
 isCabalFile :: FilePath -> Bool

--- a/tricorder/test/Unit/Tricorder/GhciSessionSpec.hs
+++ b/tricorder/test/Unit/Tricorder/GhciSessionSpec.hs
@@ -1,6 +1,7 @@
 module Unit.Tricorder.GhciSessionSpec (spec_GhciSession) where
 
 import Control.Exception (ErrorCall (..))
+import Data.Default (def)
 import Data.Time (UTCTime (..), addUTCTime, fromGregorian)
 import Effectful (IOE, runEff)
 import Effectful.Concurrent (Concurrent, runConcurrent)
@@ -25,6 +26,8 @@ import Tricorder.Effects.GhciSession
     )
 import Tricorder.Effects.TestRunner (TestRunner, runTestRunnerScripted)
 import Tricorder.GhciSession (filterToWatchDirs, mergeDiagnostics, sessionListener)
+import Tricorder.Runtime (ProjectRoot (..))
+import Tricorder.Session (Session (..))
 
 
 spec_GhciSession :: Spec
@@ -47,40 +50,40 @@ testScripted = do
             it "returns scripted messages" do
                 LoadResult {diagnostics = msgs} <-
                     runScripted [simpleResult [errMsg]]
-                        $ withGhci "cabal repl" "/" \initial _ -> pure initial
+                        $ withGhci "cabal repl" (ProjectRoot "/") \initial _ -> pure initial
                 msgs `shouldBe` [errMsg]
 
             it "returns empty list when scripted result has no messages" do
                 LoadResult {diagnostics = msgs} <-
                     runScripted [simpleResult []]
-                        $ withGhci "cabal repl" "/" \initial _ -> pure initial
+                        $ withGhci "cabal repl" (ProjectRoot "/") \initial _ -> pure initial
                 msgs `shouldBe` []
 
             it "throws when scripted result is Left" do
                 result <-
                     runScripted [Left (toException boom)]
                         $ try @ErrorCall
-                        $ withGhci "cabal repl" "/" \initial _ -> pure initial
+                        $ withGhci "cabal repl" (ProjectRoot "/") \initial _ -> pure initial
                 result `shouldBe` Left boom
 
         describe "reloading" do
             it "returns scripted messages" do
                 LoadResult {diagnostics = msgs} <-
                     runScripted [simpleResult [warnMsg], simpleResult [errMsg]]
-                        $ withGhci "cabal repl" "/" \_ reload -> reload
+                        $ withGhci "cabal repl" (ProjectRoot "/") \_ reload -> reload
                 msgs `shouldBe` [errMsg]
 
             it "throws when scripted result is Left" do
                 result <-
                     runScripted [Left (toException boom)]
                         $ try @ErrorCall
-                        $ withGhci "cabal repl" "/" \_ reload -> reload
+                        $ withGhci "cabal repl" (ProjectRoot "/") \_ reload -> reload
                 result `shouldBe` Left boom
 
     describe "sequencing" do
         it "consumes results in order across mixed operations" do
             (a, b) <- runScripted [simpleResult [errMsg], simpleResult [warnMsg]] do
-                withGhci "cabal repl" "/" \LoadResult {diagnostics = a} reload -> do
+                withGhci "cabal repl" (ProjectRoot "/") \LoadResult {diagnostics = a} reload -> do
                     LoadResult {diagnostics = b} <- reload
                     pure (a, b)
             a `shouldBe` [errMsg]
@@ -88,8 +91,8 @@ testScripted = do
 
         it "recover scenario: error then success" do
             result <- runScripted [Left (toException boom), simpleResult []] do
-                r1 <- try @ErrorCall $ withGhci "cabal repl" "/" \i _ -> pure i
-                LoadResult {diagnostics = r2} <- withGhci "cabal repl" "/" \i _ -> pure i
+                r1 <- try @ErrorCall $ withGhci "cabal repl" (ProjectRoot "/") \i _ -> pure i
+                LoadResult {diagnostics = r2} <- withGhci "cabal repl" (ProjectRoot "/") \i _ -> pure i
                 pure (r1, r2)
             fst result `shouldSatisfy` isLeft
             snd result `shouldBe` []
@@ -106,7 +109,7 @@ testSessionListener = do
             let t0 = epoch
                 t1 = addUTCTime 2 epoch -- 2 seconds later
             result <- runListenerTest [t0, t1] [simpleResult []] do
-                void $ fork $ sessionListener "cabal repl" "/" [] []
+                void $ fork $ sessionListener session (ProjectRoot "/")
                 waitUntilDone
             case result.phase of
                 Done br -> br.durationMs `shouldBe` 2000
@@ -114,11 +117,16 @@ testSessionListener = do
 
         it "records moduleCount from LoadResult" do
             result <- runListenerTest [epoch, epoch] [simpleResultWith 7 []] do
-                void $ fork $ sessionListener "cabal repl" "/" [] []
+                void $ fork $ sessionListener session (ProjectRoot "/")
                 waitUntilDone
             case result.phase of
                 Done br -> br.moduleCount `shouldBe` 7
                 _ -> expectationFailure "expected Done phase"
+  where
+    session =
+        def
+            { command = "cabal repl"
+            }
 
 
 --------------------------------------------------------------------------------
@@ -181,39 +189,39 @@ testMergeDiagnostics = do
 
 testFilterToWatchDirs :: Spec
 testFilterToWatchDirs = do
-    let root = "/project"
-        watchDirs = ["/project/src"]
+    let root = ProjectRoot "/project"
+        session = def {watchDirs = ["/project/src"]}
 
     it "keeps diagnostics under a watched directory" do
         -- ./src/Foo.hs is what toRelative produces for an absolute project file
         let d = errMsg {file = "./src/Foo.hs"}
-        filterToWatchDirs root watchDirs [d] `shouldBe` [d]
+        filterToWatchDirs root session [d] `shouldBe` [d]
 
     it "drops diagnostics from outside the project (e.g. Nix store .h files)" do
         let d = errMsg {file = "/nix/store/abc123/ghcautoconf.h"}
-        filterToWatchDirs root watchDirs [d] `shouldBe` []
+        filterToWatchDirs root session [d] `shouldBe` []
 
     it "drops diagnostics with mangled CPP filenames" do
         -- The ghcid parser produces "In file included from <path>" as the file
         -- field for GCC-style CPP include-chain messages.
         let d = errMsg {file = "In file included from src/Foo.hs"}
-        filterToWatchDirs root watchDirs [d] `shouldBe` []
+        filterToWatchDirs root session [d] `shouldBe` []
 
     it "drops mangled CPP filenames when watchDirs is [\".\"] (project root)" do
         -- With watchDirs=["."], the watch dir resolves to projectRoot itself.
         -- A mangled path joined onto projectRoot would incorrectly start with
         -- projectRoot+"/", so this case requires an explicit guard.
         let d = errMsg {file = "In file included from src/Foo.hs"}
-        filterToWatchDirs root ["."] [d] `shouldBe` []
+        filterToWatchDirs root (def {watchDirs = ["."]}) [d] `shouldBe` []
 
     it "passes everything through when watchDirs is empty" do
         let d = errMsg {file = "/nix/store/abc123/ghcautoconf.h"}
-        filterToWatchDirs root [] [d] `shouldBe` [d]
+        filterToWatchDirs root (def {watchDirs = []}) [d] `shouldBe` [d]
 
     it "works with the '.' fallback watch dir (whole project root)" do
         let d = errMsg {file = "./src/Foo.hs"}
             nixD = errMsg {file = "/nix/store/abc123/ghcautoconf.h"}
-        filterToWatchDirs root ["."] [d, nixD] `shouldBe` [d]
+        filterToWatchDirs root (def {watchDirs = ["."]}) [d, nixD] `shouldBe` [d]
 
 
 --------------------------------------------------------------------------------

--- a/tricorder/test/Unit/Tricorder/SessionSpec.hs
+++ b/tricorder/test/Unit/Tricorder/SessionSpec.hs
@@ -3,72 +3,97 @@ module Unit.Tricorder.SessionSpec (spec_Session) where
 import Data.Default (Default (..))
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescriptionMaybe)
 import Distribution.Types.GenericPackageDescription (GenericPackageDescription)
+import Effectful (runPureEff)
+import Effectful.State.Static.Shared (evalState)
 import Test.Hspec
 
-import Tricorder.Session (Session (..), allComponentTargets, resolveTestTargets, sourceDirsForTarget)
+import Data.Map.Strict qualified as Map
+
+import Atelier.Effects.FileSystem (runFileSystemState)
+import Tricorder.Runtime (ProjectRoot (..))
+import Tricorder.Session
+    ( Config (..)
+    , allComponentTargets
+    , resolveCommand
+    , resolveTestTargets
+    , sourceDirsForTarget
+    )
 
 
 spec_Session :: Spec
 spec_Session = do
+    describe "resolveCommand" testResolveCommand
     describe "resolveTestTargets" testResolveTestTargets
-    describe "sourceDirsForTarget" do
-        describe "lib:" do
-            it "returns main library source dirs" do
-                sourceDirsForTarget gpd "lib:" `shouldBe` ["src"]
+    describe "sourceDirsForTarget" testSourceDirsForTarget
+    describe "allComponentTargets" testAllComponentTargets
 
-        describe "lib:<package-name>" do
-            it "returns main library source dirs when name matches package name" do
-                sourceDirsForTarget gpd "lib:myapp" `shouldBe` ["src"]
 
-        describe "lib:<sub-library>" do
-            it "returns sub-library source dirs" do
-                sourceDirsForTarget gpd "lib:myapp-utils" `shouldBe` ["utils"]
+testSourceDirsForTarget :: Spec
+testSourceDirsForTarget = do
+    describe "lib:" do
+        it "returns main library source dirs" do
+            sourceDirsForTarget gpd "lib:" `shouldBe` ["src"]
 
-            it "returns empty list for unknown sub-library" do
-                sourceDirsForTarget gpd "lib:nonexistent" `shouldBe` []
+    describe "lib:<package-name>" do
+        it "returns main library source dirs when name matches package name" do
+            sourceDirsForTarget gpd "lib:myapp" `shouldBe` ["src"]
 
-        describe "exe:<name>" do
-            it "returns executable source dirs" do
-                sourceDirsForTarget gpd "exe:myapp-exe" `shouldBe` ["app"]
+    describe "lib:<sub-library>" do
+        it "returns sub-library source dirs" do
+            sourceDirsForTarget gpd "lib:myapp-utils" `shouldBe` ["utils"]
 
-        describe "test:<name>" do
-            it "returns test suite source dirs" do
-                sourceDirsForTarget gpd "test:myapp-test" `shouldBe` ["test"]
+        it "returns empty list for unknown sub-library" do
+            sourceDirsForTarget gpd "lib:nonexistent" `shouldBe` []
 
-        describe "unknown target" do
-            it "returns empty list" do
-                sourceDirsForTarget gpd "unknown" `shouldBe` []
+    describe "exe:<name>" do
+        it "returns executable source dirs" do
+            sourceDirsForTarget gpd "exe:myapp-exe" `shouldBe` ["app"]
 
-    describe "allComponentTargets" do
-        it "includes the main library as lib:<package-name>" do
-            allComponentTargets gpd `shouldContain` ["lib:myapp"]
+    describe "test:<name>" do
+        it "returns test suite source dirs" do
+            sourceDirsForTarget gpd "test:myapp-test" `shouldBe` ["test"]
 
-        it "includes sub-libraries" do
-            allComponentTargets gpd `shouldContain` ["lib:myapp-utils"]
+    describe "unknown target" do
+        it "returns empty list" do
+            sourceDirsForTarget gpd "unknown" `shouldBe` []
 
-        it "includes executables" do
-            allComponentTargets gpd `shouldContain` ["exe:myapp-exe"]
 
-        it "includes test suites" do
-            allComponentTargets gpd `shouldContain` ["test:myapp-test"]
+testAllComponentTargets :: Spec
+testAllComponentTargets = do
+    it "includes the main library as lib:<package-name>" do
+        allComponentTargets gpd `shouldContain` ["lib:myapp"]
 
-        it "returns all four components for the fixture" do
-            allComponentTargets gpd
-                `shouldBe` ["lib:myapp", "lib:myapp-utils", "exe:myapp-exe", "test:myapp-test"]
+    it "includes sub-libraries" do
+        allComponentTargets gpd `shouldContain` ["lib:myapp-utils"]
+
+    it "includes executables" do
+        allComponentTargets gpd `shouldContain` ["exe:myapp-exe"]
+
+    it "includes test suites" do
+        allComponentTargets gpd `shouldContain` ["test:myapp-test"]
+
+    it "returns all four components for the fixture" do
+        allComponentTargets gpd
+            `shouldBe` ["lib:myapp", "lib:myapp-utils", "exe:myapp-exe", "test:myapp-test"]
 
 
 testResolveTestTargets :: Spec
 testResolveTestTargets = do
     it "infers test: components from targets when testTargets is absent" do
-        let cfg = def {targets = ["lib:mylib", "test:mylib-test"]}
+        let cfg = def {targets = ["lib:mylib", "test:mylib-test"]} :: Config
         resolveTestTargets cfg `shouldBe` ["test:mylib-test"]
 
     it "returns empty list when no test: components in targets" do
-        let cfg = def {targets = ["lib:mylib", "exe:myapp"]}
+        let cfg = def {targets = ["lib:mylib", "exe:myapp"]} :: Config
         resolveTestTargets cfg `shouldBe` []
 
     it "uses explicit testTargets list when set" do
-        let cfg = def {targets = ["lib:a", "test:a-test", "test:b-test"], testTargets = Just ["test:b-test"]}
+        let cfg =
+                def
+                    { targets = ["lib:a", "test:a-test", "test:b-test"]
+                    , testTargets = Just ["test:b-test"]
+                    }
+                    :: Config
         resolveTestTargets cfg `shouldBe` ["test:b-test"]
 
     it "returns empty list when testTargets is explicitly empty" do
@@ -78,6 +103,57 @@ testResolveTestTargets = do
     it "infers multiple test: components" do
         let cfg = def {targets = ["lib:a", "test:a-test", "test:b-test"]}
         resolveTestTargets cfg `shouldBe` ["test:a-test", "test:b-test"]
+
+
+testResolveCommand :: Spec
+testResolveCommand = do
+    describe "when config has a command" do
+        it "should use specified command" do
+            let actual =
+                    runPureEff
+                        . evalState mempty
+                        . runFileSystemState
+                        $ resolveCommand pr def {command = Just "foo"}
+            actual `shouldBe` "foo"
+
+    describe "when config does not have a command" do
+        describe "and there is a cabal.project file" do
+            it "should use cabal with --enable-multi-repl" do
+                let actual =
+                        runPureEff
+                            . evalState (Map.singleton "/cabal.project" "")
+                            . runFileSystemState
+                            $ resolveCommand pr cfg
+                actual `shouldBe` "cabal repl --enable-multi-repl --builddir /replbuild lib:foo"
+
+        describe "and there is at least one *.cabal file" do
+            it "should use cabal with --enable-multi-repl" do
+                let actual =
+                        runPureEff
+                            . evalState (Map.singleton "/foo.cabal" "")
+                            . runFileSystemState
+                            $ resolveCommand pr cfg
+                actual `shouldBe` "cabal repl --enable-multi-repl --builddir /replbuild lib:foo"
+        describe "and there is a stack.yaml file" do
+            it "should use stack ghci" do
+                let actual =
+                        runPureEff
+                            . evalState (Map.singleton "/stack.yaml" "")
+                            . runFileSystemState
+                            $ resolveCommand pr cfg
+                actual `shouldBe` "stack ghci lib:foo"
+
+        describe "but there are no project files" do
+            it "should use default cabal repl" do
+                let actual =
+                        runPureEff
+                            . evalState mempty
+                            . runFileSystemState
+                            $ resolveCommand pr cfg
+                actual `shouldBe` "cabal repl --builddir /replbuild lib:foo"
+  where
+    pr = ProjectRoot "/"
+    cfg = def {replBuildDir = "/replbuild", targets = ["lib:foo"]}
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Depends on https://github.com/atelier-hub/tricorder/pull/75

One of my motivations for (the thoroughly misguided) https://github.com/atelier-hub/tricorder/pull/74 was how easy it was to accidentally use properties like `command`, `targets`, `testTargets` and `watchDirs` in `Session` without resolving them properly with their corresponding `resolveX` functions. This PR merely makes `Session` already parse and resolve these values, so that it is safe (and expected) to use them as-is. A future PR will have to solve reloading these configuration values on cabal file changes, which is not something that is currently supported neither with this implementation nor with the old one.