### PR TITLE
feat: restart daemon on tricorder config changes

### DIFF
--- a/tricorder/src/Tricorder/Config.hs
+++ b/tricorder/src/Tricorder/Config.hs
@@ -1,5 +1,11 @@
-module Tricorder.Config (LoadedConfig (..), runLoadedConfig) where
+module Tricorder.Config
+    ( LoadedConfig (..)
+    , runLoadedConfig
+    , restartOnConfigChange
+    ) where
 
+import Data.List (isSuffixOf)
+import Effectful.Concurrent.MVar (Concurrent, newEmptyMVar, putMVar, takeMVar)
 import Effectful.Reader.Static (Reader, ask, runReader)
 import System.FilePath ((</>))
 
@@ -8,10 +14,15 @@ import Data.Aeson.KeyMap qualified as KM
 import Data.Yaml qualified as Yaml
 
 import Atelier.Config (LoadedConfig (..))
+import Atelier.Effects.Conc (Conc)
+import Atelier.Effects.Debounce (Debounce)
 import Atelier.Effects.FileSystem (FileSystem)
+import Atelier.Effects.FileWatcher (FileWatcher)
 import Tricorder.Runtime (ProjectRoot (..))
 
+import Atelier.Effects.Conc qualified as Conc
 import Atelier.Effects.FileSystem qualified as FileSystem
+import Atelier.Effects.FileWatcher qualified as FileWatcher
 
 
 -- | Load config from .tricorder.yaml in the project root.
@@ -27,7 +38,11 @@ loadTricorderConfig projectRoot = do
             Left _ -> Aeson.Object KM.empty
             Right v -> v
   where
-    yamlPath = projectRoot </> ".tricorder.yaml"
+    yamlPath = projectRoot </> configFileName
+
+
+configFileName :: FilePath
+configFileName = ".tricorder.yaml"
 
 
 runLoadedConfig
@@ -39,3 +54,29 @@ runLoadedConfig act = do
     ProjectRoot projectRoot <- ask
     cfg <- loadTricorderConfig projectRoot
     runReader cfg act
+
+
+restartOnConfigChange
+    :: ( Conc :> es
+       , Concurrent :> es
+       , Debounce FilePath :> es
+       , FileWatcher :> es
+       , Reader ProjectRoot :> es
+       )
+    => Eff es a -> Eff es a
+restartOnConfigChange act = do
+    ProjectRoot projectRoot <- ask
+    ref <- newEmptyMVar
+    var <- Conc.scoped do
+        void $ Conc.fork do
+            res <- act
+            putMVar ref $ Just res
+
+        Conc.fork_ $ FileWatcher.watchFilePathsDebounced
+            [FileWatcher.dirWhere projectRoot (configFileName `isSuffixOf`)]
+            \_ -> putMVar ref Nothing
+
+        takeMVar ref
+    case var of
+        Nothing -> restartOnConfigChange act
+        Just x -> pure x

--- a/tricorder/src/Tricorder/Daemon/Main.hs
+++ b/tricorder/src/Tricorder/Daemon/Main.hs
@@ -22,7 +22,7 @@ import Atelier.Effects.FileWatcher (runFileWatcherIO)
 import Atelier.Effects.Monitoring.Tracing (TracingConfig, runTracingFromConfig)
 import Atelier.Effects.Publishing (runPubSub)
 import Tricorder.BuildState (BuildId (..), runDaemonInfo)
-import Tricorder.Config (runLoadedConfig)
+import Tricorder.Config (restartOnConfigChange, runLoadedConfig)
 import Tricorder.Effects.BuildStore (runBuildStore)
 import Tricorder.Effects.GhcPkg (runGhcPkgIO)
 import Tricorder.Effects.GhciSession (runGhciSessionIO)
@@ -48,15 +48,18 @@ import Tricorder.Watcher qualified as Watcher
 main :: IO ()
 main =
     runEff
-        . runTimeout
         . runConcurrent
         . runConc
-        . runExit
         . runClock
         . runDelay
