### PR TITLE
feat: re-resolve targets on cabal change

### DIFF
--- a/atelier/src/Atelier/Effects/Conc.hs
+++ b/atelier/src/Atelier/Effects/Conc.hs
@@ -12,6 +12,7 @@ module Atelier.Effects.Conc
     , Scope (..)
     , scoped
     , restartableForkWith
+    , restartableForkLoop
 
       -- * Interpreters
     , runConcBase
@@ -75,6 +76,18 @@ restartableForkWith signal setup action = forever $ scoped do
     r <- setup
     _ <- fork (action r)
     signal
+
+
+-- | Like 'restartableForkWith', but threads a value across iterations: the
+-- signal returns the next @r@, which is passed to the next fork. The initial
+-- @r@ seeds the first fork.
+restartableForkLoop :: (Conc :> es) => r -> Eff es r -> (r -> Eff es a) -> Eff es Void
+restartableForkLoop initial signal action = go initial
+  where
+    go r = scoped do
+        _ <- fork (action r)
+        r' <- signal
+        go r'
 
 
 -- | Base interpreter: resolves 'Conc' operations using Ki.

--- a/atelier/src/Atelier/Effects/Conc.hs
+++ b/atelier/src/Atelier/Effects/Conc.hs
@@ -21,9 +21,24 @@ module Atelier.Effects.Conc
     )
 where
 
-import Effectful (Effect, IOE, Limit (..), Persistence (..), UnliftStrategy (..), raise, withEffToIO)
+import Effectful
+    ( Effect
+    , IOE
+    , Limit (..)
+    , Persistence (..)
+    , UnliftStrategy (..)
+    , raise
+    , withEffToIO
+    )
 import Effectful.Concurrent.STM (atomically, runConcurrent)
-import Effectful.Dispatch.Dynamic (EffectHandler, interpose, interpret, localLend, localUnlift, localUnliftIO)
+import Effectful.Dispatch.Dynamic
+    ( EffectHandler
+    , interpose
+    , interpret
+    , localLend
+    , localUnlift
+    , localUnliftIO
+    )
 import Effectful.TH (makeEffect)
 
 import Ki qualified

--- a/atelier/src/Atelier/Effects/Conc.hs
+++ b/atelier/src/Atelier/Effects/Conc.hs
@@ -11,6 +11,7 @@ module Atelier.Effects.Conc
       -- * Scope
     , Scope (..)
     , scoped
+    , restartableForkWith
 
       -- * Interpreters
     , runConcBase
@@ -63,6 +64,17 @@ newtype Thread a = Thread (Ki.Thread a)
 
 
 makeEffect ''Conc
+
+
+-- | Forks an action in a loop, with a setup step that runs in the scope before
+-- each fork. Each time @signal@ returns, the current fork is cancelled, and
+-- setup and fork are run again. The setup result is passed to the forked
+-- action, structurally guaranteeing it completes before the fork starts.
+restartableForkWith :: (Conc :> es) => Eff es () -> Eff es r -> (r -> Eff es a) -> Eff es Void
+restartableForkWith signal setup action = forever $ scoped do
+    r <- setup
+    _ <- fork (action r)
+    signal
 
 
 -- | Base interpreter: resolves 'Conc' operations using Ki.

--- a/atelier/src/Atelier/Effects/Publishing.hs
+++ b/atelier/src/Atelier/Effects/Publishing.hs
@@ -3,6 +3,8 @@ module Atelier.Effects.Publishing
     , Sub
     , listen
     , listen_
+    , listenOnce
+    , listenOnce_
     , publish
     , runPubSub
     , runPubWriter
@@ -12,8 +14,11 @@ where
 import Data.Time (UTCTime)
 import Effectful (Effect)
 import Effectful.Dispatch.Dynamic (interpretWith, interpretWith_, interpret_, localSeqUnlift)
+import Effectful.Error.Static (runErrorNoCallStack, throwError)
 import Effectful.TH (makeEffect)
 import Effectful.Writer.Static.Shared (Writer, tell)
+
+import Text.Show qualified as S
 
 import Atelier.Effects.Chan (Chan)
 import Atelier.Effects.Clock (Clock)
@@ -38,6 +43,26 @@ makeEffect ''Sub
 
 listen_ :: (Sub event :> es) => (event -> Eff es ()) -> Eff es Void
 listen_ listener = listen $ \_timestamp event -> listener event
+
+
+-- | Wait for a single event and then return said event.
+listenOnce :: forall event es. (Sub event :> es) => Eff es (UTCTime, event)
+listenOnce = do
+    res <- runErrorNoCallStack
+        $ listen
+        $ \timestamp event -> throwError $ OnceEx (timestamp, event)
+    case res of
+        Left (OnceEx x) -> pure x
+        Right v -> absurd v
+
+
+-- | Same as 'listenOnce', but discards the timestamp.
+listenOnce_ :: (Sub event :> es) => Eff es event
+listenOnce_ = snd <$> listenOnce
+
+
+data OnceEx ev = OnceEx ev
+instance Show (OnceEx ev) where show _ = "OnceEx"
 
 
 -- | Internal wrapper for events with trace context

--- a/atelier/src/Atelier/Effects/Stream.hs
+++ b/atelier/src/Atelier/Effects/Stream.hs
@@ -1,0 +1,52 @@
+module Atelier.Effects.Stream
+    ( Stream
+    , next
+    , fromEvents
+    , filter
+    , changes
+    ) where
+
+import Atelier.Effects.Chan (Chan)
+import Atelier.Effects.Conc (Conc)
+import Atelier.Effects.Publishing (Sub)
+import Prelude hiding (filter)
+
+import Atelier.Effects.Chan qualified as Chan
+import Atelier.Effects.Conc qualified as Conc
+import Atelier.Effects.Publishing qualified as Sub
+
+
+-- | An infinite pull-based stream of values.
+newtype Stream es a = Stream {next :: Eff es a}
+    deriving (Functor) via (Eff es)
+
+
+-- | Run a continuation with a buffered stream of 'Sub' events. The stream
+-- subscribes before the continuation runs, so no events are missed. The
+-- internal listener thread is scoped to the continuation.
+fromEvents
+    :: forall event es a
+     . (Chan :> es, Conc :> es, Sub event :> es)
+    => (Stream es event -> Eff es a)
+    -> Eff es a
+fromEvents use = Conc.scoped do
+    (inChan, outChan) <- Chan.newChan
+    Conc.fork_ $ Sub.listen_ (Chan.writeChan inChan)
+    use $ Stream (Chan.readChan outChan)
+
+
+filter :: (a -> Bool) -> Stream es a -> Stream es a
+filter p (Stream n) = Stream loop
+  where
+    loop = do
+        x <- n
+        if p x then pure x else loop
+
+
+-- | Only emit values that differ from the previous one.
+changes :: (Eq a) => a -> Stream es a -> Stream es a
+changes initial stream = Stream (loop initial)
+  where
+    loop prev = do
+        x <- next (filter (/= prev) stream)
+        pure x

--- a/tricorder.cabal
+++ b/tricorder.cabal
@@ -33,6 +33,7 @@ library
       Tricorder.Effects.GhciSession.GhciProcess
       Tricorder.Effects.GhcPkg
       Tricorder.Effects.Logging
+      Tricorder.Effects.SessionStore
       Tricorder.Effects.TestRunner
       Tricorder.Effects.UnixSocket
       Tricorder.Events.FileChanged
@@ -457,6 +458,7 @@ test-suite tricorder-test
       Unit.Tricorder.CLI.RenderSpec
       Unit.Tricorder.Effects.GhciSession.GhciParserSpec
       Unit.Tricorder.Effects.GhciSessionSpec
+      Unit.Tricorder.Effects.SessionStoreSpec
       Unit.Tricorder.GhcPkgSpec
       Unit.Tricorder.SessionSpec
       Unit.Tricorder.SocketSpec

--- a/tricorder.cabal
+++ b/tricorder.cabal
@@ -147,6 +147,7 @@ library atelier
       Atelier.Effects.Posix.Daemons
       Atelier.Effects.Posix.IO
       Atelier.Effects.Publishing
+      Atelier.Effects.Stream
       Atelier.Effects.Tally
       Atelier.Effects.UUID
       Atelier.Exception

