### PR TITLE
feat: make runConfig accept nested properties

### DIFF
--- a/atelier/src/Atelier/Config.hs
+++ b/atelier/src/Atelier/Config.hs
@@ -4,16 +4,15 @@ module Atelier.Config
     ( envOverrides
     , deepMerge
     , extractConfig
+    , extractNestedConfig
     , LoadedConfig (..)
     , runConfig
     ) where
 
 import Data.Aeson (FromJSON (..), Value (..))
 import Data.Default (Default (..))
-import Effectful.Exception (throwIO)
 import Effectful.Reader.Static (Reader, ask, runReader)
 import GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
-import System.IO.Error (userError)
 
 import Data.Aeson qualified as Aeson
 import Data.Aeson.KeyMap qualified as KM
@@ -93,24 +92,49 @@ extractConfig (LoadedConfig root) =
         _ -> def
 
 
--- | Extract and decode a config section by type-level key from the root config Value.
--- Falls back to the type's 'Default' instance if the key is absent.
+-- | Variant of 'extractConfig' that extracts nested configuration values.
+-- Nested properties are delimited by @"."@, so @foo.bar@ would attempt to
+-- extract the nested property @bar@ contained in the top-level property @foo@.
+--
+-- Example:
+--
+-- Assuming @cfg@ is a 'LoadedConfig' representing the following JSON/YAML
+-- structure:
+--
+-- @
+-- {
+--   "foo": {
+--     "bar": "test"
+--   }
+-- }
+-- @
+--
+-- The following will be @True@:
+--
+-- @
+-- extractNestedConfig \@"foo.bar" \@Text cfg == "test"
+-- @
+extractNestedConfig :: forall (key :: Symbol) r. (Default r, FromJSON r, KnownSymbol key) => LoadedConfig -> r
+extractNestedConfig (LoadedConfig root) = go props root
+  where
+    props = T.splitOn "." $ toText $ symbolVal $ Proxy @key
+
+    go (p : ps) (Aeson.Object m) = maybe def (go ps) $ KM.lookup (fromString $ toString p) m
+    go (_ : _) _ = def
+    go [] x = fromJSON x
+
+    fromJSON x = case Aeson.fromJSON x of
+        Aeson.Success a -> a
+        Aeson.Error _ -> def
+
+
+-- | Extract and decode a (potentially nested) config section by type-level key
+-- from the root config Value.
+-- Falls back to the type's 'Default' instance if the (nested) key is absent.
 runConfig
     :: forall (key :: Symbol) r es a
      . (Default r, FromJSON r, KnownSymbol key, Reader LoadedConfig :> es)
-    => Eff (Reader r : es) a
-    -> Eff es a
-runConfig eff = do
-    LoadedConfig root <- ask
-    r <- case root of
-        Aeson.Object m ->
-            case KM.lookup (fromString (symbolVal (Proxy @key))) m of
-                Nothing -> pure def
-                Just v -> case Aeson.fromJSON v of
-                    Aeson.Success a -> pure a
-                    Aeson.Error e ->
-                        throwIO
-                            $ userError
-                            $ "Failed to parse config key '" <> symbolVal (Proxy @key) <> "': " <> e
-        _ -> pure def
-    runReader r eff
+    => Eff (Reader r : es) a -> Eff es a
+runConfig act = do
+    loadedCfg <- ask
+    runReader (extractNestedConfig @key loadedCfg) act

