### PR TITLE
fix: pass resolved targets to resolveTestTargets

### DIFF
--- a/tricorder/src/Tricorder/Session.hs
+++ b/tricorder/src/Tricorder/Session.hs
@@ -119,11 +119,11 @@ detectCommand targets replBuildDir (ProjectRoot projectRoot) = do
 -- 1. @watch_dirs@ from config, if non-empty (used as-is relative to project root)
 -- 2. @hs-source-dirs@ inferred from cabal targets, if targets are set
 -- 3. Falls back to @["."]@ (project root) if neither is available
-resolveWatchDirs :: (FileSystem :> es) => ProjectRoot -> Config -> Eff es [FilePath]
-resolveWatchDirs projectRoot cfg =
+resolveWatchDirs :: (FileSystem :> es) => ProjectRoot -> Config -> [Text] -> Eff es [FilePath]
+resolveWatchDirs projectRoot cfg targets =
     case cfg.watchDirs of
         dirs@(_ : _) -> pure $ map (coerce projectRoot </>) dirs
-        [] -> resolveWatchDirsFromTargets cfg.targets projectRoot
+        [] -> resolveWatchDirsFromTargets targets projectRoot
 
 
 resolveWatchDirsFromTargets :: (FileSystem :> es) => [Text] -> ProjectRoot -> Eff es [FilePath]
@@ -218,7 +218,7 @@ runSession act = do
     let cfgFile = extractConfig @"session" @Config loadedCfg
     effectiveTargets <- resolveTargets projectRoot cfgFile.targets
     command <- resolveCommand projectRoot cfgFile
-    watchDirs <- resolveWatchDirs projectRoot cfgFile
+    watchDirs <- resolveWatchDirs projectRoot cfgFile effectiveTargets
     let testTargets = resolveTestTargets cfgFile effectiveTargets
         cfg =
             Session

--- a/tricorder/src/Tricorder/Session.hs
+++ b/tricorder/src/Tricorder/Session.hs
@@ -198,10 +198,10 @@ allComponentTargets gpd =
 --
 -- When 'testTargets' is set in config, those suites are used directly.
 -- Otherwise, all @test:@ components in 'targets' are inferred.
-resolveTestTargets :: Config -> [Text]
-resolveTestTargets cfg = case cfg.testTargets of
+resolveTestTargets :: Config -> [Text] -> [Text]
+resolveTestTargets cfg targets = case cfg.testTargets of
     Just explicit -> explicit
-    Nothing -> filter ("test:" `T.isPrefixOf`) cfg.targets
+    Nothing -> filter ("test:" `T.isPrefixOf`) targets
 
 
 runSession
@@ -219,7 +219,7 @@ runSession act = do
     effectiveTargets <- resolveTargets projectRoot cfgFile.targets
     command <- resolveCommand projectRoot cfgFile
     watchDirs <- resolveWatchDirs projectRoot cfgFile
-    let testTargets = resolveTestTargets cfgFile
+    let testTargets = resolveTestTargets cfgFile effectiveTargets
         cfg =
             Session
                 { targets = effectiveTargets

--- a/tricorder/test/Unit/Tricorder/SessionSpec.hs
+++ b/tricorder/test/Unit/Tricorder/SessionSpec.hs
@@ -80,29 +80,24 @@ testAllComponentTargets = do
 testResolveTestTargets :: Spec
 testResolveTestTargets = do
     it "infers test: components from targets when testTargets is absent" do
-        let cfg = def {targets = ["lib:mylib", "test:mylib-test"]} :: Config
-        resolveTestTargets cfg `shouldBe` ["test:mylib-test"]
+        let cfg = def :: Config
+        resolveTestTargets cfg ["lib:mylib", "test:mylib-test"] `shouldBe` ["test:mylib-test"]
 
     it "returns empty list when no test: components in targets" do
-        let cfg = def {targets = ["lib:mylib", "exe:myapp"]} :: Config
-        resolveTestTargets cfg `shouldBe` []
+        let cfg = def :: Config
+        resolveTestTargets cfg ["lib:mylib", "exe:myapp"] `shouldBe` []
 
     it "uses explicit testTargets list when set" do
-        let cfg =
-                def
-                    { targets = ["lib:a", "test:a-test", "test:b-test"]
-                    , testTargets = Just ["test:b-test"]
-                    }
-                    :: Config
-        resolveTestTargets cfg `shouldBe` ["test:b-test"]
+        let cfg = def {testTargets = Just ["test:b-test"]} :: Config
+        resolveTestTargets cfg ["lib:a", "test:a-test", "test:b-test"] `shouldBe` ["test:b-test"]
 
     it "returns empty list when testTargets is explicitly empty" do
-        let cfg = def {targets = ["lib:a", "test:a-test"], testTargets = Just []}
-        resolveTestTargets cfg `shouldBe` []
+        let cfg = def {testTargets = Just []} :: Config
+        resolveTestTargets cfg ["lib:a", "test:a-test"] `shouldBe` []
 
     it "infers multiple test: components" do
-        let cfg = def {targets = ["lib:a", "test:a-test", "test:b-test"]}
-        resolveTestTargets cfg `shouldBe` ["test:a-test", "test:b-test"]
+        let cfg = def :: Config
+        resolveTestTargets cfg ["lib:a", "test:a-test", "test:b-test"] `shouldBe` ["test:a-test", "test:b-test"]
 
 
 testResolveCommand :: Spec

--- a/tricorder/test/Unit/Tricorder/SessionSpec.hs
+++ b/tricorder/test/Unit/Tricorder/SessionSpec.hs
@@ -16,6 +16,7 @@ import Tricorder.Session
     , allComponentTargets
     , resolveCommand
     , resolveTestTargets
+    , resolveWatchDirs
     , sourceDirsForTarget
     )
 