--- a/tricorder/proposals/006-re-resolve-targets-on-cabal-change/README.md
+++ b/tricorder/proposals/006-re-resolve-targets-on-cabal-change/README.md
@@ -1,0 +1,59 @@
+# Re-Resolve Targets on Cabal Change — Completed
+
+## Summary
+
+When a `.cabal` file changes, tricorder now reloads the active `Session` (targets, GHCi
+command, watch directories, test targets) from disk and restarts the affected components
+with the updated configuration — without restarting the daemon process. Previously, the
+session was resolved once at startup and held statically; new or removed targets were
+invisible until a manual daemon restart.
+
+**Deliverables shipped:**
+
+- `Tricorder.Effects.SessionStore` — `SessionStore` effect with `get` as its public
+  operation, `withSession` restart helper, `withSubSession` general sub-session restart
+  primitive, `Reloader` handle, `runSessionStore`, `runSessionStoreConst`
+- `SessionStoreReloaded` event — published after each successful reload
+- `Reloader` — a newtype wrapping a `reload` action, passed by `withSubSession` to the
+  managed function so it can trigger a session reload by direct call rather than via the
+  event bus
+- `BuilderSession` — focused projection of `Session` fields relevant to Builder, used to
+  avoid unnecessary restarts when unrelated session fields change
+- `withBuilderSession` — thin wrapper around `withSubSession`; restarts Builder's core
+  listeners when `BuilderSession` changes after a reload
+- `WatcherSession` — focused projection of `Session` containing only `watchDirs`
+- `withWatcherSession` — thin wrapper around `withSubSession`; re-registers filesystem
+  watches when `watchDirs` changes after a reload
+- `Session.loadSession` — replaces `runSession`; returns a plain `Session` value usable
+  at startup and on each reload
+- `Atelier.Effects.Publishing.listenOnce` / `listenOnce_` — await a single event and return
+- `Atelier.Effects.Conc.race` — fork two computations, return whichever completes first
+
+---
+
+## Module Map
+
+| Module | Role |
+|---|---|
+| `Tricorder.Effects.SessionStore` | Effect: `Get` (public); `withSession` restart loop; `withSubSession` sub-session restart primitive; `Reloader`; `runSessionStore`; `runSessionStoreConst` |
+| `Tricorder.Session` | `loadSession` — resolves `Session` from config and cabal file |
+| `Tricorder.Builder` | `BuilderSession`, `withBuilderSession`, `restartableListeners` |
+| `Tricorder.Watcher` | `WatcherSession`, `withWatcherSession`, `watchFiles` — restarts file watches when `watchDirs` changes |
+| `Tricorder.Effects.TestRunner` | Reads session via `SessionStore.get` instead of `Reader Session` |
+| `Tricorder.BuildState` | Reads session via `SessionStore.get` instead of `Reader Session` |
+| `Atelier.Effects.Conc` | Added `race` |
+| `Atelier.Effects.Publishing` | Added `listenOnce`, `listenOnce_` |
+
+---
+
+## Background Documents
+
+- [`design.md`](design.md) — problem statement, design decisions, alternatives rejected,
+  trade-offs
+
+---
+
+## Classification
+
+- **Nature:** Technical (feature / correctness fix)
+- **Status:** Completed

--- a/tricorder/proposals/006-re-resolve-targets-on-cabal-change/design.md
+++ b/tricorder/proposals/006-re-resolve-targets-on-cabal-change/design.md
@@ -1,0 +1,161 @@
+# Design: Re-Resolve Targets on Cabal Change
+
+## Status
+
+Implemented. See `README.md` for the module map.
+
+---
+
+## Problem
+
+Tricorder resolved the active `Session` (targets, GHCi command, watch directories,
+test targets) once at daemon startup and stored it statically in a `Reader Session`
+context. When a `.cabal` file changed, GHCi was restarted but the session was not
+re-read — new or removed targets were silently ignored until the daemon process was
+manually restarted.
+
+---
+
+## Approach
+
+### SessionStore effect
+
+A new `SessionStore` effect owns the live `Session` value. Its only public operation is
+`get :: SessionStore m Session`, which reads the current session. Session reloads are
+triggered through the `Reloader` handle that `withSubSession` passes to managed functions
+(see below); the underlying reload effect operation is internal to the module and not
+exported.
+
+`runSessionStore` backs the effect with a `State Session` thread. All previous uses of
+`Reader Session` across `Builder`, `Watcher`, `TestRunner`, and `BuildState` were
+replaced with `SessionStore.get`.
+
+`Session.runSession` (which combined session resolution with `runReader`) was split into
+`Session.loadSession`, a plain function that returns a `Session`. This is called both at
+startup (to seed `runSessionStore`) and on each reload.
+
+### withSession
+
+`withSession :: (ActiveSession es -> Eff es a) -> Eff es Void` runs a caller-supplied
+action in a loop. Each iteration:
+
+1. Fetches the current session via `get`.
+2. Forks the action, passing an `ActiveSession` value that carries the session and a
+   `reloadSession` handle.
+3. Waits for a `SessionStoreReloaded` event via `listenOnce_`.
+4. Ends the scope (cancelling the forked action) and repeats from step 1.
+
+This provides a uniform restart primitive for any component that needs to react to
+session reloads without each component having to manage its own reload loop.
+
+### Sub-session projections and Reloader
+
+Not every component cares about the whole `Session`. `withSubSession` generalises the
+restart pattern into a single primitive in `SessionStore`:
+
+```
+withSubSession
+    :: forall subSession es
+     . (Eq subSession, ...)
+    => (Session -> subSession)
+    -> Session
+    -> (Reloader es -> subSession -> Eff es Void)
+    -> Eff es Void
+```
+
+It takes a projection from `Session` to a smaller record, an initial session, and the
+function to restart on change. Internally it maintains a `State subSession` and only
+signals a restart when the projected value actually changes — a reload that touches
+`testTimeout` or `outputFile` does not interrupt a running GHCi session.
+
+`withSubSession` passes a `Reloader` handle to the managed function:
+
+```
+newtype Reloader es = Reloader { reload :: Eff es () }
+```
+
+Calling `reloader.reload` triggers a session reload.
+
+Two concrete projections use this primitive:
+
+- **`BuilderSession`** (`command`, `targets`, `testTargets`, `watchDirs`) — projection
+  used by Builder. `withBuilderSession` calls `withSubSession` and threads the `Reloader`
+  down through `restartableListeners`, `buildWithGhciOnChange`, `rebuildOnChange`, and
+  into `restartOnCabalChange`, which calls `reloader.reload` when a cabal change is
+  detected.
+
+- **`WatcherSession`** (`watchDirs`) — projection used by Watcher. `withWatcherSession`
+  calls `withSubSession` and the managed function ignores the `Reloader` (`\_ session ->`),
+  since Watcher never requests a reload independently — it only re-registers watches when
+  `watchDirs` actually changes in the reloaded session.
+
+### Reload flow
+
+1. `Watcher` detects a `.cabal` file change and publishes `CabalChangeDetected`.
+2. Builder's `restartOnCabalChange` increments the build ID, publishes
+   `EnteringNewPhase buildId (Building Nothing)`, and calls `reloader.reload` (the
+   `Reloader` handle threaded in from `withBuilderSession`).
+3. `reloader.reload` re-runs `loadSession`, stores the new `Session`, and publishes
+   `SessionStoreReloaded`.
+4. `withSubSession` inside `withBuilderSession` observes the `SessionStoreReloaded`
+   event via `withSession`. It compares the new `BuilderSession` projection against the
+   stored one. If anything changed, it updates the state and signals the restart
+   semaphore, ending the scope that contains `restartableListeners` (and therefore the
+   GHCi process), then re-forks with the fresh config.
+5. `withSubSession` inside `withWatcherSession` observes the same `SessionStoreReloaded`
+   event. It compares the new `WatcherSession` projection; if `watchDirs` changed, it
+   signals `watchFiles` to restart and re-register filesystem watches.
+
+
+### listenOnce and race
+
+Two utilities were added to support the session-management loops:
+
+- `Publishing.listenOnce` / `listenOnce_` — subscribe to an event, block until one
+  arrives, then return. Used internally by `withSession` to detect each
+  `SessionStoreReloaded` event, which in turn drives the restart logic in both
+  `withSubSession` instances.
+- `Conc.race` — fork two computations and return whichever completes first, cancelling
+  the other. Enables future patterns where a component needs to react to whichever of
+  two events arrives first.
+
+---
+
+## Alternatives Considered
+
+### Keep `Reader Session`; re-run `runSession` on cabal change
+
+Re-running `runSession` would require threading it through every component that held a
+`Reader Session` context, or rebuilding the entire effect stack on each reload. Either
+option is invasive. `SessionStore` centralises the mutable session in one place and
+lets all consumers call `get` without structural changes to their own effect rows.
+
+### Restart the daemon process on cabal change
+
+Simple but too blunt: daemon startup is not free (config loading, socket setup, GHC
+package cache queries), and any in-flight build state would be lost. A live reload is
+strictly better.
+
+### Reload the session on every `get` call
+
+Eager reload on every read would hit the filesystem and cabal-file parser on every
+build cycle. The event-driven approach amortises the cost: reload only when a
+`CabalChangeDetected` event says there is something new to read.
+
+---
+
+## Trade-offs
+
+**Projection staleness.** `BuilderSession` and `WatcherSession` are snapshots of the
+session fields each component cares about. If a field is added to `Session` that a
+component should respond to, both the sub-session record and its `mkSubSession` projection
+must be updated manually. The explicit projection makes the dependency visible, which is
+preferable to silent drift.
+
+**Reloader threading.** The `Reloader` handle is passed through several call sites in
+`Builder` (`restartableListeners` → `buildWithGhciOnChange` → `rebuildOnChange` →
+`restartOnCabalChange`). This is more explicit than the previous event-based approach
+but adds a parameter to each internal function. The alternative — publishing a
+`RequestSessionReload` event and subscribing to it inside `withSubSession` — required
+a type-level parameter, an extra constraint, and an internal listener thread, at the
+cost of making the control flow less direct.

