### PR TITLE
feat: auto-determine log file from XDG runtime dir

### DIFF
--- a/tricorder/src/Tricorder.hs
+++ b/tricorder/src/Tricorder.hs
@@ -21,12 +21,11 @@ import Tricorder.Daemon (startDaemon, stopDaemon, waitForDaemon)
 import Tricorder.Effects.Brick (Brick)
 import Tricorder.Effects.BrickChan (BrickChan)
 import Tricorder.Effects.UnixSocket (UnixSocket)
-import Tricorder.Runtime (PidFile (..), SocketPath (..))
+import Tricorder.Runtime (LogPath (..), PidFile (..), SocketPath (..))
 import Tricorder.Socket.Client (isDaemonRunning, queryStatus)
 import Tricorder.UI (viewUi)
 
 import Atelier.Effects.Console qualified as Console
-import Tricorder.Observability qualified as Observability
 
 
 run
@@ -42,7 +41,7 @@ run
        , FileSystem :> es
        , IOE :> es
        , Reader Command :> es
-       , Reader Observability.Config :> es
+       , Reader LogPath :> es
        , Reader PidFile :> es
        , Reader SocketPath :> es
        , Timeout :> es
@@ -82,16 +81,17 @@ run =
                 showTests opts
         Log followMode -> do
             running <- isDaemonRunning
-            mLogFile <-
+            logFile <-
                 if running then do
                     SocketPath sp <- ask
                     result <- queryStatus sp
+                    LogPath fallback <- ask
                     pure $ case result of
                         Right state -> state.daemonInfo.logFile
-                        Left _ -> Nothing
+                        Left _ -> fallback
                 else
-                    asks @Observability.Config (.logFile)
-            showLog mLogFile followMode
+                    asks @LogPath (.getLogPath)
+            showLog logFile followMode
         UI -> do
             running <- isDaemonRunning
             unless running do

--- a/tricorder/src/Tricorder/BuildState.hs
+++ b/tricorder/src/Tricorder/BuildState.hs
@@ -29,7 +29,7 @@ import Effectful.Concurrent.STM (TVar)
 import Effectful.Reader.Static (Reader, ask, runReader)
 import System.FilePath (makeRelative)
 
-import Tricorder.Runtime (ProjectRoot (..), SocketPath (..))
+import Tricorder.Runtime (LogPath (..), ProjectRoot (..), SocketPath (..))
 import Tricorder.Session (Session (..))
 
 import Tricorder.Observability qualified as Observability
@@ -45,7 +45,7 @@ data DaemonInfo = DaemonInfo
     { targets :: [Text]
     , watchDirs :: [FilePath]
     , sockPath :: FilePath
-    , logFile :: Maybe FilePath
+    , logFile :: FilePath
     , metricsPort :: Maybe Int
     }
     deriving stock (Eq, Generic, Show)
@@ -53,7 +53,8 @@ data DaemonInfo = DaemonInfo
 
 
 runDaemonInfo
