### PR TITLE
fix: don't start GHCi twice on startup

### DIFF
--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -14,7 +14,7 @@ module Tricorder.Builder
     ) where
 
 import Data.Time (diffUTCTime)
-import Effectful.Concurrent.MVar (Concurrent, MVar, newMVar, putMVar, takeMVar)
+import Effectful.Concurrent.MVar (Concurrent, MVar, newEmptyMVar, putMVar, takeMVar)
 import Effectful.Reader.Static (Reader, ask, asks)
 import Effectful.State.Static.Shared (State, execState, get, put, state)
 import Relude.Extra.Tuple (dup)
@@ -91,7 +91,7 @@ component =
             session <- ask @Session
             Log.debug $ "Builder.component: resolved command = " <> session.command
             Log.debug $ "Builder.component: projectRoot = " <> toText projectRoot
-            builderCancelRef <- newMVar ()
+            builderCancelRef <- newEmptyMVar
             pure
                 [ Sub.listen_ compileLoadResultsIntoBuildResults
                 , Sub.listen_ requestTestRunsForNewBuildResults


### PR DESCRIPTION
`newMVar ()` created a pre-filled MVar, so `takeMVar` in `rebuildOnChange` returned immediately instead of blocking, causing `forever` to loop and launch a second GHCi session right after the initial build.