-        . runFile
+        . runDebounce
+        . runFileWatcherIO
         . runFileSystemIO
         . runProjectRoot
+        . restartOnConfigChange
+        . runTimeout
+        . runExit
+        . runFile
         . runRuntimeDir
         . runSocketPath
         . runLogPath
@@ -80,8 +83,6 @@ main =
         . runCacheTtl @GhcPkg.ModuleName @GhcPkg.PackageId
         . runCacheTtl @(GhcPkg.PackageId, GhcPkg.ModuleName) @Text
         . runBuildStore
-        . runFileWatcherIO
-        . runDebounce
         . runGhcPkgIO
         . runUnixSocketIO
         . runGhciSessionIO

--- a/tricorder/src/Tricorder/Socket/Client.hs
+++ b/tricorder/src/Tricorder/Socket/Client.hs
@@ -2,7 +2,7 @@ module Tricorder.Socket.Client
     ( queryStatus
     , queryStatusWait
     , queryWatch
-    , WatchError (..)
+    , Restarting (..)
     , querySource
     , queryDiagnostic
     , requestShutdown
@@ -10,15 +10,18 @@ module Tricorder.Socket.Client
     ) where
 
 import Data.Aeson (decode, eitherDecode, encode)
-import Effectful.Error.Static (Error, throwError)
-import Effectful.Exception (catchJust)
+import Effectful (inject)
+import Effectful.Exception (catchJust, trySync)
 import Effectful.Reader.Static (Reader, ask)
+import Effectful.State.Static.Shared (evalState, get, modify, put)
 import System.IO.Error (isEOFError)
 
 import Data.ByteString.Lazy qualified as BSL
 
+import Atelier.Effects.Delay (Delay)
 import Atelier.Effects.File (File)
 import Atelier.Effects.Posix.Daemons (Daemons)
+import Atelier.Time (Millisecond)
 import Tricorder.BuildState (BuildState, Diagnostic)
 import Tricorder.Effects.UnixSocket (UnixSocket, withConnection)
 import Tricorder.GhcPkg.Types (ModuleName)
@@ -26,6 +29,7 @@ import Tricorder.Runtime (PidFile)
 import Tricorder.Socket.Protocol (ClientMessage (..), DiagnosticQuery (..), Query (..), StatusQuery (..))
 import Tricorder.SourceLookup (ModuleSourceResult)
 
+import Atelier.Effects.Delay qualified as Delay
 import Atelier.Effects.File qualified as File
 import Atelier.Effects.Posix.Daemons qualified as Daemons
 import Tricorder.Version qualified as Version
@@ -51,29 +55,44 @@ queryStatusWait sockPath = withConnection sockPath \h -> do
     receiveState h
 
 
-data WatchError = SocketClosed
-    deriving stock (Show)
+data Restarting = Restarting
 
 
 -- | Connect and stream build updates, calling the handler after each completed build.
+-- Retries automatically when the connection is lost or the daemon is restarting.
 queryWatch
-    :: (Error WatchError :> es, File :> es, UnixSocket :> es)
+    :: forall es
+     . (Delay :> es, File :> es, UnixSocket :> es)
     => FilePath
-    -> (BuildState -> Eff es ())
+    -> (Either Restarting BuildState -> Eff es ())
     -> Eff es ()
-queryWatch sockPath handler = withConnection sockPath \h -> do
-    sendQuery h Watch
-    loop h
+queryWatch sockPath handler = evalState retryLimit retryLoop
   where
+    retryLimit = 3 :: Int
+    retryLoop = do
+        retries <- get @Int
+        if retries <= 0 then
+            pure ()
+        else do
+            void $ trySync $ withConnection sockPath \h -> sendQuery h Watch >> loop h
+            Delay.wait (500 :: Millisecond)
+            modify $ subtract 1
+            retryLoop
+
     loop h = do
-        line <-
+        mLine <-
             catchJust
                 (\e -> if isEOFError e then Just e else Nothing)
