### PR TITLE
feat: sort diagnostics errors-first

### DIFF
--- a/tricorder/src/Tricorder/BuildState.hs
+++ b/tricorder/src/Tricorder/BuildState.hs
@@ -170,7 +170,7 @@ data Diagnostic = Diagnostic
 
 
 data Severity = SError | SWarning
-    deriving stock (Eq, Show)
+    deriving stock (Eq, Ord, Show)
 
 
 instance FromJSON Severity where

--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -314,7 +314,7 @@ compileLoadResultsIntoBuildResults NewLoadResult {startTime, endTime, loadResult
             { completedAt = endTime
             , durationMs = round (realToFrac (diffUTCTime endTime startTime) * 1000 :: Double) :: Int
             , moduleCount = loadResult.moduleCount
-            , diagnostics = concat (Map.elems newAccumulated)
+            , diagnostics = sortOn (\d -> (d.severity, d.file, d.line, d.col)) $ concat (Map.elems newAccumulated)
             , testRuns = []
             }
 


### PR DESCRIPTION
- Adds `Ord` to `Severity` so `SError < SWarning`
- Sorts diagnostics by `(severity, file, line, col)` before publishing, so errors always appear above warnings in the UI and CLI output