--- a/atelier/test/Unit/Atelier/ConfigSpec.hs
+++ b/atelier/test/Unit/Atelier/ConfigSpec.hs
@@ -1,0 +1,100 @@
+module Unit.Atelier.ConfigSpec (spec_Config) where
+
+import Data.Aeson (FromJSON, ToJSON)
+import Data.Default (Default (..))
+import GHC.Generics (Generically (..))
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+import Data.Aeson qualified as Aeson
+import Data.Aeson.KeyMap qualified as KM
+
+import Atelier.Config (LoadedConfig (..), extractNestedConfig)
+import Atelier.Types.QuietSnake (QuietSnake (..))
+import Atelier.Types.WithDefaults (WithDefaults (..))
+
+
+spec_Config :: Spec
+spec_Config = do
+    describe "extractNestedConfig" testExtractNestedConfig
+
+
+testExtractNestedConfig :: Spec
+testExtractNestedConfig = do
+    it "should use default value for non-object Values" do
+        let actual = extractNestedConfig @"foo" $ LoadedConfig $ Aeson.String "foo"
+        actual `shouldBe` Val "default"
+
+    it "should fetch top-level property" do
+        let actual =
+                extractNestedConfig @"foo"
+                    $ LoadedConfig
+                    $ Aeson.Object
+                    $ KM.singleton "foo"
+                    $ Aeson.Object
+                    $ KM.singleton "value"
+                    $ Aeson.String "actual"
+        actual `shouldBe` Val "actual"
+
+    it "should return default for a missing key" do
+        let actual =
+                extractNestedConfig @"missing"
+                    $ LoadedConfig
+                    $ Aeson.Object KM.empty
+        actual `shouldBe` Val "default"
+
+    it "should fetch a nested property via dot notation" do
+        let actual =
+                extractNestedConfig @"foo.bar"
+                    $ LoadedConfig
+                    $ Aeson.Object
+                    $ KM.singleton "foo"
+                    $ Aeson.Object
+                    $ KM.singleton "bar"
+                    $ Aeson.Object
+                    $ KM.singleton "value"
+                    $ Aeson.String "nested"
+        actual `shouldBe` Val "nested"
+
+    it "should return default for a missing intermediate segment" do
+        let actual =
+                extractNestedConfig @"foo.bar"
+                    $ LoadedConfig
+                    $ Aeson.Object KM.empty
+        actual `shouldBe` Val "default"
+
+    it "should return default for a missing leaf segment" do
+        let actual =
+                extractNestedConfig @"foo.bar"
+                    $ LoadedConfig
+                    $ Aeson.Object
+                    $ KM.singleton "foo"
+                    $ Aeson.Object KM.empty
+        actual `shouldBe` Val "default"
+
+    it "should return default when an intermediate value is not an object" do
+        let actual =
+                extractNestedConfig @"foo.bar"
+                    $ LoadedConfig
+                    $ Aeson.Object
+                    $ KM.singleton "foo"
+                    $ Aeson.String "not-an-object"
+        actual `shouldBe` Val "default"
+
+    it "should return default when the leaf value fails to decode" do
+        let actual =
+                extractNestedConfig @"foo"
+                    $ LoadedConfig
+                    $ Aeson.Object
+                    $ KM.singleton "foo"
+                    $ Aeson.String "not-an-object"
+        actual `shouldBe` Val "default"
+
+
+data Val = Val {value :: Text}
+    deriving stock (Eq, Generic, Show)
+    deriving (ToJSON) via Generically Val
+    deriving (FromJSON) via WithDefaults (QuietSnake Val)
+
+
+instance Default Val where
+    def = Val "default"

--- a/tricorder.cabal
+++ b/tricorder.cabal
@@ -377,6 +377,7 @@ test-suite atelier-test
   type: exitcode-stdio-1.0
   main-is: Driver.hs
   other-modules:
+      Unit.Atelier.ConfigSpec
       Unit.Atelier.Effects.Cache.SingleflightSpec
       Unit.Atelier.Effects.CacheSpec
       Unit.Atelier.Effects.ChanSpec


### PR DESCRIPTION
The `runConfig @"observability.tracing"` call in `Tricorder.Daemon.Main` probably didn't work properly until this change, since it would look for a property called `"observability.tracing"` instead of looking for the nested property `"tracing"` inside `"observability"`. This PR fixes this, and allows us to more easily pick out parts of our configuration should the need arise.

Depends on #80 