-                (File.hGetLine h)
-                (\_ -> throwError SocketClosed)
-        case decode (BSL.fromStrict (encodeUtf8 (toText line))) of
-            Nothing -> pure ()
-            Just state -> handler state >> loop h
+                (Just <$> File.hGetLine h)
+                (\_ -> pure Nothing)
+        case mLine of
+            Nothing -> inject $ handler (Left Restarting)
+            Just line ->
+                case decode (BSL.fromStrict (encodeUtf8 (toText line))) of
+                    Nothing -> pure ()
+                    Just state -> do
+                        put retryLimit
+                        inject (handler (Right state)) >> loop h
 
 
 -- | Look up the source for one or more modules via the daemon.

--- a/tricorder/src/Tricorder/UI.hs
+++ b/tricorder/src/Tricorder/UI.hs
@@ -9,7 +9,6 @@ import Brick
     , neverShowCursor
     )
 import Brick.Keybindings (KeyConfig)
-import Effectful.Error.Static (runErrorWith)
 import Effectful.Reader.Static (Reader, ask)
 
 import Graphics.Vty.Attributes qualified as Attr
@@ -18,12 +17,13 @@ import Graphics.Vty.Attributes.Color qualified as Color
 import Atelier.Effects.Clock (Clock)
 import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.Console (Console)
+import Atelier.Effects.Delay (Delay)
 import Atelier.Effects.File (File)
 import Tricorder.Effects.Brick (Brick)
 import Tricorder.Effects.BrickChan (BrickChan)
 import Tricorder.Effects.UnixSocket (UnixSocket)
 import Tricorder.Runtime (SocketPath (..))
-import Tricorder.Socket.Client (WatchError, queryWatch)
+import Tricorder.Socket.Client (queryWatch)
 import Tricorder.UI.Event (Event (..), handleEvent)
 import Tricorder.UI.Keys (KeyEvent, dispatcher)
 import Tricorder.UI.State (State (..), Viewports (..))
@@ -44,6 +44,7 @@ viewUi
        , Clock :> es
        , Conc :> es
        , Console :> es
+       , Delay :> es
        , File :> es
        , Reader Keys.Config :> es
        , Reader SocketPath :> es
@@ -56,11 +57,9 @@ viewUi = do
     initialState <- Model.init
     Conc.scoped do
         _ <-
-            Conc.fork
-                $ runErrorWith @WatchError
-                    (\_ e -> BrickChan.writeBChan chan $ FailedBuild $ show e)
-                $ queryWatch sockPath
-                $ BrickChan.writeBChan chan . NewBuildState
+            Conc.fork do
+                queryWatch sockPath $ BrickChan.writeBChan chan . NewBuildState
+                BrickChan.writeBChan chan $ FailedBuild "Lost contact with the daemon"
         keyConfig <- Keys.mkKeyConfig
         void
             $ Brick.runBrickApp

--- a/tricorder/src/Tricorder/UI/Event.hs
+++ b/tricorder/src/Tricorder/UI/Event.hs
@@ -10,12 +10,13 @@ import Control.Monad.State (modify)
 import Graphics.Vty qualified as Vty
 
 import Tricorder.BuildState (BuildState (..))
+import Tricorder.Socket.Client (Restarting (..))
 import Tricorder.UI.Keys (KeyEvent)
 import Tricorder.UI.State (Processed (..), State (..), Viewports (..))
 
 
 data Event
-    = NewBuildState BuildState
+    = NewBuildState (Either Restarting BuildState)
     | FailedBuild Text
 
 
@@ -27,7 +28,9 @@ handleEvent _ _ = pure ()
 
 handleAppEvent :: Event -> EventM Viewports State ()
 handleAppEvent = \case
-    NewBuildState bs ->
+    NewBuildState (Left Restarting) ->
+        modify \s -> s {buildState = Waiting}
+    NewBuildState (Right bs) ->
         modify \s -> s {buildState = Success bs}
     FailedBuild reason ->
         modify \s -> s {buildState = Failure reason}


### PR DESCRIPTION
The daemon will restart all its components and the associated effect interpreters when the `.tricorder.yaml` file changes.

Closes https://github.com/atelier-hub/tricorder/issues/71