### PR TITLE
feat: add configurable timeout for test suite runs

### DIFF
--- a/atelier/src/Atelier/Effects/Delay.hs
+++ b/atelier/src/Atelier/Effects/Delay.hs
@@ -2,6 +2,7 @@ module Atelier.Effects.Delay
     ( Delay
     , wait
     , every
+    , withTimeout
     , runDelay
     , runDelayNoOp
 
@@ -18,6 +19,7 @@ module Atelier.Effects.Delay
 import Data.Time.Units (TimeUnit, convertUnit, toMicroseconds)
 import Effectful (Effect, IOE)
 import Effectful.Concurrent (Concurrent, threadDelay)
+import Effectful.Concurrent.Async (race)
 import Effectful.Concurrent.MVar (newEmptyMVar, takeMVar)
 import Effectful.Dispatch.Dynamic (interpret_)
 import Effectful.State.Static.Shared (State, modifyM)
@@ -43,6 +45,16 @@ every :: (Delay :> es, TimeUnit t) => t -> Eff es () -> Eff es Void
 every delay action = forever do
     action
     wait delay
+
+
+-- | Race an action against a deadline. Returns 'Right' if the action
+-- completes first, 'Left' if the timeout fires first.
+withTimeout
+    :: (Concurrent :> es, Delay :> es, TimeUnit t)
+    => t
+    -> Eff es a
+    -> Eff es (Either () a)
+withTimeout duration = race (wait duration)
 
 
 runDelay :: (Concurrent :> es) => Eff (Delay : es) a -> Eff es a

--- a/atelier/test/Unit/Atelier/Effects/DelaySpec.hs
+++ b/atelier/test/Unit/Atelier/Effects/DelaySpec.hs
@@ -7,6 +7,7 @@ import Effectful.Prim.IORef (atomicModifyIORef, newIORef, readIORef)
 import Effectful.State.Static.Shared (evalState, execState, gets)
 import Test.Hspec
 
+import Effectful.Concurrent.Async qualified as Async
 import Effectful.Prim.IORef qualified as IORef
 
 import Atelier.Effects.Delay (mkTimers, runDelayWithControls)
@@ -19,6 +20,7 @@ import Atelier.Effects.Delay qualified as Delay
 spec_Delay :: Spec
 spec_Delay = do
     describe "runDelayWithControls" testRunDelayWithControls
+    describe "withTimeout" testWithTimeout
 
 
 testRunDelayWithControls :: Spec
@@ -207,3 +209,26 @@ testRunDelayWithControls = do
     runTest = runEff . runPrim . runConcurrent . Conc.runConc . evalState mkTimers . runDelayWithControls
     newRef = newIORef (0 :: Int)
     incRef ref = atomicModifyIORef ref $ (,()) . (+ 1)
+
+
+testWithTimeout :: Spec
+testWithTimeout = do
+    it "instant action returns Right" do
+        result <- runTest $ Delay.withTimeout (100 :: Microsecond) (pure ())
+        result `shouldBe` Right ()
+
+    it "action finishes before deadline returns Right" do
+        result <- runTest do
+            a <- Async.async $ Delay.withTimeout (100 :: Microsecond) (Delay.wait (10 :: Microsecond))
+            Delay.tickNext
+            Async.wait a
+        result `shouldBe` Right ()
+
+    it "deadline fires before action returns Left" do
+        result <- runTest do
+            a <- Async.async $ Delay.withTimeout (10 :: Microsecond) (Delay.wait (100 :: Microsecond))
+            Delay.tickNext
+            Async.wait a
+        result `shouldBe` Left ()
+  where
+    runTest = runEff . runPrim . runConcurrent . Conc.runConc . evalState mkTimers . runDelayWithControls

--- a/tricorder/src/Tricorder/Effects/TestRunner.hs
+++ b/tricorder/src/Tricorder/Effects/TestRunner.hs
@@ -13,20 +13,25 @@ module Tricorder.Effects.TestRunner
     ) where
 
 import Control.Exception (throwIO)
+import Data.Time.Units (Second)
 import Effectful (Effect, IOE)
+import Effectful.Concurrent (Concurrent)
+import Effectful.Concurrent.STM (atomically)
 import Effectful.Dispatch.Dynamic (interpretWith_, reinterpret)
 import Effectful.Exception (trySync)
 import Effectful.Reader.Static (Reader, ask)
 import Effectful.State.Static.Shared (State, evalState, get, put)
 import Effectful.TH (makeEffect)
-import System.Process.Typed (byteStringInput, proc, readProcess, setStdin, setWorkingDir)
+import System.Process.Typed (byteStringInput, byteStringOutput, getStderr, getStdout, proc, setStderr, setStdin, setStdout, setWorkingDir, withProcessTerm)
 
 import Data.ByteString.Lazy qualified as BSL
 import Data.List qualified as List
 import Data.Text qualified as T
 