-    :: ( Reader Observability.Config :> es
+    :: ( Reader LogPath :> es
+       , Reader Observability.Config :> es
        , Reader ProjectRoot :> es
        , Reader Session :> es
        , Reader SocketPath :> es
@@ -64,12 +65,13 @@ runDaemonInfo act = do
     obsCfg <- ask @Observability.Config
     ProjectRoot projectRoot <- ask
     SocketPath sockPath <- ask
+    LogPath logFile <- ask
     let daemonInfo =
             DaemonInfo
                 { targets = session.targets
                 , watchDirs = map (makeRelative projectRoot) session.watchDirs
                 , sockPath
-                , logFile = obsCfg.logFile
+                , logFile
                 , metricsPort = if obsCfg.metrics.enabled then Just obsCfg.metrics.port else Nothing
                 }
     runReader daemonInfo act

--- a/tricorder/src/Tricorder/CLI.hs
+++ b/tricorder/src/Tricorder/CLI.hs
@@ -153,17 +153,14 @@ showLog
        , Delay :> es
        , FileSystem :> es
        )
-    => Maybe FilePath -> FollowMode -> Eff es ()
-showLog mLogFile followMode = case mLogFile of
-    Nothing ->
-        Console.putStrLn "No log file configured. Add `log_file: /path/to/tricorder.log` to .tricorder.yaml"
-    Just path -> do
-        exists <- doesFileExist path
-        if not exists then
-            Console.putTextLn $ "Log file does not exist yet: " <> toText path
-        else case followMode of
-            Follow -> followFile path Console.putStr
-            NoFollow -> readFileLbs path >>= Console.putStr . BSL.toStrict
+    => FilePath -> FollowMode -> Eff es ()
+showLog path followMode = do
+    exists <- doesFileExist path
+    if not exists then
+        Console.putTextLn $ "Log file does not exist yet: " <> toText path
+    else case followMode of
+        Follow -> followFile path Console.putStr
+        NoFollow -> readFileLbs path >>= Console.putStr . BSL.toStrict
 
 
 showTests

--- a/tricorder/src/Tricorder/CLI/Main.hs
+++ b/tricorder/src/Tricorder/CLI/Main.hs
@@ -4,7 +4,6 @@ import Effectful (runEff)
 import Effectful.Concurrent (runConcurrent)
 import Effectful.Timeout (runTimeout)
 
-import Atelier.Config (runConfig)
 import Atelier.Effects.Clock (runClock)
 import Atelier.Effects.Conc (runConc)
 import Atelier.Effects.Console (runConsole)
@@ -18,10 +17,9 @@ import Tricorder.Config (runLoadedConfig)
 import Tricorder.Effects.Brick (runBrick)
 import Tricorder.Effects.BrickChan (runBrickChan)
 import Tricorder.Effects.UnixSocket (runUnixSocketIO)
-import Tricorder.Runtime (runPidFile, runProjectRoot, runRuntimeDir, runSocketPath)
+import Tricorder.Runtime (runLogPath, runPidFile, runProjectRoot, runRuntimeDir, runSocketPath)
 
 import Tricorder qualified
-import Tricorder.Observability qualified as Observability
 
 
 main :: IO ()
@@ -42,8 +40,8 @@ main =
         . runRuntimeDir
         . runPidFile
         . runSocketPath
+        . runLogPath
         . runLoadedConfig
-        . runConfig @"observability" @Observability.Config
         . runDaemons
         . runArguments
         . runUnixSocketIO

--- a/tricorder/src/Tricorder/Daemon/Main.hs
+++ b/tricorder/src/Tricorder/Daemon/Main.hs
@@ -29,7 +29,7 @@ import Tricorder.Effects.GhciSession (runGhciSessionIO)
 import Tricorder.Effects.Logging (runLogging)
 import Tricorder.Effects.TestRunner (runTestRunnerIO)
 import Tricorder.Effects.UnixSocket (runUnixSocketIO)
-import Tricorder.Runtime (runProjectRoot, runRuntimeDir, runSocketPath)
+import Tricorder.Runtime (runLogPath, runProjectRoot, runRuntimeDir, runSocketPath)
 import Tricorder.Session (runSession)
 
 import Atelier.Effects.Cache.Config qualified as CacheConfig
@@ -59,6 +59,7 @@ main =
         . runProjectRoot
         . runRuntimeDir
         . runSocketPath
+        . runLogPath
         . runLoadedConfig
         . runSession
         . runConfig @"observability" @Observability.Config

--- a/tricorder/src/Tricorder/Effects/BuildStore.hs
+++ b/tricorder/src/Tricorder/Effects/BuildStore.hs
@@ -90,7 +90,7 @@ runBuildStoreSTM eff = do
         Testing _ -> True
         Done _ -> False
 
-    emptyDaemonInfo = DaemonInfo {targets = [], watchDirs = [], sockPath = "", logFile = Nothing, metricsPort = Nothing}
+    emptyDaemonInfo = DaemonInfo {targets = [], watchDirs = [], sockPath = "", logFile = "", metricsPort = Nothing}
 
 
 -- | Production interpreter that shares a 'BuildStateRef' TVar with writers

--- a/tricorder/src/Tricorder/Effects/Logging.hs
+++ b/tricorder/src/Tricorder/Effects/Logging.hs
@@ -4,17 +4,15 @@ import Effectful (IOE)
 import Effectful.Reader.Static (Reader, asks)
 
 import Atelier.Effects.File (File)
-import Atelier.Effects.Log (Log, Severity (..), runLogNoOp, runLogToHandle)
+import Atelier.Effects.Log (Log, Severity (..), runLogToHandle)
+import Tricorder.Runtime (LogPath (..))
 
 import Atelier.Effects.File qualified as File
-import Tricorder.Observability qualified as Observability
 
 
-runLogging :: (File :> es, IOE :> es, Reader Observability.Config :> es) => Eff (Log : es) a -> Eff es a
+runLogging :: (File :> es, IOE :> es, Reader LogPath :> es) => Eff (Log : es) a -> Eff es a
 runLogging act = do
-    logFile <- asks @Observability.Config (.logFile)
-    case logFile of
-        Nothing -> runLogNoOp act
-        Just path -> File.withFile path AppendMode \h -> do
-            File.hSetBuffering h LineBuffering
-            runLogToHandle h INFO act
+    path <- asks @LogPath (.getLogPath)
+    File.withFile path AppendMode \h -> do
+        File.hSetBuffering h LineBuffering
+        runLogToHandle h INFO act

--- a/tricorder/src/Tricorder/Observability.hs
+++ b/tricorder/src/Tricorder/Observability.hs
@@ -38,7 +38,6 @@ instance Default MetricsConfig where
 
 data Config = Config
     { metrics :: MetricsConfig
-    , logFile :: Maybe FilePath
     , tracing :: TracingConfig
     }
     deriving stock (Eq, Generic, Show)
@@ -46,7 +45,7 @@ data Config = Config
 
 
 instance Default Config where
-    def = Config {metrics = def, logFile = Nothing, tracing = def}
+    def = Config {metrics = def, tracing = def}
 
 
 component :: (Delay :> es, IOE :> es, Log :> es, Reader Config :> es) => Component es

--- a/tricorder/src/Tricorder/Runtime.hs
+++ b/tricorder/src/Tricorder/Runtime.hs
@@ -8,6 +8,8 @@ module Tricorder.Runtime
     , SocketPath (..)
     , runSocketPath
     , runSocketPathConst
+    , LogPath (..)
+    , runLogPath
     ) where
 
 import Effectful.Reader.Static (Reader, ask, runReader)