--- a/tricorder/proposals/README.md
+++ b/tricorder/proposals/README.md
@@ -7,3 +7,4 @@
 | [003](003-source-lookup/) | Package Source Lookup | Draft |
 | [004](004-tests-after-build/) | Run Tests After Build | Draft |
 | [005](005-replace-ghcid/) | Custom GHCi Session Manager | Draft |
+| [006](006-re-resolve-targets-on-cabal-change/) | Re-Resolve Targets on Cabal Change | Done |

--- a/tricorder/src/Tricorder/BuildState.hs
+++ b/tricorder/src/Tricorder/BuildState.hs
@@ -30,9 +30,11 @@ import Effectful.Reader.Static (Reader, ask, runReader)
 import System.FilePath (makeRelative)
 
 import Atelier.Time (Millisecond)
+import Tricorder.Effects.SessionStore (SessionStore)
 import Tricorder.Runtime (LogPath (..), ProjectRoot (..), SocketPath (..))
 import Tricorder.Session (Session (..))
 
+import Tricorder.Effects.SessionStore qualified as SessionStore
 import Tricorder.Observability qualified as Observability
 
 
@@ -57,12 +59,12 @@ runDaemonInfo
     :: ( Reader LogPath :> es
        , Reader Observability.Config :> es
        , Reader ProjectRoot :> es
-       , Reader Session :> es
        , Reader SocketPath :> es
+       , SessionStore :> es
        )
     => Eff (Reader DaemonInfo : es) a -> Eff es a
 runDaemonInfo act = do
-    session <- ask @Session
+    session <- SessionStore.get
     obsCfg <- ask @Observability.Config
     ProjectRoot projectRoot <- ask
     SocketPath sockPath <- ask

--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -1,5 +1,7 @@
 module Tricorder.Builder
     ( component
+    , withBuilderSession
+    , BuilderSession (..)
     , filterToWatchDirs
     , mergeDiagnostics
     , NewLoadResult (..)
@@ -8,15 +10,16 @@ module Tricorder.Builder
     , requestTestRunsForNewBuildResults
     , buildWithGhciOnChange
     , handleInitialBuild
-    , restartOnCabalChange
+    , onRestart
     , reloadOnSourceChange
     , setNewPhase
     ) where
 
+import Data.Default (Default (..))
 import Data.Time (diffUTCTime)
 import Effectful.Concurrent (Concurrent)
 import Effectful.Exception (bracket_, trySync)
-import Effectful.Reader.Static (Reader, ask, asks)
+import Effectful.Reader.Static (Reader, ask)
 import Effectful.State.Static.Shared (State, execState, get, put, state)
 import Relude.Extra.Tuple (dup)
 import System.FilePath (isAbsolute, (</>))
@@ -45,6 +48,7 @@ import Tricorder.BuildState
     )
 import Tricorder.Effects.BuildStore (BuildStore)
 import Tricorder.Effects.GhciSession (GhciSession, LoadResult (..))
+import Tricorder.Effects.SessionStore (SessionStore, SessionStoreReloaded)
 import Tricorder.Effects.TestRunner (TestRunner)
 import Tricorder.Runtime (ProjectRoot (..))
 import Tricorder.Session (Session (..))
@@ -56,6 +60,7 @@ import Atelier.Effects.Publishing qualified as Sub
 import Atelier.Types.Semaphore qualified as Sem
 import Tricorder.Effects.BuildStore qualified as BuildStore
 import Tricorder.Effects.GhciSession qualified as GhciSession
+import Tricorder.Effects.SessionStore qualified as SessionStore
 import Tricorder.Effects.TestRunner qualified as TestRunner
 
 
@@ -78,7 +83,85 @@ component
        , Pub EnteringNewPhase :> es
        , Pub NewLoadResult :> es
        , Reader ProjectRoot :> es
-       , Reader Session :> es
+       , SessionStore :> es
+       , State BuildId :> es
+       , State DiagnosticMap :> es
+       , Sub BuildResult :> es
+       , Sub CabalChangeDetected :> es
+       , Sub EnteringNewPhase :> es
+       , Sub NewLoadResult :> es
+       , Sub SessionStoreReloaded :> es
+       , Sub SourceChangeDetected :> es
+       , TestRunner :> es
+       )
+    => Component es
+component =
+    defaultComponent
+        { name = "Builder"
+        , listeners = do
+            session <- SessionStore.get
+            pure [withBuilderSession session restartableListeners]
+        }
+
+
+-- | A subset of 'Session' with just the properties that 'Builder' cares about.
+data BuilderSession = BuilderSession
+    { command :: Text
+    , targets :: [Text]
+    , testTargets :: [Text]
+    , watchDirs :: [FilePath]
+    }
+    deriving stock (Eq)
+
+
+instance Default BuilderSession where
+    def =
+        BuilderSession
+            { command = session.command
+            , targets = session.targets
+            , testTargets = session.testTargets
+            , watchDirs = session.watchDirs
+            }
+      where
+        session = def @Session
+
+
+-- | Tracks the parts of 'Session' that 'Builder' cares about, and restarts the
+-- passed function whenever those parts change.
+withBuilderSession
+    :: ( Conc :> es
+       , Concurrent :> es
+       , SessionStore :> es
+       , Sub SessionStoreReloaded :> es
+       )
+    => Session
+    -> (SessionStore.Reloader es -> BuilderSession -> Eff es ())
+    -> Eff es Void
+withBuilderSession =
+    SessionStore.withSubSession mkBuilderSession
+  where
+    mkBuilderSession session =
+        BuilderSession
+            { command = session.command
+            , targets = session.targets
+            , testTargets = session.testTargets
+            , watchDirs = session.watchDirs
+            }
+
+
+restartableListeners
+    :: ( BuildStore :> es
+       , Clock :> es
+       , Conc :> es
+       , Concurrent :> es
+       , Debounce Text :> es
+       , GhciSession :> es
+       , Log :> es
+       , Pub BuildResult :> es
+       , Pub EnteredNewPhase :> es
+       , Pub EnteringNewPhase :> es
+       , Pub NewLoadResult :> es
+       , Reader ProjectRoot :> es
        , State BuildId :> es
        , State DiagnosticMap :> es
        , Sub BuildResult :> es
@@ -88,23 +171,30 @@ component
        , Sub SourceChangeDetected :> es
        , TestRunner :> es
        )
-    => Component es
-component =
-    defaultComponent
-        { name = "Builder"
-        , listeners = do
-            ProjectRoot projectRoot <- ask
-            session <- ask @Session
-            Log.debug $ "Builder.component: resolved command = " <> session.command
-            Log.debug $ "Builder.component: projectRoot = " <> toText projectRoot
-            builderCancelSem <- Sem.new
-            pure
-                [ Sub.listen_ compileLoadResultsIntoBuildResults
-                , Sub.listen_ requestTestRunsForNewBuildResults
-                , buildWithGhciOnChange builderCancelSem
-                , Sub.listen_ setNewPhase
-                ]
-        }
+    => SessionStore.Reloader es
+    -> BuilderSession
+    -> Eff es ()
+restartableListeners reloader config = bracket_ (pure ()) (onRestart) $ Conc.scoped do
+    ProjectRoot projectRoot <- ask
+    Log.info $ "Builder.component: resolved command = " <> config.command
+    Log.info $ "Builder.component: projectRoot = " <> toText projectRoot
+    Conc.fork_ $ Sub.listen_ $ compileLoadResultsIntoBuildResults config
+    Conc.fork_ $ Sub.listen_ $ requestTestRunsForNewBuildResults config
+    Conc.fork_ $ buildWithGhciOnChange reloader config
+    Conc.fork_ $ Sub.listen_ setNewPhase
+    Conc.awaitAll
+
+
+onRestart
+    :: ( Log :> es
+       , Pub EnteringNewPhase :> es
+       , State BuildId :> es
+       )
+    => Eff es ()
+onRestart = do
+    Log.info "Restarting builder..."
+    buildId <- state (\b -> (b, b + 1))
+    publish $ EnteringNewPhase buildId $ Building Nothing
 
 
 setNewPhase
