### PR TITLE
refactor: move stripGhciNoise to TestOutput, apply to --verbose

### DIFF
--- a/tricorder/src/Tricorder/CLI.hs
+++ b/tricorder/src/Tricorder/CLI.hs
@@ -52,6 +52,7 @@ import Tricorder.Socket.Client
     , queryStatus
     , queryStatusWait
     )
+import Tricorder.TestOutput (stripGhciNoise)
 
 import Atelier.Effects.Console qualified as Console
 
@@ -126,7 +127,7 @@ showStatus opts = do
             TestRunCompleted c -> c.target <> "  " <> if c.passed then "passed" else "failed"
         when (verbosity == Verbose) $ case tr of
             TestRunCompleted c ->
-                mapM_ (Console.putTextLn . ("  " <>) . toText) (lines c.output)
+                mapM_ (Console.putTextLn . ("  " <>)) (stripGhciNoise (T.lines c.output))
             _ -> pure ()
 
     buildHasErrors r = any ((== SError) . (.severity)) r.diagnostics
@@ -236,16 +237,6 @@ showTests opts = do
             TestCaseFailed details ->
                 mapM_ (Console.putTextLn . ("    " <>)) (T.lines details)
             TestCasePassed -> pure ()
-
-    stripGhciNoise ls =
-        case dropWhile (not . T.isPrefixOf "ghci> ") ls of
-            [] -> ls
-            _ : afterPrompt -> reverse $ dropWhile isGhciNoiseLine $ reverse afterPrompt
-
-    isGhciNoiseLine l =
-        T.isPrefixOf "ghci>" l
-            || l == "Leaving GHCi."
-            || T.isPrefixOf "*** Exception: " l
 
 
 showSource

--- a/tricorder/src/Tricorder/TestOutput.hs
+++ b/tricorder/src/Tricorder/TestOutput.hs
@@ -1,4 +1,4 @@
-module Tricorder.TestOutput (parseHspecOutput) where
+module Tricorder.TestOutput (parseHspecOutput, stripGhciNoise) where
 
 import Data.Text qualified as T
 
@@ -29,3 +29,18 @@ parseHspecOutput = go . T.lines
         T.strip $ T.dropEnd (T.length suffix) $ T.stripEnd l
 
     indentOf = T.length . T.takeWhile (== ' ')
+
+
+-- | Strip GHCi/cabal startup and shutdown noise from captured output lines.
+stripGhciNoise :: [Text] -> [Text]
+stripGhciNoise ls =
+    case dropWhile (not . T.isPrefixOf "ghci> ") ls of
+        [] -> ls
+        _ : afterPrompt -> reverse $ dropWhile isGhciNoiseLine $ reverse afterPrompt
+
+
+isGhciNoiseLine :: Text -> Bool
+isGhciNoiseLine l =
+    T.isPrefixOf "ghci>" l
+        || l == "Leaving GHCi."
+        || T.isPrefixOf "*** Exception: " l

--- a/tricorder/test/Unit/Tricorder/TestOutputSpec.hs
+++ b/tricorder/test/Unit/Tricorder/TestOutputSpec.hs
@@ -3,7 +3,7 @@ module Unit.Tricorder.TestOutputSpec (spec_TestOutput) where
 import Test.Hspec
 
 import Tricorder.BuildState (TestCase (..), TestCaseOutcome (..))
-import Tricorder.TestOutput (parseHspecOutput)
+import Tricorder.TestOutput (parseHspecOutput, stripGhciNoise)
 
 
 spec_TestOutput :: Spec
@@ -66,4 +66,74 @@ spec_TestOutput = do
                 `shouldBe` [ TestCase {description = "passes:", outcome = TestCasePassed}
                            , TestCase {description = "fails:", outcome = TestCaseFailed "reason"}
                            , TestCase {description = "also passes:", outcome = TestCasePassed}
+                           ]
+
+    describe "stripGhciNoise" do
+        it "passes through empty list" do
+            stripGhciNoise [] `shouldBe` []
+
+        it "passes through output with no ghci prompt" do
+            let ls = ["line one", "line two", "line three"]
+            stripGhciNoise ls `shouldBe` ls
+
+        it "strips cabal build preamble" do
+            let ls =
+                    [ "Resolving dependencies..."
+                    , "Build profile: -w ghc-9.6.3 -O1"
+                    , "ghci> :reload"
+                    , "  test one:                                          OK"
+                    , "  test two:                                          OK"
+                    ]
+            stripGhciNoise ls
+                `shouldBe` [ "  test one:                                          OK"
+                           , "  test two:                                          OK"
+                           ]
+
+        it "strips trailing ghci prompt" do
+            let ls =
+                    [ "ghci> :reload"
+                    , "  a test:                                            OK"
+                    , "ghci> "
+                    ]
+            stripGhciNoise ls `shouldBe` ["  a test:                                            OK"]
+
+        it "strips trailing \"Leaving GHCi.\" line" do
+            let ls =
+                    [ "ghci> :reload"
+                    , "  a test:                                            OK"
+                    , "Leaving GHCi."
+                    ]
+            stripGhciNoise ls `shouldBe` ["  a test:                                            OK"]
+
+        it "strips trailing \"*** Exception: ...\" lines" do
+            let ls =
+                    [ "ghci> :reload"
+                    , "  a test:                                            OK"
+                    , "*** Exception: ExitSuccess"
+                    ]
+            stripGhciNoise ls `shouldBe` ["  a test:                                            OK"]
+
+        it "full round-trip strips build noise, keeps test output" do
+            let ls =
+                    [ "Resolving dependencies..."
+                    , "Build profile: -w ghc-9.6.3 -O1"
+                    , "Preprocessing test suite 'spec' for tricorder-0.1.0.0..."
+                    , "ghci> :reload"
+                    , "  Suite"
+                    , "    passes:                                          OK"
+                    , "    fails:                                           FAIL"
+                    , "      some detail"
+                    , ""
+                    , "Finished in 0.0001 seconds"
+                    , "ghci> "
+                    , "Leaving GHCi."
+                    , "*** Exception: ExitFailure 1"
+                    ]
+            stripGhciNoise ls
+                `shouldBe` [ "  Suite"
+                           , "    passes:                                          OK"
+                           , "    fails:                                           FAIL"
+                           , "      some detail"
+                           , ""
+                           , "Finished in 0.0001 seconds"
                            ]


### PR DESCRIPTION
- Move `stripGhciNoise` from a local where-clause in `showTests` to `Tricorder.TestOutput` as an exported top-level function
- `status --verbose` now strips GHCi/cabal noise the same way `test-results` does
- Add 7 unit tests for `stripGhciNoise` in `TestOutputSpec`