@@ -74,6 +76,15 @@ runPidFile :: (Reader RuntimeDir :> es) => Eff (Reader PidFile : es) a -> Eff es
 runPidFile act = do
     RuntimeDir runtimeDir <- ask
     runReader (PidFile $ runtimeDir </> "daemon.pid") act
+
+
+newtype LogPath = LogPath {getLogPath :: FilePath}
+
+
+runLogPath :: (Reader RuntimeDir :> es) => Eff (Reader LogPath : es) a -> Eff es a
+runLogPath act = do
+    RuntimeDir runtimeDir <- ask
+    runReader (LogPath $ runtimeDir </> "daemon.log") act
 
 
 -- | Polynomial hash of a file path, returned as a hex string.

--- a/tricorder/src/Tricorder/UI/View.hs
+++ b/tricorder/src/Tricorder/UI/View.hs
@@ -157,10 +157,8 @@ viewMetrics (Just port) =
         ]
 
 
-viewLogFile :: Maybe FilePath -> Widget n
-viewLogFile = \case
-    Nothing -> emptyWidget
-    Just p -> hBoxSpaced 1 [emphasis $ txt "Log:", txt $ toText p]
+viewLogFile :: FilePath -> Widget n
+viewLogFile p = hBoxSpaced 1 [emphasis $ txt "Log:", txt $ toText p]
 
 
 viewSockPath :: FilePath -> Widget n

--- a/tricorder/test/Unit/Tricorder/BuildStateSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuildStateSpec.hs
@@ -61,7 +61,7 @@ mkBuildState msgs =
     BuildState
         { buildId = BuildId 1
         , phase = Done (BuildResult {completedAt = epoch, durationMs = 0, moduleCount = 0, diagnostics = msgs, testRuns = []})
-        , daemonInfo = DaemonInfo {targets = [], watchDirs = [], sockPath = "", logFile = Nothing, metricsPort = Nothing}
+        , daemonInfo = DaemonInfo {targets = [], watchDirs = [], sockPath = "", logFile = "", metricsPort = Nothing}
         }
   where
     epoch = UTCTime (fromGregorian 1970 1 1) 0

--- a/tricorder/test/Unit/Tricorder/BuildStoreSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuildStoreSpec.hs
@@ -131,7 +131,7 @@ testSTM = do
 --------------------------------------------------------------------------------
 
 emptyDaemonInfo :: DaemonInfo
-emptyDaemonInfo = DaemonInfo {targets = [], watchDirs = [], sockPath = "", logFile = Nothing, metricsPort = Nothing}
+emptyDaemonInfo = DaemonInfo {targets = [], watchDirs = [], sockPath = "", logFile = "", metricsPort = Nothing}
 
 
 buildingAt :: Int -> BuildState

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -503,6 +503,6 @@ emptyDaemonInfo =
         { targets = []
         , watchDirs = []
         , sockPath = ""
-        , logFile = Nothing
+        , logFile = ""
         , metricsPort = Nothing
         }

--- a/tricorder/test/Unit/Tricorder/WatcherSpec.hs
+++ b/tricorder/test/Unit/Tricorder/WatcherSpec.hs
@@ -63,6 +63,6 @@ emptyDaemonInfo =
         { targets = []
         , watchDirs = []
         , sockPath = ""
-        , logFile = Nothing
+        , logFile = ""
         , metricsPort = Nothing
         }


### PR DESCRIPTION
- Add `LogPath`/`runLogPath` to `Runtime`, resolving to `$XDG_RUNTIME_DIR/tricorder/<hash>/daemon.log`
- Remove `log_file` from `Observability.Config` — no longer configurable
- `runLogging` always writes to the auto-computed path (no more no-op mode)
- `tricorder log` reads the path from `Reader LogPath` instead of config
- Update `DaemonInfo.logFile` from `Maybe FilePath` to `FilePath`