@@ -128,40 +218,42 @@ buildWithGhciOnChange
        , Pub EnteringNewPhase :> es
        , Pub NewLoadResult :> es
        , Reader ProjectRoot :> es
-       , Reader Session :> es
-       , State (Map FilePath [Diagnostic]) :> es
        , State BuildId :> es
+       , State DiagnosticMap :> es
        , Sub CabalChangeDetected :> es
        , Sub SourceChangeDetected :> es
        )
-    => Semaphore -> Eff es Void
-buildWithGhciOnChange sem = forever do
+    => SessionStore.Reloader es
+    -> BuilderSession
+    -> Eff es Void
+buildWithGhciOnChange reloader config = forever do
     put Map.empty
-    session <- ask @Session
     projectRoot <- ask
     BuildId n <- get
-    Log.info $ "Starting GHCi session #" <> show n <> ": " <> session.command
+    Log.info $ "Starting GHCi session #" <> show n <> ": " <> config.command
 
     initialStartTime <- Clock.currentTime
-    GhciSession.withGhci session.command projectRoot \initialLoad controls -> do
+    GhciSession.withGhci config.command projectRoot \initialLoad controls -> do
         initialEndTime <- Clock.currentTime
-        handleInitialBuild initialStartTime initialEndTime initialLoad
-        rebuildOnChange sem controls
+        handleInitialBuild config initialStartTime initialEndTime initialLoad
+        rebuildOnChange reloader controls
 
 
 handleInitialBuild
     :: ( Log :> es
        , Pub NewLoadResult :> es
        , Reader ProjectRoot :> es
-       , Reader Session :> es
        , State BuildId :> es
        )
-    => UTCTime -> UTCTime -> LoadResult -> Eff es ()
-handleInitialBuild startTime endTime loadResult = do
-    session <- ask @Session
+    => BuilderSession
+    -> UTCTime
+    -> UTCTime
+    -> LoadResult
+    -> Eff es ()
+handleInitialBuild config startTime endTime loadResult = do
     ProjectRoot projectRoot <- ask
     BuildId n <- get
-    let filteredMsgs = filterToWatchDirs projectRoot session.watchDirs loadResult.diagnostics
+    let filteredMsgs = filterToWatchDirs projectRoot config.watchDirs loadResult.diagnostics
 
     Log.info
         $ mconcat
@@ -192,28 +284,17 @@ rebuildOnChange
        , Sub CabalChangeDetected :> es
        , Sub SourceChangeDetected :> es
        )
-    => Semaphore -> GhciSession.Controls (Eff es) -> Eff es ()
-rebuildOnChange sem controls = do
-    Conc.scoped do
-        BuildId n <- get
-        Log.debug $ "Builder: waiting for dirty flag (build #" <> show n <> ")"
-        Conc.fork_ $ Sub.listen_ $ restartOnCabalChange sem
-        Conc.fork_ $ handleSourceChanges controls
-        Sem.wait sem
-
-
-restartOnCabalChange
-    :: ( Concurrent :> es
-       , Log :> es
-       , Pub EnteringNewPhase :> es
-       , State BuildId :> es
-       )
-    => Semaphore -> CabalChangeDetected -> Eff es ()
-restartOnCabalChange sem CabalChangeDetected = do
-    Log.info "Cabal file changed; restarting GHCi session"
-    buildId <- state (\b -> (b, b + 1))
-    publish $ EnteringNewPhase buildId Restarting
-    Sem.signal sem
+    => SessionStore.Reloader es
+    -> GhciSession.Controls (Eff es)
+    -> Eff es Void
+rebuildOnChange reloader controls = Conc.scoped do
+    BuildId n <- get
+    Log.debug $ "Builder: waiting for dirty flag (build #" <> show n <> ")"
+    Conc.fork_ $ Sub.listen_ @CabalChangeDetected $ \_ -> do
+        Log.info "Cabal file changed; reloading session"
+        -- Signals to `withBuilderSession` that the session should be reloaded.
+        reloader.reload
+    handleSourceChanges controls
 
 
 handleSourceChanges
@@ -294,14 +375,13 @@ data NewLoadResult = NewLoadResult
 compileLoadResultsIntoBuildResults
     :: ( Pub BuildResult :> es
        , Reader ProjectRoot :> es
-       , Reader Session :> es
-       , State (Map FilePath [Diagnostic]) :> es
+       , State DiagnosticMap :> es
        )
-    => NewLoadResult -> Eff es ()
-compileLoadResultsIntoBuildResults NewLoadResult {startTime, endTime, loadResult} = do
+    => BuilderSession
+    -> NewLoadResult
+    -> Eff es ()
+compileLoadResultsIntoBuildResults session newLoadResult = do
     ProjectRoot projectRoot <- ask