@@ -23,6 +24,7 @@ import Tricorder.Session
 spec_Session :: Spec
 spec_Session = do
     describe "resolveCommand" testResolveCommand
+    describe "resolveWatchDirs" testResolveWatchDirs
     describe "resolveTestTargets" testResolveTestTargets
     describe "sourceDirsForTarget" testSourceDirsForTarget
     describe "allComponentTargets" testAllComponentTargets
@@ -75,6 +77,45 @@ testAllComponentTargets = do
     it "returns all four components for the fixture" do
         allComponentTargets gpd
             `shouldBe` ["lib:myapp", "lib:myapp-utils", "exe:myapp-exe", "test:myapp-test"]
+
+
+testResolveWatchDirs :: Spec
+testResolveWatchDirs = do
+    describe "when watch_dirs is set in config" do
+        it "uses config dirs relative to project root" do
+            let actual =
+                    runPureEff
+                        . evalState mempty
+                        . runFileSystemState
+                        $ resolveWatchDirs pr def {watchDirs = ["src", "test"]} []
+            actual `shouldBe` ["/src", "/test"]
+
+    describe "when watch_dirs is not set" do
+        it "falls back to [\".\"] when targets list is empty" do
+            let actual =
+                    runPureEff
+                        . evalState mempty
+                        . runFileSystemState
+                        $ resolveWatchDirs pr def []
+            actual `shouldBe` ["."]
+
+        it "infers source dirs from resolved targets" do
+            let actual =
+                    runPureEff
+                        . evalState (Map.singleton "/myapp.cabal" cabalFixture)
+                        . runFileSystemState
+                        $ resolveWatchDirs pr def ["lib:myapp", "test:myapp-test"]
+            actual `shouldBe` ["/src", "/test"]
+
+        it "falls back to [\".\"] when no cabal file exists" do
+            let actual =
+                    runPureEff
+                        . evalState mempty
+                        . runFileSystemState
+                        $ resolveWatchDirs pr def ["lib:myapp"]
+            actual `shouldBe` ["."]
+  where
+    pr = ProjectRoot "/"
 
 
 testResolveTestTargets :: Spec


### PR DESCRIPTION
## Problem

When targets are not explicitly configured, tricorder auto-detects them from the `.cabal` file via `resolveTargets`. However, `resolveTestTargets` and `resolveWatchDirs` were both reading `cfgFile.targets` directly — the raw config value, which is empty before resolution. This meant:

- **Tests never ran**: `resolveTestTargets` filtered an empty list for `test:` components, always producing `[]`
- **Wrong watch directories**: `resolveWatchDirs` passed the empty list to `resolveWatchDirsFromTargets`, which fell back to `["."]` (the entire project root) instead of inferring source dirs from the cabal file

Both functions already had the right logic — they just received the wrong input.

## Changes

- `resolveTestTargets` now takes the resolved target list as an explicit argument instead of reading `cfg.targets`
- `resolveWatchDirs` does the same
- Both are called in `runSession` with `effectiveTargets` (the post-resolution list) rather than the raw config field
- Added `resolveWatchDirs` unit tests covering: explicit `watch_dirs` config, empty-targets fallback, source dir inference from resolved targets, and no-cabal-file fallback