+import Atelier.Effects.Delay (Delay, withTimeout)
 import Tricorder.BuildState (TestRun (..), TestRunCompletion (..), TestRunError (..))
 import Tricorder.Runtime (ProjectRoot (..))
+import Tricorder.Session (Session (..))
 import Tricorder.TestOutput (parseHspecOutput)
 
 
@@ -42,23 +47,36 @@ makeEffect ''TestRunner
 -- | Production interpreter that spawns a short-lived @cabal repl test:\<name\>@
 -- process for each suite, feeds @:main\\n:quit\\n@ to stdin, captures combined
 -- stdout+stderr, and detects the outcome via 'detectOutcome'.
-runTestRunnerIO :: (IOE :> es, Reader ProjectRoot :> es) => Eff (TestRunner : es) a -> Eff es a
+runTestRunnerIO :: (Concurrent :> es, Delay :> es, IOE :> es, Reader ProjectRoot :> es, Reader Session :> es) => Eff (TestRunner : es) a -> Eff es a
 runTestRunnerIO act = do
     ProjectRoot projectRoot <- ask
     interpretWith_ act \case
         RunTestSuite target -> do
-            result <- trySync $ liftIO do
-                let config =
-                        setStdin (byteStringInput ":main\n:quit\n")
-                            $ setWorkingDir projectRoot
-                            $ proc "cabal" ["repl", toString target]
-                (_, out, err) <- readProcess config
-                pure (out, err)
+            Session {testTimeout} <- ask
+            let config =
+                    proc "cabal" ["repl", toString target]
+                        & setStdin (byteStringInput ":main\n:quit\n")
+                        & setWorkingDir projectRoot
+                        & setStdout byteStringOutput
+                        & setStderr byteStringOutput
+            result <- trySync $ withProcessTerm config \p -> do
+                let collectOutput = do
+                        out <- atomically (getStdout p)
+                        err <- atomically (getStderr p)
+                        pure (out <> err)
+                case testTimeout of
+                    secs | secs <= 0 -> Right <$> collectOutput
+                    secs ->
+                        withTimeout (fromIntegral secs :: Second) collectOutput >>= \case
+                            Left () -> pure (Left secs)
+                            Right combined -> pure (Right combined)
             pure $ case result of
                 Left ex ->
                     TestRunErrored $ TestRunError {target, message = show ex}
-                Right (out, err) ->
-                    let output = decodeUtf8 (BSL.toStrict out) <> decodeUtf8 (BSL.toStrict err)
+                Right (Left secs) ->
+                    TestRunErrored $ TestRunError {target, message = "Test suite timed out after " <> show secs <> "s"}
+                Right (Right combined) ->
+                    let output = decodeUtf8 (BSL.toStrict combined)
                     in  case detectOutcome output of
                             GhciCrashed msg ->
                                 TestRunErrored $ TestRunError {target, message = msg}

--- a/tricorder/src/Tricorder/Session.hs
+++ b/tricorder/src/Tricorder/Session.hs
@@ -51,6 +51,7 @@ data Session = Session
     , watchDirs :: [FilePath]
     , outputFile :: Maybe FilePath
     , replBuildDir :: FilePath
+    , testTimeout :: Int
     }
 
 
@@ -63,6 +64,7 @@ instance Default Session where
             , watchDirs = []
             , outputFile = Nothing
             , replBuildDir = "/tmp"
+            , testTimeout = 10
             }
 
 
@@ -73,6 +75,7 @@ data Config = Config
     , testTargets :: Maybe [Text]
     , outputFile :: Maybe FilePath
     , replBuildDir :: FilePath
+    , testTimeout :: Int
     }
     deriving stock (Eq, Generic, Show)
     deriving (FromJSON) via WithDefaults (QuietSnake Config)
@@ -87,6 +90,7 @@ instance Default Config where
             , testTargets = Nothing
             , outputFile = Just "build.json"
             , replBuildDir = "dist-newstyle/tricorder"
+            , testTimeout = 10
             }
 
 
@@ -228,5 +232,6 @@ runSession act = do
                 , testTargets
                 , outputFile = cfgFile.outputFile
                 , replBuildDir = cfgFile.replBuildDir
+                , testTimeout = cfgFile.testTimeout
                 }
     runReader cfg act


### PR DESCRIPTION
- Add `testTimeout :: Int` (seconds) to `Session.Config` and `Session`, defaulting to 10s; set `test-timeout: 0` in `.tricorder.yaml` to disable
- Replace `readProcess` in `runTestRunnerIO` with `withProcessTerm` + `withTimeout`, sending SIGTERM and returning `TestRunErrored` on expiry
- Add `withTimeout` to `Atelier.Effects.Delay` as a general utility that races an action against a `Delay`-based deadline, tested in `DelaySpec`