-    watchDirs <- asks @Session (.watchDirs)
-
     let filteredResult =
             loadResult
                 { GhciSession.diagnostics =
@@ -318,29 +398,38 @@ compileLoadResultsIntoBuildResults NewLoadResult {startTime, endTime, loadResult
             , diagnostics = sortOn (\d -> (d.severity, d.file, d.line, d.col)) $ concat (Map.elems newAccumulated)
             , testRuns = []
             }
+  where
+    BuilderSession {watchDirs} = session
+    NewLoadResult {startTime, endTime, loadResult} = newLoadResult
 
 
 requestTestRunsForNewBuildResults
     :: ( Log :> es
        , Pub EnteringNewPhase :> es
-       , Reader Session :> es
        , State BuildId :> es
        , TestRunner :> es
        )
-    => BuildResult -> Eff es ()
-requestTestRunsForNewBuildResults partialResult = do
-    session <- ask @Session
+    => BuilderSession
+    -> BuildResult
+    -> Eff es ()
+requestTestRunsForNewBuildResults config partialResult = do
     buildId <- get
-    testRuns <- runTestsIfClean session buildId partialResult
+    testRuns <- runTestsIfClean config buildId partialResult
     publish $ EnteringNewPhase buildId $ Done partialResult {testRuns}
 
 
 -- Run all configured test suites if the build has no errors.
 -- Transitions to 'Testing' phase while suites are running.
 runTestsIfClean
-    :: (Log :> es, Pub EnteringNewPhase :> es, TestRunner :> es)
-    => Session -> BuildId -> BuildResult -> Eff es [TestRun]
-runTestsIfClean (Session {testTargets}) bid partialResult
+    :: ( Log :> es
+       , Pub EnteringNewPhase :> es
+       , TestRunner :> es
+       )
+    => BuilderSession
+    -> BuildId
+    -> BuildResult
+    -> Eff es [TestRun]
+runTestsIfClean (BuilderSession {testTargets}) bid partialResult
     | null testTargets || any (\d -> d.severity == SError) partialResult.diagnostics = pure []
     | otherwise = do
         publish
@@ -371,7 +460,7 @@ runTestsIfClean (Session {testTargets}) bid partialResult
 -- by any new diagnostics produced for them in this cycle. Files absent from
 -- 'compiledFiles' were skipped by incremental compilation and retain their
 -- previous diagnostics unchanged.
-mergeDiagnostics :: Map.Map FilePath [Diagnostic] -> LoadResult -> Map.Map FilePath [Diagnostic]
+mergeDiagnostics :: DiagnosticMap -> LoadResult -> DiagnosticMap
 mergeDiagnostics prev LoadResult {compiledFiles, diagnostics} =
     let cleared = foldr Map.delete prev compiledFiles
         newByFile = Map.fromListWith (++) [(d.file, [d]) | d <- diagnostics]

--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -130,7 +130,6 @@ instance Default BuilderSession where
 -- passed function whenever those parts change.
 withBuilderSession
     :: ( Conc :> es
-       , Concurrent :> es
        , SessionStore :> es
        , Sub SessionStoreReloaded :> es
        )

--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -27,6 +27,7 @@ import System.FilePath (isAbsolute, (</>))
 import Data.Map.Strict qualified as Map
 
 import Atelier.Component (Component (..), defaultComponent)
+import Atelier.Effects.Chan (Chan)
 import Atelier.Effects.Clock (Clock, UTCTime)
 import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.Debounce (Debounce, debounced)
@@ -72,6 +73,7 @@ type DiagnosticMap = Map FilePath [Diagnostic]
 -- from the watcher.
 component
     :: ( BuildStore :> es
+       , Chan :> es
        , Clock :> es
        , Conc :> es
        , Concurrent :> es
@@ -129,7 +131,8 @@ instance Default BuilderSession where
 -- | Tracks the parts of 'Session' that 'Builder' cares about, and restarts the
 -- passed function whenever those parts change.
 withBuilderSession
-    :: ( Conc :> es
+    :: ( Chan :> es
+       , Conc :> es
        , SessionStore :> es
        , Sub SessionStoreReloaded :> es
        )

--- a/tricorder/src/Tricorder/Daemon/Main.hs
+++ b/tricorder/src/Tricorder/Daemon/Main.hs
@@ -27,15 +27,16 @@ import Tricorder.Effects.BuildStore (runBuildStore)
 import Tricorder.Effects.GhcPkg (runGhcPkgIO)
 import Tricorder.Effects.GhciSession (runGhciSession)
 import Tricorder.Effects.Logging (runLogging)
+import Tricorder.Effects.SessionStore (runSessionStore)
 import Tricorder.Effects.TestRunner (runTestRunnerIO)
 import Tricorder.Effects.UnixSocket (runUnixSocketIO)
 import Tricorder.Runtime (runLogPath, runProjectRoot, runRuntimeDir, runSocketPath)
-import Tricorder.Session (runSession)
 
 import Atelier.Effects.Cache.Config qualified as CacheConfig
 import Atelier.Effects.Log qualified as Log
 import Tricorder.BuildState qualified as BuildState
 import Tricorder.Builder qualified as Builder
+import Tricorder.Effects.SessionStore qualified as SessionStore
 import Tricorder.GhcPkg.Types qualified as GhcPkg
 import Tricorder.Observability qualified as Observability
 import Tricorder.Socket.Server qualified as SocketServer
@@ -53,7 +54,8 @@ main =
         . runConc
         . runClock
         . runDelay
-        . runDebounce
+        . runDebounce @FilePath
+        . runDebounce @Text
         . runFileWatcherIO
         . runFileSystemIO
         . runProjectRoot
@@ -65,12 +67,13 @@ main =
         . runSocketPath
         . runLogPath
         . runLoadedConfig
-        . runSession
         . runConfig @"observability" @Observability.Config
         . runConfig @"observability.tracing" @TracingConfig
         . runTracingFromConfig
-        . runReader @CacheConfig.Config def
         . runChan
+        . runPubSub @SessionStore.SessionStoreReloaded
+        . runSessionStore
+        . runReader @CacheConfig.Config def
         . runPubSub @Watcher.WatchedFile
         . runPubSub @Builder.NewLoadResult
         . runPubSub @BuildState.BuildResult
@@ -89,7 +92,6 @@ main =
         . runGhciSession
         . evalState (BuildId 1)
         . evalState @Builder.DiagnosticMap mempty
-        . runDebounce @Text
         $ do
             Log.info $ "Starting tricorder " <> Version.gitHash
             runSystem

--- a/tricorder/src/Tricorder/Effects/SessionStore.hs
+++ b/tricorder/src/Tricorder/Effects/SessionStore.hs
@@ -11,7 +11,6 @@ module Tricorder.Effects.SessionStore
     ) where
 
 import Effectful (Effect, inject)
-import Effectful.Concurrent (Concurrent)
 import Effectful.Dispatch.Dynamic (interpret_, reinterpretWith_)
 import Effectful.Reader.Static (Reader)
 import Effectful.TH (makeEffect)
@@ -28,7 +27,6 @@ import Tricorder.Session (Session, loadSession)
 
 import Atelier.Effects.Conc qualified as Conc
 import Atelier.Effects.Publishing qualified as Sub
-import Atelier.Types.Semaphore qualified as Sem
 
 
 data SessionStore :: Effect where
@@ -58,16 +56,9 @@ withSession
        )
     => (ActiveSession es -> Eff es a)
     -> Eff es Void
-withSession act = forever $ Conc.scoped do
-    session <- get
-    _ <-
-        Conc.fork
-            $ act
-            $ ActiveSession
-                { session
-                , reloader = Reloader rawReload
-                }
-    void $ Sub.listenOnce_ @SessionStoreReloaded
+withSession act =
+    Conc.restartableForkWith (void $ Sub.listenOnce_ @SessionStoreReloaded) get \session ->
+        act ActiveSession {session, reloader = Reloader rawReload}
 
 
 -- | Tracks the parts of 'Session' that the caller cares about, and restarts
@@ -76,7 +67,6 @@ withSession act = forever $ Conc.scoped do
 withSubSession
     :: forall subSession es a
      . ( Conc :> es
-       , Concurrent :> es
        , Eq subSession
        , SessionStore :> es
        , Sub SessionStoreReloaded :> es
@@ -86,28 +76,18 @@ withSubSession
     -> (Reloader es -> subSession -> Eff es a)
     -> Eff es Void
 withSubSession mkSubSession initialSession action =
-    State.evalState (mkSubSession initialSession) do
-        -- Used to signal the thread running the passed function to restart
-        -- the function.
-        restartSem <- Sem.new
-
-        Conc.fork_ $ withSession \activeSession -> do
-            let newSubSession = mkSubSession activeSession.session
-            oldSubSession <- State.get @subSession
-            when (newSubSession /= oldSubSession) do
-                State.put newSubSession
-                -- Sub session is changed. Signal the thread managing the
-                -- passed function to restart said function.
-                Sem.signal restartSem
-
-        -- Run the passed function and wait for the signal to restart.
-        forever $ Conc.scoped do
-            cfg <- State.get
-            _ <- Conc.fork $ inject $ action (Reloader rawReload) cfg
-            -- Passing this 'Sem.wait' ends the scope, killing all
-            -- associated threads, and restarts the passed function again,
-            -- fetching a new, fresh `subSession`.
-            Sem.wait restartSem
+    State.evalState (mkSubSession initialSession)
+        $ Conc.restartableForkWith awaitChange State.get \cfg ->
+            inject $ action (Reloader rawReload) cfg
+  where
+    awaitChange = do
+        SessionStoreReloaded newSession <- Sub.listenOnce_ @SessionStoreReloaded
+        let newSubSession = mkSubSession newSession
+        oldSubSession <- State.get @subSession
+        if newSubSession == oldSubSession then
+            awaitChange
+        else
+            State.put newSubSession
 
 
 data SessionStoreReloaded = SessionStoreReloaded Session

--- a/tricorder/src/Tricorder/Effects/SessionStore.hs
+++ b/tricorder/src/Tricorder/Effects/SessionStore.hs
@@ -1,0 +1,135 @@
+module Tricorder.Effects.SessionStore
+    ( SessionStore (..)
+    , SessionStoreReloaded (..)
+    , get
+    , withSession
+    , withSubSession
+    , ActiveSession (..)
+    , Reloader (..)
+    , runSessionStore
+    , runSessionStoreConst
+    ) where
+
+import Effectful (Effect, inject)
+import Effectful.Concurrent (Concurrent)
+import Effectful.Dispatch.Dynamic (interpret_, reinterpretWith_)
+import Effectful.Reader.Static (Reader)
+import Effectful.TH (makeEffect)
+import Relude.Extra.Tuple (dup)
+
+import Effectful.State.Static.Shared qualified as State
+
+import Atelier.Config (LoadedConfig)
+import Atelier.Effects.Conc (Conc)
+import Atelier.Effects.FileSystem (FileSystem)
+import Atelier.Effects.Publishing (Pub, Sub, publish)
+import Tricorder.Runtime (ProjectRoot)
+import Tricorder.Session (Session, loadSession)
+
+import Atelier.Effects.Conc qualified as Conc
+import Atelier.Effects.Publishing qualified as Sub
+import Atelier.Types.Semaphore qualified as Sem
+
+
+data SessionStore :: Effect where
+    Get :: SessionStore m Session
+    RawReload :: SessionStore m ()
+
+
+makeEffect ''SessionStore
+
+
+data ActiveSession es = ActiveSession
+    { session :: Session
+    , reloader :: Reloader es
+    }
+
+
+newtype Reloader es = Reloader {reload :: Eff es ()}
+
+
+-- | Operate on the most recent 'Session' stored. Whenever the session is
+-- reloaded, the passed action is cancelled, and started again with the new
+-- 'Session'.
+withSession
+    :: ( Conc :> es
+       , SessionStore :> es
+       , Sub SessionStoreReloaded :> es
+       )
+    => (ActiveSession es -> Eff es a)
+    -> Eff es Void
+withSession act = forever $ Conc.scoped do
+    session <- get
+    _ <-
+        Conc.fork
+            $ act
+            $ ActiveSession
+                { session
+                , reloader = Reloader rawReload
+                }
+    void $ Sub.listenOnce_ @SessionStoreReloaded
+
+
+-- | Tracks the parts of 'Session' that the caller cares about, and restarts
+-- the passed function whenever those parts change based on the 'subSession's
+-- 'Eq' instance.
+withSubSession
+    :: forall subSession es a
+     . ( Conc :> es
+       , Concurrent :> es
+       , Eq subSession
+       , SessionStore :> es
+       , Sub SessionStoreReloaded :> es
+       )
+    => (Session -> subSession)
+    -> Session
+    -> (Reloader es -> subSession -> Eff es a)
+    -> Eff es Void
+withSubSession mkSubSession initialSession action =
+    State.evalState (mkSubSession initialSession) do
+        -- Used to signal the thread running the passed function to restart
+        -- the function.
+        restartSem <- Sem.new
+
+        Conc.fork_ $ withSession \activeSession -> do
+            let newSubSession = mkSubSession activeSession.session
+            oldSubSession <- State.get @subSession
+            when (newSubSession /= oldSubSession) do
+                State.put newSubSession
+                -- Sub session is changed. Signal the thread managing the
+                -- passed function to restart said function.
+                Sem.signal restartSem
+
+        -- Run the passed function and wait for the signal to restart.
+        forever $ Conc.scoped do
+            cfg <- State.get
+            _ <- Conc.fork $ inject $ action (Reloader rawReload) cfg
+            -- Passing this 'Sem.wait' ends the scope, killing all
+            -- associated threads, and restarts the passed function again,
+            -- fetching a new, fresh `subSession`.
+            Sem.wait restartSem
+
+
+data SessionStoreReloaded = SessionStoreReloaded Session
+
+
+runSessionStore
+    :: ( FileSystem :> es
+       , Pub SessionStoreReloaded :> es
+       , Reader LoadedConfig :> es
+       , Reader ProjectRoot :> es
+       )
+    => Eff (SessionStore : es) a -> Eff es a
+runSessionStore act = do
+    initialSession <- loadSession
+    reinterpretWith_ (State.evalState initialSession) act \case
+        Get -> State.get
+        RawReload -> do
+            session <- State.stateM (\_ -> dup <$> loadSession)
+            publish $ SessionStoreReloaded session
+
+
+runSessionStoreConst :: Session -> Eff (SessionStore : es) a -> Eff es a
+runSessionStoreConst session = interpret_ \case
+    Get -> pure session
+    RawReload -> pure ()

--- a/tricorder/src/Tricorder/Effects/SessionStore.hs
+++ b/tricorder/src/Tricorder/Effects/SessionStore.hs
@@ -10,7 +10,7 @@ module Tricorder.Effects.SessionStore
     , runSessionStoreConst
     ) where
 
-import Effectful (Effect, inject)
+import Effectful (Effect)
 import Effectful.Dispatch.Dynamic (interpret_, reinterpretWith_)
 import Effectful.Reader.Static (Reader)
 import Effectful.TH (makeEffect)
@@ -19,6 +19,7 @@ import Relude.Extra.Tuple (dup)
 import Effectful.State.Static.Shared qualified as State
 
 import Atelier.Config (LoadedConfig)
+import Atelier.Effects.Chan (Chan)
 import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.FileSystem (FileSystem)
 import Atelier.Effects.Publishing (Pub, Sub, publish)
@@ -27,6 +28,7 @@ import Tricorder.Session (Session, loadSession)
 
 import Atelier.Effects.Conc qualified as Conc
 import Atelier.Effects.Publishing qualified as Sub
+import Atelier.Effects.Stream qualified as Stream
 
 
 data SessionStore :: Effect where
@@ -66,7 +68,8 @@ withSession act =
 -- 'Eq' instance.
 withSubSession
     :: forall subSession es a
-     . ( Conc :> es
+     . ( Chan :> es
+       , Conc :> es
        , Eq subSession
        , SessionStore :> es
        , Sub SessionStoreReloaded :> es
@@ -76,18 +79,16 @@ withSubSession
     -> (Reloader es -> subSession -> Eff es a)
     -> Eff es Void
 withSubSession mkSubSession initialSession action =
-    State.evalState (mkSubSession initialSession)
-        $ Conc.restartableForkWith awaitChange State.get \cfg ->
-            inject $ action (Reloader rawReload) cfg
-  where
-    awaitChange = do
-        SessionStoreReloaded newSession <- Sub.listenOnce_ @SessionStoreReloaded
-        let newSubSession = mkSubSession newSession
-        oldSubSession <- State.get @subSession
-        if newSubSession == oldSubSession then
-            awaitChange
-        else
-            State.put newSubSession
+    Stream.fromEvents @SessionStoreReloaded \stream ->
+        let initialSubSession = mkSubSession initialSession
+            subStream =
+                Stream.changes
+                    initialSubSession
+                    (fmap (\(SessionStoreReloaded s) -> mkSubSession s) stream)
+        in  Conc.restartableForkLoop
+                initialSubSession
+                (Stream.next subStream)
+                \cfg -> action (Reloader rawReload) cfg
 
 
 data SessionStoreReloaded = SessionStoreReloaded Session

--- a/tricorder/src/Tricorder/Effects/TestRunner.hs
+++ b/tricorder/src/Tricorder/Effects/TestRunner.hs
@@ -31,9 +31,12 @@ import Atelier.Effects.Delay (Delay, withTimeout)
 import Atelier.Effects.File (File)
 import Tricorder.BuildState (TestRun (..), TestRunCompletion (..), TestRunError (..))
 import Tricorder.Effects.GhciSession.GhciProcess (execGhci, withGhciProcess)
+import Tricorder.Effects.SessionStore (SessionStore)
 import Tricorder.Runtime (ProjectRoot (..))
 import Tricorder.Session (Session (..))
 import Tricorder.TestOutput (parseHspecDuration, parseHspecOutput)
+
+import Tricorder.Effects.SessionStore qualified as SessionStore
 
 
 data TestRunner :: Effect where
@@ -55,14 +58,14 @@ runTestRunnerIO
        , File :> es
        , IOE :> es
        , Reader ProjectRoot :> es
-       , Reader Session :> es
+       , SessionStore :> es
        )
     => Eff (TestRunner : es) a -> Eff es a
 runTestRunnerIO act = do
     ProjectRoot projectRoot <- ask
     interpretWith_ act \case
         RunTestSuite target -> do
-            Session {testTimeout} <- ask
+            Session {testTimeout} <- SessionStore.get
             result <- trySync $ withGhciProcess def ("cabal repl " <> target) projectRoot \ghci _ -> do
                 case testTimeout of
                     secs | secs <= 0 -> Right <$> execGhci ghci ":main"

--- a/tricorder/src/Tricorder/Session.hs
+++ b/tricorder/src/Tricorder/Session.hs
@@ -1,7 +1,7 @@
 module Tricorder.Session
     ( Session (..)
     , Config (..)
-    , runSession
+    , loadSession
     , resolveCommand
     , resolveTargets
     , allComponentTargets
@@ -32,7 +32,7 @@ import Distribution.Types.PackageName (unPackageName)
 import Distribution.Types.TestSuite (testBuildInfo)
 import Distribution.Types.UnqualComponentName (mkUnqualComponentName, unUnqualComponentName)
 import Distribution.Utils.Path (getSymbolicPath)
-import Effectful.Reader.Static (Reader, ask, runReader)
+import Effectful.Reader.Static (Reader, ask)
 import System.FilePath (takeExtension, (</>))
 
 import Data.Text qualified as T
@@ -208,15 +208,13 @@ resolveTestTargets cfg targets = case cfg.testTargets of
     Nothing -> filter ("test:" `T.isPrefixOf`) targets
 
 
-runSession
+loadSession
     :: ( FileSystem :> es
-       , HasCallStack
        , Reader LoadedConfig :> es
        , Reader ProjectRoot :> es
        )
-    => Eff (Reader Session : es) a
-    -> Eff es a
-runSession act = do
+    => Eff es Session
+loadSession = do
     projectRoot <- ask @ProjectRoot
     loadedCfg <- ask
     let cfgFile = extractConfig @"session" @Config loadedCfg
@@ -224,14 +222,13 @@ runSession act = do
     command <- resolveCommand projectRoot cfgFile
     watchDirs <- resolveWatchDirs projectRoot cfgFile effectiveTargets
     let testTargets = resolveTestTargets cfgFile effectiveTargets
-        cfg =
-            Session
-                { targets = effectiveTargets
-                , command
-                , watchDirs
-                , testTargets
-                , outputFile = cfgFile.outputFile
-                , replBuildDir = cfgFile.replBuildDir
-                , testTimeout = cfgFile.testTimeout
-                }
-    runReader cfg act
+    pure
+        $ Session
+            { targets = effectiveTargets
+            , command
+            , watchDirs
+            , testTargets
+            , outputFile = cfgFile.outputFile
+            , replBuildDir = cfgFile.replBuildDir
+            , testTimeout = cfgFile.testTimeout
+            }

--- a/tricorder/src/Tricorder/Watcher.hs
+++ b/tricorder/src/Tricorder/Watcher.hs
@@ -5,7 +5,6 @@ module Tricorder.Watcher
     , markWatchedFiles
     ) where
 
-import Effectful.Concurrent (Concurrent)
 import Effectful.Reader.Static (Reader, ask)
 import System.FilePath (takeExtension, takeFileName)
 
@@ -44,7 +43,6 @@ import Tricorder.Effects.SessionStore qualified as SessionStore
 component
     :: ( BuildStore :> es
        , Conc :> es
-       , Concurrent :> es
        , Debounce FilePath :> es
        , FileWatcher :> es
        , Pub CabalChangeDetected :> es
@@ -90,7 +88,6 @@ data WatcherSession = WatcherSession
 
 withWatcherSession
     :: ( Conc :> es
-       , Concurrent :> es
        , SessionStore :> es
        , Sub SessionStoreReloaded :> es
        )
@@ -103,7 +100,6 @@ withWatcherSession =
 
 watchFiles
     :: ( Conc :> es
-       , Concurrent :> es
        , Debounce FilePath :> es
        , FileWatcher :> es
        , Pub WatchedFile :> es

--- a/tricorder/src/Tricorder/Watcher.hs
+++ b/tricorder/src/Tricorder/Watcher.hs
@@ -9,6 +9,7 @@ import Effectful.Reader.Static (Reader, ask)
 import System.FilePath (takeExtension, takeFileName)
 
 import Atelier.Component (Component (..), defaultComponent)
+import Atelier.Effects.Chan (Chan)
 import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.Debounce (Debounce)
 import Atelier.Effects.FileWatcher
@@ -42,6 +43,7 @@ import Tricorder.Effects.SessionStore qualified as SessionStore
 -- or session restart accordingly.
 component
     :: ( BuildStore :> es
+       , Chan :> es
        , Conc :> es
        , Debounce FilePath :> es
        , FileWatcher :> es
@@ -87,7 +89,8 @@ data WatcherSession = WatcherSession
 
 
 withWatcherSession
-    :: ( Conc :> es
+    :: ( Chan :> es
+       , Conc :> es
        , SessionStore :> es
        , Sub SessionStoreReloaded :> es
        )
@@ -99,7 +102,8 @@ withWatcherSession =
 
 
 watchFiles
-    :: ( Conc :> es
+    :: ( Chan :> es
+       , Conc :> es
        , Debounce FilePath :> es
        , FileWatcher :> es
        , Pub WatchedFile :> es

--- a/tricorder/src/Tricorder/Watcher.hs
+++ b/tricorder/src/Tricorder/Watcher.hs
@@ -5,10 +5,12 @@ module Tricorder.Watcher
     , markWatchedFiles
     ) where
 
+import Effectful.Concurrent (Concurrent)
 import Effectful.Reader.Static (Reader, ask)
 import System.FilePath (takeExtension, takeFileName)
 
 import Atelier.Component (Component (..), defaultComponent)
+import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.Debounce (Debounce)
 import Atelier.Effects.FileWatcher
     ( FileWatcher
@@ -26,11 +28,13 @@ import Tricorder.BuildState
     , SourceChangeDetected (..)
     )
 import Tricorder.Effects.BuildStore (BuildStore)
+import Tricorder.Effects.SessionStore (SessionStore, SessionStoreReloaded)
 import Tricorder.Runtime (ProjectRoot (..))
 import Tricorder.Session (Session (..))
 
 import Atelier.Effects.Publishing qualified as Sub
 import Tricorder.Effects.BuildStore qualified as BuildStore
+import Tricorder.Effects.SessionStore qualified as SessionStore
 
 
 -- | Watcher component.
@@ -39,30 +43,24 @@ import Tricorder.Effects.BuildStore qualified as BuildStore
 -- or session restart accordingly.
 component
     :: ( BuildStore :> es
+       , Conc :> es
+       , Concurrent :> es
        , Debounce FilePath :> es
        , FileWatcher :> es
        , Pub CabalChangeDetected :> es
        , Pub SourceChangeDetected :> es
        , Pub WatchedFile :> es
        , Reader ProjectRoot :> es
-       , Reader Session :> es
+       , SessionStore :> es
+       , Sub SessionStoreReloaded :> es
        , Sub WatchedFile :> es
        )
     => Component es
 component =
     defaultComponent
         { name = "Watcher"
-        , triggers = do
-            session <- ask @Session
-            projectRoot <- ask
-            let watches = sourceWatches session <> cabalWatches projectRoot
-            pure
-                [ watchFilePathsDebounced watches $ publish . WatchedFile
-                ]
-        , listeners =
-            pure
-                [ Sub.listen_ markWatchedFiles
-                ]
+        , triggers = pure [watchFiles]
+        , listeners = pure [Sub.listen_ markWatchedFiles]
         }
 
 
@@ -84,8 +82,46 @@ markWatchedFiles f = do
 newtype WatchedFile = WatchedFile {getWatchedFile :: FilePath}
 
 
-sourceWatches :: Session -> [Watch]
-sourceWatches = map (\d -> dirExt d ".hs" `excluding` containing "dist-newstyle") . (.watchDirs)
+data WatcherSession = WatcherSession
+    { watchDirs :: [FilePath]
+    }
+    deriving stock (Eq)
+
+
+withWatcherSession
+    :: ( Conc :> es
+       , Concurrent :> es
+       , SessionStore :> es
+       , Sub SessionStoreReloaded :> es
+       )
+    => Session
+    -> (SessionStore.Reloader es -> WatcherSession -> Eff es Void)
+    -> Eff es Void
+withWatcherSession =
+    SessionStore.withSubSession $ WatcherSession . (.watchDirs)
+
+
+watchFiles
+    :: ( Conc :> es
+       , Concurrent :> es
+       , Debounce FilePath :> es
+       , FileWatcher :> es
+       , Pub WatchedFile :> es
+       , Reader ProjectRoot :> es
+       , SessionStore :> es
+       , Sub SessionStoreReloaded :> es
+       )
+    => Eff es Void
+watchFiles = do
+    initialSession <- SessionStore.get
+    withWatcherSession initialSession $ \_ session -> do
+        projectRoot <- ask
+        let watches = sourceWatches session.watchDirs <> cabalWatches projectRoot
+        watchFilePathsDebounced watches $ publish . WatchedFile
+
+
+sourceWatches :: [FilePath] -> [Watch]
+sourceWatches = map (\d -> dirExt d ".hs" `excluding` containing "dist-newstyle")
 
 
 cabalWatches :: ProjectRoot -> [Watch]

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -21,7 +21,6 @@ import Tricorder.BuildState
     , BuildPhase (..)
     , BuildResult (..)
     , BuildState (..)
-    , CabalChangeDetected (..)
     , DaemonInfo (..)
     , Diagnostic (..)
     , EnteredNewPhase (..)
@@ -32,24 +31,24 @@ import Tricorder.BuildState
     , TestRunCompletion (..)
     )
 import Tricorder.Builder
-    ( NewLoadResult (..)
+    ( BuilderSession (..)
+    , NewLoadResult (..)
     , compileLoadResultsIntoBuildResults
     , filterToWatchDirs
     , mergeDiagnostics
+    , onRestart
     , reloadOnSourceChange
     , requestTestRunsForNewBuildResults
-    , restartOnCabalChange
     , setNewPhase
     )
 import Tricorder.Effects.GhciSession (Controls (..), LoadResult (..), extractTitle)
 import Tricorder.Effects.TestRunner (runTestRunnerScripted)
 import Tricorder.Runtime (ProjectRoot (..))
-import Tricorder.Session (Session (..))
 
 import Atelier.Types.Semaphore qualified as Sem
 import Tricorder.BuildState qualified as BuildState
+import Tricorder.Builder qualified as Builder
 import Tricorder.Effects.BuildStore qualified as BuildStore
-import Tricorder.Session qualified as Session (Session (..))
 
 
 spec_Builder :: Spec
@@ -66,27 +65,19 @@ spec_Builder = do
 
 testRestartOnCabalChange :: Spec
 testRestartOnCabalChange = do
-    it "should signal the semaphore, exiting the current build loop" $ run do
-        sem <- Sem.new
-        _ <- runTest sem CabalChangeDetected
-        actual <- Sem.peek sem
-        liftIO $ actual `shouldBe` True
-
-    it "should publish that it is restarting the build process" $ run do
-        sem <- Sem.new
-        (phases, _) <- runTest sem CabalChangeDetected
-        liftIO $ phases `shouldBe` [EnteringNewPhase (BuildId 1) Restarting]
+    it "should publish that it is building" $ run do
+        (phases, _) <- runTest
+        liftIO $ phases `shouldBe` [EnteringNewPhase (BuildId 1) $ Building Nothing]
 
     it "should increment the build ID" $ run do
-        sem <- Sem.new
-        (_, buildId) <- runTest sem CabalChangeDetected
+        (_, buildId) <- runTest
         liftIO $ buildId `shouldBe` BuildId 2
   where
-    runTest sem =
+    runTest =
         runState (BuildId 1)
             . execWriter
-            . runPubWriter
-            . restartOnCabalChange sem
+            . runPubWriter @EnteringNewPhase
+            $ onRestart
 
     run = runEff . runConcurrent . runLogNoOp
 
@@ -211,9 +202,8 @@ testCompileLoadResultsIntoBuildResults = do
             . runWriter
             . runPubWriter
             . runReader (ProjectRoot "/")
-            . runReader @Session (def {Session.watchDirs = ["/src"]})
             . execState acc
-            . compileLoadResultsIntoBuildResults
+            . compileLoadResultsIntoBuildResults (def {Builder.watchDirs = ["/src"]})
 
 
 testRequestTestRunsForNewBuildResults :: Spec
@@ -262,11 +252,10 @@ testRequestTestRunsForNewBuildResults = do
         runEff
             . runLogNoOp
             . evalState (BuildId 1)
-            . runReader (def {testTargets})
             . execWriter
             . runPubWriter
             . runTestRunnerScripted script
-            . requestTestRunsForNewBuildResults
+            . requestTestRunsForNewBuildResults (def {testTargets})
 
     mkPhase = EnteringNewPhase (BuildId 1)
     mkTesting = mkPhase . Testing

--- a/tricorder/test/Unit/Tricorder/Effects/SessionStoreSpec.hs
+++ b/tricorder/test/Unit/Tricorder/Effects/SessionStoreSpec.hs
@@ -1,0 +1,157 @@
+module Unit.Tricorder.Effects.SessionStoreSpec (spec_SessionStore) where
+
+import Control.Concurrent (threadDelay)
+import Data.Default (def)
+import Data.IORef (IORef)
+import Data.Time (UTCTime (..), fromGregorian)
+import Effectful (IOE, runEff)
+import Effectful.Dispatch.Dynamic (interpret_)
+import Effectful.Error.Static (Error, runErrorNoCallStack, throwError)
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+import Data.IORef qualified as IORef
+
+import Atelier.Effects.Chan (Chan, runChan)
+import Atelier.Effects.Clock (Clock, runClockConst)
+import Atelier.Effects.Conc (Conc, runConc)
+import Atelier.Effects.Monitoring.Tracing (Tracing, runTracingNoOp)
+import Atelier.Effects.Publishing (Pub, Sub, publish, runPubSub)
+import Tricorder.Effects.SessionStore
+    ( ActiveSession (..)
+    , SessionStore (..)
+    , SessionStoreReloaded (..)
+    , runSessionStoreConst
+    , withSession
+    )
+import Tricorder.Session (Session (..))
+
+import Tricorder.Effects.SessionStore qualified as SessionStore
+
+
+spec_SessionStore :: Spec
+spec_SessionStore = do
+    describe "withSession" testWithSession
+
+
+testWithSession :: Spec
+testWithSession = do
+    it "calls the action with the current session" do
+        cmdRef <- IORef.newIORef Nothing
+        _ <- runFixed session1 do
+            withSession \active -> do
+                liftIO $ IORef.writeIORef cmdRef (Just active.session.command)
+                throwError StopSignal
+        result <- IORef.readIORef cmdRef
+        result `shouldBe` Just session1.command
+
+    it "provides a reloader that calls rawReload" do
+        reloadedRef <- IORef.newIORef False
+        _ <- runFlagged reloadedRef do
+            withSession \active -> do
+                active.reloader.reload
+                throwError StopSignal
+        reloaded <- IORef.readIORef reloadedRef
+        reloaded `shouldBe` True
+
+    it "restarts with the new session when reloaded" do
+        sessionsRef <- IORef.newIORef []
+        sessionRef <- IORef.newIORef session1
+        callCount <- IORef.newIORef (0 :: Int)
+        _ <- runMutable sessionRef do
+            withSession \active -> do
+                liftIO $ IORef.modifyIORef' sessionsRef (active.session.command :)
+                n <- liftIO $ IORef.atomicModifyIORef' callCount (\x -> (x + 1, x + 1))
+                if n == 1 then do
+                    -- Give withSession time to call listenOnce_ before we publish.
+                    liftIO $ threadDelay 1_000
+                    liftIO $ IORef.writeIORef sessionRef session2
+                    publish (SessionStoreReloaded session2)
+                else
+                    throwError StopSignal
+        sessions <- reverse <$> IORef.readIORef sessionsRef
+        sessions `shouldBe` [session1.command, session2.command]
+
+
+--------------------------------------------------------------------------------
+-- Effect stack
+--------------------------------------------------------------------------------
+
+data StopSignal = StopSignal
+    deriving stock (Show)
+
+
+type TestEs =
+    '[ Conc
+     , Error StopSignal
+     , Pub SessionStoreReloaded
+     , Sub SessionStoreReloaded
+     , SessionStore
+     , Chan
+     , Clock
+     , Tracing
+     , IOE
+     ]
+
+
+runFixed :: Session -> Eff TestEs a -> IO (Either StopSignal a)
+runFixed session =
+    runEff
+        . runTracingNoOp
+        . runClockConst epoch
+        . runChan
+        . runSessionStoreConst session
+        . runPubSub @SessionStoreReloaded
+        . runErrorNoCallStack @StopSignal
+        . runConc
+
+
+runFlagged :: IORef Bool -> Eff TestEs a -> IO (Either StopSignal a)
+runFlagged flag =
+    runEff
+        . runTracingNoOp
+        . runClockConst epoch
+        . runChan
+        . runSessionStoreFlagged flag
+        . runPubSub @SessionStoreReloaded
+        . runErrorNoCallStack @StopSignal
+        . runConc
+
+
+runMutable :: IORef Session -> Eff TestEs a -> IO (Either StopSignal a)
+runMutable ref =
+    runEff
+        . runTracingNoOp
+        . runClockConst epoch
+        . runChan
+        . runSessionStoreMutable ref
+        . runPubSub @SessionStoreReloaded
+        . runErrorNoCallStack @StopSignal
+        . runConc
+
+
+runSessionStoreFlagged :: (IOE :> es) => IORef Bool -> Eff (SessionStore : es) a -> Eff es a
+runSessionStoreFlagged flag = interpret_ \case
+    Get -> pure session1
+    RawReload -> liftIO $ IORef.writeIORef flag True
+
+
+runSessionStoreMutable :: (IOE :> es) => IORef Session -> Eff (SessionStore : es) a -> Eff es a
+runSessionStoreMutable ref = interpret_ \case
+    Get -> liftIO $ IORef.readIORef ref
+    RawReload -> pure ()
+
+
+--------------------------------------------------------------------------------
+-- Fixtures
+--------------------------------------------------------------------------------
+
+session1 :: Session
+session1 = def {command = "session-1"}
+
+
+session2 :: Session
+session2 = def {command = "session-2"}
+
+
+epoch :: UTCTime
+epoch = UTCTime (fromGregorian 1970 1 1) 0


### PR DESCRIPTION
- **Session re-resolution on cabal change**: introduces a SessionStore effect that owns the live Session value and
  reloads it when a .cabal file changes, replacing the static Reader Session that required a daemon restart to pick up
  new targets
- **withSubSession restart primitive**: generalises the reload loop — BuilderSession and WatcherSession are projections
  of Session that trigger restarts only when their relevant fields actually change, avoiding unnecessary GHCi
  interruptions
- **Reloader handle**: passed to managed components so they can trigger a session reload directly (e.g.
  restartOnCabalChange calls reloader.reload after detecting a cabal change)
- **SessionStoreReloaded event**: published after each reload; drives the restart logic in withBuilderSession and
  withWatcherSession
- **Utility additions**: Conc.race (return whichever of two computations finishes first) and Publishing.listenOnce /
  listenOnce_ (await a single event)

Closes https://github.com/atelier-hub/tricorder/issues/95
Depends on https://github.com/atelier-hub/tricorder/pull/96