### PR TITLE
feat: add test results view to UI under T key

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,10 +131,12 @@ The following event names are recognized:
 
 - `toggle_daemon_info_view`: Toggle displaying daemon info.
 - `quit`: Exit the TUI.
+- `exit_view`: Exit the current view or go back.
 - `scroll_up`: Scroll up in the diagnostic list.
 - `scroll_down`: Scroll down in the diagnostic list.
 - `toggle_help`: Toggle displaying the available key bindings. This includes
   your custom key bindings.
+- `cycle_test_view`: Cycle through test results views.
 
 Key binds are specified in the format `<modifiers>-<key>`, where `<modifiers>`
 is an optional `-`-separated list of modifier keys, and `<key>` is any

--- a/atelier/src/Atelier/Time.hs
+++ b/atelier/src/Atelier/Time.hs
@@ -11,11 +11,12 @@ module Atelier.Time
 
       -- * Conversions
     , nominalDiffTime
+    , fromMicroseconds
     , toMicroseconds
     , convertUnit
     ) where
 
-import Data.Aeson (FromJSON (..))
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Time (NominalDiffTime)
 import Data.Time.Units (Hour, Microsecond, Millisecond, Minute, Second, TimeUnit, convertUnit, fromMicroseconds, toMicroseconds)
 
@@ -45,3 +46,23 @@ instance FromJSON Minute where
 
 instance FromJSON Hour where
     parseJSON = fmap fromInteger . parseJSON
+
+
+instance ToJSON Microsecond where
+    toJSON us = toJSON (toMicroseconds us)
+
+
+instance ToJSON Millisecond where
+    toJSON ms = toJSON (toMicroseconds ms `div` 1000)
+
+
+instance ToJSON Second where
+    toJSON s = toJSON (toMicroseconds s `div` 1_000_000)
+
+
+instance ToJSON Minute where
+    toJSON m = toJSON (toMicroseconds m `div` 60_000_000)
+
+
+instance ToJSON Hour where
+    toJSON h = toJSON (toMicroseconds h `div` 3_600_000_000)

--- a/tricorder/src/Tricorder/BuildState.hs
+++ b/tricorder/src/Tricorder/BuildState.hs
@@ -105,6 +105,7 @@ data TestRunCompletion = TestRunCompletion
     , passed :: Bool
     , output :: Text
     , testCases :: [TestCase]
+    , durationMs :: Maybe Int
     }
     deriving stock (Eq, Generic, Show)
     deriving anyclass (FromJSON, ToJSON)

--- a/tricorder/src/Tricorder/BuildState.hs
+++ b/tricorder/src/Tricorder/BuildState.hs
@@ -29,6 +29,7 @@ import Effectful.Concurrent.STM (TVar)
 import Effectful.Reader.Static (Reader, ask, runReader)
 import System.FilePath (makeRelative)
 
+import Atelier.Time (Millisecond)
 import Tricorder.Runtime (LogPath (..), ProjectRoot (..), SocketPath (..))
 import Tricorder.Session (Session (..))
 
@@ -105,7 +106,7 @@ data TestRunCompletion = TestRunCompletion
     , passed :: Bool
     , output :: Text
     , testCases :: [TestCase]
-    , durationMs :: Maybe Int
+    , duration :: Maybe Millisecond
     }
     deriving stock (Eq, Generic, Show)
     deriving anyclass (FromJSON, ToJSON)
@@ -121,7 +122,7 @@ data TestRun
 
 data BuildResult = BuildResult
     { completedAt :: UTCTime
-    , durationMs :: Int
+    , duration :: Millisecond
     , moduleCount :: Int
     , diagnostics :: [Diagnostic]
     , testRuns :: [TestRun]

--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -29,6 +29,7 @@ import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.Debounce (Debounce, debounced)
 import Atelier.Effects.Log (Log)
 import Atelier.Effects.Publishing (Pub, Sub, publish)
+import Atelier.Time (Millisecond, nominalDiffTime)
 import Atelier.Types.Semaphore (Semaphore)
 import Tricorder.BuildState
     ( BuildId (..)
@@ -312,7 +313,7 @@ compileLoadResultsIntoBuildResults NewLoadResult {startTime, endTime, loadResult
     publish
         BuildResult
             { completedAt = endTime
-            , durationMs = round (realToFrac (diffUTCTime endTime startTime) * 1000 :: Double) :: Int
+            , duration = nominalDiffTime (diffUTCTime endTime startTime) :: Millisecond
             , moduleCount = loadResult.moduleCount
             , diagnostics = sortOn (\d -> (d.severity, d.file, d.line, d.col)) $ concat (Map.elems newAccumulated)
             , testRuns = []

--- a/tricorder/src/Tricorder/CLI.hs
+++ b/tricorder/src/Tricorder/CLI.hs
@@ -124,7 +124,7 @@ showStatus opts = do
         Console.putTextLn $ case tr of
             TestRunning t -> t <> "  running..."
             TestRunErrored e -> e.target <> "  error: " <> e.message
-            TestRunCompleted c -> c.target <> "  " <> if c.passed then "passed" else "failed"
+            TestRunCompleted c -> c.target <> "  " <> completionSummary c
         when (verbosity == Verbose) $ case tr of
             TestRunCompleted c ->
                 mapM_ (Console.putTextLn . ("  " <>)) (stripGhciNoise (T.lines c.output))
@@ -146,6 +146,22 @@ showStatus opts = do
                 "All good. " <> stats <> " " <> ts
             else
                 show errs <> " error(s), " <> show warns <> " warning(s) " <> stats <> " " <> ts
+
+
+completionSummary :: TestRunCompletion -> Text
+completionSummary c = statusText <> maybe "" (\ms -> " (" <> formatDuration ms <> ")") c.durationMs
+  where
+    statusText
+        | null c.testCases = if c.passed then "passed" else "failed"
+        | otherwise =
+            let total = length c.testCases
+                failedCount = length $ filter isFailedCase c.testCases
+            in  if failedCount == 0 then
+                    "passed (" <> show total <> ")"
+                else
+                    show failedCount <> "/" <> show total <> " failed"
+    isFailedCase (TestCase _ (TestCaseFailed _)) = True
+    isFailedCase _ = False
 
 
 showLog
@@ -215,7 +231,7 @@ showTests opts = do
         TestRunErrored e ->
             Console.putTextLn $ e.target <> "  error: " <> e.message
         TestRunCompleted c -> do
-            Console.putTextLn $ c.target <> "  " <> if c.passed then "passed" else "failed"
+            Console.putTextLn $ c.target <> "  " <> completionSummary c
             if opts.failedOnly then
                 if null c.testCases then do
                     Console.putTextLn "  (unrecognised test runner format — showing full output)"

--- a/tricorder/src/Tricorder/CLI.hs
+++ b/tricorder/src/Tricorder/CLI.hs
@@ -141,7 +141,7 @@ showStatus opts = do
         let errs = length $ filter ((== SError) . (.severity)) r.diagnostics
             warns = length $ filter ((== SWarning) . (.severity)) r.diagnostics
             ts = toText $ "— " <> formatTime defaultTimeLocale "%H:%M:%S" (utcToLocalTime tz r.completedAt)
-            stats = toText $ "(" <> show r.moduleCount <> " modules, " <> formatDuration r.durationMs <> ")"
+            stats = toText $ "(" <> show r.moduleCount <> " modules, " <> formatDuration r.duration <> ")"
         in  if null r.diagnostics then
                 "All good. " <> stats <> " " <> ts
             else
@@ -149,7 +149,7 @@ showStatus opts = do
 
 
 completionSummary :: TestRunCompletion -> Text
-completionSummary c = statusText <> maybe "" (\ms -> " (" <> formatDuration ms <> ")") c.durationMs
+completionSummary c = statusText <> maybe "" (\d -> " (" <> formatDuration d <> ")") c.duration
   where
     statusText
         | null c.testCases = if c.passed then "passed" else "failed"

--- a/tricorder/src/Tricorder/CLI/Render.hs
+++ b/tricorder/src/Tricorder/CLI/Render.hs
@@ -8,6 +8,7 @@ module Tricorder.CLI.Render
     ) where
 
 import Atelier.Effects.Console (Console)
+import Atelier.Time (Millisecond, toMicroseconds)
 import Tricorder.BuildState
     ( Diagnostic (..)
     , Severity (..)
@@ -18,12 +19,13 @@ import Tricorder.SourceLookup (ModuleSourceResult (..))
 import Atelier.Effects.Console qualified as Console
 
 
-formatDuration :: Int -> Text
-formatDuration ms =
-    if ms < 1000 then
-        show ms <> "ms"
-    else
-        show (ms `div` 1000) <> "." <> show ((ms `mod` 1000) `div` 100) <> "s"
+formatDuration :: Millisecond -> Text
+formatDuration d =
+    let ms = toMicroseconds d `div` 1000
+    in  if ms < 1000 then
+            show ms <> "ms"
+        else
+            show (ms `div` 1000) <> "." <> show ((ms `mod` 1000) `div` 100) <> "s"
 
 
 -- | Single-line diagnostic for plain-text / shell output.

--- a/tricorder/src/Tricorder/Effects/TestRunner.hs
+++ b/tricorder/src/Tricorder/Effects/TestRunner.hs
@@ -87,7 +87,7 @@ runTestRunnerIO act = do
                                         , passed = outcome == GhciPassed
                                         , output
                                         , testCases = parseHspecOutput output
-                                        , durationMs = parseHspecDuration output
+                                        , duration = parseHspecDuration output
                                         }
 
 

--- a/tricorder/src/Tricorder/Effects/TestRunner.hs
+++ b/tricorder/src/Tricorder/Effects/TestRunner.hs
@@ -32,7 +32,7 @@ import Atelier.Effects.Delay (Delay, withTimeout)
 import Tricorder.BuildState (TestRun (..), TestRunCompletion (..), TestRunError (..))
 import Tricorder.Runtime (ProjectRoot (..))
 import Tricorder.Session (Session (..))
-import Tricorder.TestOutput (parseHspecOutput)
+import Tricorder.TestOutput (parseHspecDuration, parseHspecOutput)
 
 
 data TestRunner :: Effect where
@@ -87,6 +87,7 @@ runTestRunnerIO act = do
                                         , passed = outcome == GhciPassed
                                         , output
                                         , testCases = parseHspecOutput output
+                                        , durationMs = parseHspecDuration output
                                         }
 
 

--- a/tricorder/src/Tricorder/Effects/TestRunner.hs
+++ b/tricorder/src/Tricorder/Effects/TestRunner.hs
@@ -22,11 +22,12 @@ import Effectful.Exception (trySync)
 import Effectful.Reader.Static (Reader, ask)
 import Effectful.State.Static.Shared (State, evalState, get, put)
 import Effectful.TH (makeEffect)
-import System.Process.Typed (byteStringInput, byteStringOutput, getStderr, getStdout, proc, setStderr, setStdin, setStdout, setWorkingDir, withProcessTerm)
+import System.Process.Typed (byteStringInput, byteStringOutput, createPipe, getStderr, getStdout, proc, setStderr, setStdin, setStdout, setWorkingDir, withProcessTerm)
 
 import Data.ByteString.Lazy qualified as BSL
 import Data.List qualified as List
 import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
 
 import Atelier.Effects.Delay (Delay, withTimeout)
 import Tricorder.BuildState (TestRun (..), TestRunCompletion (..), TestRunError (..))
@@ -55,40 +56,41 @@ runTestRunnerIO act = do
             Session {testTimeout} <- ask
             let config =
                     proc "cabal" ["repl", toString target]
-                        & setStdin (byteStringInput ":main\n:quit\n")
+                        & setStdin (byteStringInput testRunnerStdin)
                         & setWorkingDir projectRoot
-                        & setStdout byteStringOutput
+                        & setStdout createPipe
                         & setStderr byteStringOutput
             result <- trySync $ withProcessTerm config \p -> do
-                let collectOutput = do
-                        out <- atomically (getStdout p)
-                        err <- atomically (getStderr p)
-                        pure (out <> err)
+                compilationOutput <- liftIO $ drainUntilReady (getStdout p)
                 case testTimeout of
-                    secs | secs <= 0 -> Right <$> collectOutput
+                    secs | secs <= 0 -> do
+                        testOutput <- liftIO $ TIO.hGetContents (getStdout p)
+                        err <- decodeUtf8 . BSL.toStrict <$> atomically (getStderr p)
+                        pure $ Right (compilationOutput <> testOutput <> err)
                     secs ->
-                        withTimeout (fromIntegral secs :: Second) collectOutput >>= \case
+                        withTimeout (fromIntegral secs :: Second) (liftIO $ TIO.hGetContents (getStdout p)) >>= \case
                             Left () -> pure (Left secs)
-                            Right combined -> pure (Right combined)
+                            Right testOutput -> do
+                                err <- decodeUtf8 . BSL.toStrict <$> atomically (getStderr p)
+                                pure $ Right (compilationOutput <> testOutput <> err)
             pure $ case result of
                 Left ex ->
                     TestRunErrored $ TestRunError {target, message = show ex}
                 Right (Left secs) ->
                     TestRunErrored $ TestRunError {target, message = "Test suite timed out after " <> show secs <> "s"}
-                Right (Right combined) ->
-                    let output = decodeUtf8 (BSL.toStrict combined)
-                    in  case detectOutcome output of
-                            GhciCrashed msg ->
-                                TestRunErrored $ TestRunError {target, message = msg}
-                            outcome ->
-                                TestRunCompleted
-                                    $ TestRunCompletion
-                                        { target
-                                        , passed = outcome == GhciPassed
-                                        , output
-                                        , testCases = parseHspecOutput output
-                                        , durationMs = parseHspecDuration output
-                                        }
+                Right (Right output) ->
+                    case detectOutcome output of
+                        GhciCrashed msg ->
+                            TestRunErrored $ TestRunError {target, message = msg}
+                        outcome ->
+                            TestRunCompleted
+                                $ TestRunCompletion
+                                    { target
+                                    , passed = outcome == GhciPassed
+                                    , output
+                                    , testCases = parseHspecOutput output
+                                    , durationMs = parseHspecDuration output
+                                    }
 
 
 -- | Scripted interpreter for testing.
@@ -110,6 +112,39 @@ runTestRunnerScripted results = reinterpret (evalState results) $ \_ ->
                 Right r : rest -> put rest >> pure r
     in  \case
             RunTestSuite _ -> popResult
+
+
+-- ---------------------------------------------------------------------------
+-- Internal helpers
+
+-- | Sentinel marker emitted by GHCi after compilation, before ':main' runs.
+readyMarker :: Text
+readyMarker = "#~TRI-TEST-READY~#"
+
+
+-- | Stdin fed to each cabal repl session: a sentinel expression followed by
+-- ':main' and ':quit'. The sentinel fires after compilation completes, letting
+-- 'drainUntilReady' separate the compilation phase from test execution.
+testRunnerStdin :: BSL.ByteString
+testRunnerStdin =
+    BSL.fromStrict
+        $ encodeUtf8
+        $ "putStrLn " <> toText (show @String (toString readyMarker)) <> "\n:main\n:quit\n"
+
+
+-- | Read stdout until the ready marker line appears, accumulating all prior
+-- output. The marker line itself is discarded.
+drainUntilReady :: Handle -> IO Text
+drainUntilReady h = do
+    hSetBuffering h LineBuffering
+    T.unlines . reverse <$> go []
+  where
+    go acc = do
+        line <- TIO.hGetLine h
+        if readyMarker `T.isInfixOf` line then
+            pure acc
+        else
+            go (line : acc)
 
 
 data GhciOutcome

--- a/tricorder/src/Tricorder/Effects/TestRunner.hs
+++ b/tricorder/src/Tricorder/Effects/TestRunner.hs
@@ -13,24 +13,24 @@ module Tricorder.Effects.TestRunner
     ) where
 
 import Control.Exception (throwIO)
+import Data.Default (def)
 import Data.Time.Units (Second)
 import Effectful (Effect, IOE)
 import Effectful.Concurrent (Concurrent)
-import Effectful.Concurrent.STM (atomically)
 import Effectful.Dispatch.Dynamic (interpretWith_, reinterpret)
 import Effectful.Exception (trySync)
 import Effectful.Reader.Static (Reader, ask)
 import Effectful.State.Static.Shared (State, evalState, get, put)
 import Effectful.TH (makeEffect)
-import System.Process.Typed (byteStringInput, byteStringOutput, createPipe, getStderr, getStdout, proc, setStderr, setStdin, setStdout, setWorkingDir, withProcessTerm)
 
-import Data.ByteString.Lazy qualified as BSL
 import Data.List qualified as List
 import Data.Text qualified as T
-import Data.Text.IO qualified as TIO
 
+import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.Delay (Delay, withTimeout)
+import Atelier.Effects.File (File)
 import Tricorder.BuildState (TestRun (..), TestRunCompletion (..), TestRunError (..))
+import Tricorder.Effects.GhciSession.GhciProcess (execGhci, withGhciProcess)
 import Tricorder.Runtime (ProjectRoot (..))
 import Tricorder.Session (Session (..))
 import Tricorder.TestOutput (parseHspecDuration, parseHspecOutput)
@@ -48,49 +48,47 @@ makeEffect ''TestRunner
 -- | Production interpreter that spawns a short-lived @cabal repl test:\<name\>@
 -- process for each suite, feeds @:main\\n:quit\\n@ to stdin, captures combined
 -- stdout+stderr, and detects the outcome via 'detectOutcome'.
-runTestRunnerIO :: (Concurrent :> es, Delay :> es, IOE :> es, Reader ProjectRoot :> es, Reader Session :> es) => Eff (TestRunner : es) a -> Eff es a
+runTestRunnerIO
+    :: ( Conc :> es
+       , Concurrent :> es
+       , Delay :> es
+       , File :> es
+       , IOE :> es
+       , Reader ProjectRoot :> es
+       , Reader Session :> es
+       )
+    => Eff (TestRunner : es) a -> Eff es a
 runTestRunnerIO act = do
     ProjectRoot projectRoot <- ask
     interpretWith_ act \case
         RunTestSuite target -> do
             Session {testTimeout} <- ask
-            let config =
-                    proc "cabal" ["repl", toString target]
-                        & setStdin (byteStringInput testRunnerStdin)
-                        & setWorkingDir projectRoot
-                        & setStdout createPipe
-                        & setStderr byteStringOutput
-            result <- trySync $ withProcessTerm config \p -> do
-                compilationOutput <- liftIO $ drainUntilReady (getStdout p)
+            result <- trySync $ withGhciProcess def ("cabal repl " <> target) projectRoot \ghci _ -> do
                 case testTimeout of
-                    secs | secs <= 0 -> do
-                        testOutput <- liftIO $ TIO.hGetContents (getStdout p)
-                        err <- decodeUtf8 . BSL.toStrict <$> atomically (getStderr p)
-                        pure $ Right (compilationOutput <> testOutput <> err)
+                    secs | secs <= 0 -> Right <$> execGhci ghci ":main"
                     secs ->
-                        withTimeout (fromIntegral secs :: Second) (liftIO $ TIO.hGetContents (getStdout p)) >>= \case
+                        withTimeout (fromIntegral secs :: Second) (execGhci ghci ":main") >>= \case
                             Left () -> pure (Left secs)
-                            Right testOutput -> do
-                                err <- decodeUtf8 . BSL.toStrict <$> atomically (getStderr p)
-                                pure $ Right (compilationOutput <> testOutput <> err)
+                            Right ls -> pure (Right ls)
             pure $ case result of
                 Left ex ->
                     TestRunErrored $ TestRunError {target, message = show ex}
                 Right (Left secs) ->
                     TestRunErrored $ TestRunError {target, message = "Test suite timed out after " <> show secs <> "s"}
-                Right (Right output) ->
-                    case detectOutcome output of
-                        GhciCrashed msg ->
-                            TestRunErrored $ TestRunError {target, message = msg}
-                        outcome ->
-                            TestRunCompleted
-                                $ TestRunCompletion
-                                    { target
-                                    , passed = outcome == GhciPassed
-                                    , output
-                                    , testCases = parseHspecOutput output
-                                    , durationMs = parseHspecDuration output
-                                    }
+                Right (Right mainLines) ->
+                    let output = T.unlines mainLines
+                    in  case detectOutcome output of
+                            GhciCrashed msg ->
+                                TestRunErrored $ TestRunError {target, message = msg}
+                            outcome ->
+                                TestRunCompleted
+                                    $ TestRunCompletion
+                                        { target
+                                        , passed = outcome == GhciPassed
+                                        , output
+                                        , testCases = parseHspecOutput output
+                                        , durationMs = parseHspecDuration output
+                                        }
 
 
 -- | Scripted interpreter for testing.
@@ -112,39 +110,6 @@ runTestRunnerScripted results = reinterpret (evalState results) $ \_ ->
                 Right r : rest -> put rest >> pure r
     in  \case
             RunTestSuite _ -> popResult
-
-
--- ---------------------------------------------------------------------------
--- Internal helpers
-
--- | Sentinel marker emitted by GHCi after compilation, before ':main' runs.
-readyMarker :: Text
-readyMarker = "#~TRI-TEST-READY~#"
-
-
--- | Stdin fed to each cabal repl session: a sentinel expression followed by
--- ':main' and ':quit'. The sentinel fires after compilation completes, letting
--- 'drainUntilReady' separate the compilation phase from test execution.
-testRunnerStdin :: BSL.ByteString
-testRunnerStdin =
-    BSL.fromStrict
-        $ encodeUtf8
-        $ "putStrLn " <> toText (show @String (toString readyMarker)) <> "\n:main\n:quit\n"
-
-
--- | Read stdout until the ready marker line appears, accumulating all prior
--- output. The marker line itself is discarded.
-drainUntilReady :: Handle -> IO Text
-drainUntilReady h = do
-    hSetBuffering h LineBuffering
-    T.unlines . reverse <$> go []
-  where
-    go acc = do
-        line <- TIO.hGetLine h
-        if readyMarker `T.isInfixOf` line then
-            pure acc
-        else
-            go (line : acc)
 
 
 data GhciOutcome

--- a/tricorder/src/Tricorder/TestOutput.hs
+++ b/tricorder/src/Tricorder/TestOutput.hs
@@ -1,4 +1,4 @@
-module Tricorder.TestOutput (parseHspecOutput, stripGhciNoise) where
+module Tricorder.TestOutput (parseHspecOutput, parseHspecDuration, stripGhciNoise) where
 
 import Data.Text qualified as T
 
@@ -29,6 +29,21 @@ parseHspecOutput = go . T.lines
         T.strip $ T.dropEnd (T.length suffix) $ T.stripEnd l
 
     indentOf = T.length . T.takeWhile (== ' ')
+
+
+-- | Extract the test suite duration from hspec summary output.
+-- Matches non-indented summary lines ending with @"(Xs)"@,
+-- e.g. @"All 160 tests passed (0.33s)"@ or @"1 out of 177 tests failed (0.06s)"@.
+parseHspecDuration :: Text -> Maybe Int
+parseHspecDuration output =
+    listToMaybe $ mapMaybe extractMs (T.lines output)
+  where
+    extractMs line = do
+        guard $ not (T.isPrefixOf " " line)
+        guard $ T.isSuffixOf "s)" line
+        let numStr = T.takeWhileEnd (/= '(') (T.dropEnd 2 line)
+        secs <- readMaybe (T.unpack numStr) :: Maybe Double
+        pure $ round (secs * 1000)
 
 
 -- | Strip GHCi/cabal startup and shutdown noise from captured output lines.

--- a/tricorder/src/Tricorder/TestOutput.hs
+++ b/tricorder/src/Tricorder/TestOutput.hs
@@ -4,6 +4,7 @@ import Data.Char (isDigit)
 
 import Data.Text qualified as T
 
+import Atelier.Time (Millisecond, fromMicroseconds)
 import Tricorder.BuildState (TestCase (..), TestCaseOutcome (..))
 
 
@@ -60,7 +61,7 @@ stripTimingAnnotation t
 -- | Extract the test suite duration from hspec summary output.
 -- Matches non-indented summary lines ending with @"(Xs)"@,
 -- e.g. @"All 160 tests passed (0.33s)"@ or @"1 out of 177 tests failed (0.06s)"@.
-parseHspecDuration :: Text -> Maybe Int
+parseHspecDuration :: Text -> Maybe Millisecond
 parseHspecDuration output =
     listToMaybe $ mapMaybe extractMs (T.lines output)
   where
@@ -69,7 +70,7 @@ parseHspecDuration output =
         guard $ T.isSuffixOf "s)" line
         let numStr = T.takeWhileEnd (/= '(') (T.dropEnd 2 line)
         secs <- readMaybe (T.unpack numStr) :: Maybe Double
-        pure $ round (secs * 1000)
+        pure $ fromMicroseconds (round (secs * 1_000_000))
 
 
 -- | Strip GHCi/cabal startup and shutdown noise from captured output lines.

--- a/tricorder/src/Tricorder/TestOutput.hs
+++ b/tricorder/src/Tricorder/TestOutput.hs
@@ -1,5 +1,7 @@
 module Tricorder.TestOutput (parseHspecOutput, parseHspecDuration, stripGhciNoise) where
 
+import Data.Char (isDigit)
+
 import Data.Text qualified as T
 
 import Tricorder.BuildState (TestCase (..), TestCaseOutcome (..))
@@ -7,7 +9,8 @@ import Tricorder.BuildState (TestCase (..), TestCaseOutcome (..))
 
 -- | Parse hspec output into individual test case results.
 --
--- Recognises lines ending with @OK@ or @FAIL@ (right-aligned, space-padded).
+-- Recognises lines ending with @OK@ or @FAIL@ (right-aligned, space-padded),
+-- with or without a trailing timing annotation like @(0.05s)@ or @(120ms)@.
 -- For failing tests, collects the indented detail lines that follow as the
 -- failure message.
 parseHspecOutput :: Text -> [TestCase]
@@ -15,20 +18,43 @@ parseHspecOutput = go . T.lines
   where
     go [] = []
     go (l : ls)
-        | T.isSuffixOf "OK" (T.stripEnd l) =
-            TestCase {description = extractDesc "OK" l, outcome = TestCasePassed}
+        | T.isSuffixOf "OK" norm =
+            TestCase {description = extractDesc "OK" norm, outcome = TestCasePassed}
                 : go ls
-        | T.isSuffixOf "FAIL" (T.stripEnd l) =
+        | T.isSuffixOf "FAIL" norm =
             let (detailLines, rest) = span (\dl -> indentOf dl > indentOf l) ls
                 details = T.intercalate "\n" $ filter (not . T.null) $ map T.strip detailLines
-            in  TestCase {description = extractDesc "FAIL" l, outcome = TestCaseFailed details}
+            in  TestCase {description = extractDesc "FAIL" norm, outcome = TestCaseFailed details}
                     : go rest
         | otherwise = go ls
+      where
+        norm = stripTimingAnnotation (T.stripEnd l)
 
     extractDesc suffix l =
         T.strip $ T.dropEnd (T.length suffix) $ T.stripEnd l
 
     indentOf = T.length . T.takeWhile (== ' ')
+
+
+-- | Strip a trailing hspec timing annotation of the form @" (0.05s)"@ or @" (120ms)"@.
+--
+-- Scans from the end of the line: strips the closing @)@, walks backwards
+-- through digits, @.@, @s@, @m@, @μ@, then requires @(@ followed by a space.
+-- Returns the input unchanged if the suffix does not match this pattern.
+stripTimingAnnotation :: Text -> Text
+stripTimingAnnotation t
+    | T.null t || T.last t /= ')' = t
+    | otherwise =
+        let withoutClose = T.init t
+            (timePart, rest) = T.span (\c -> isDigit c || c `elem` (".smμ" :: [Char])) (T.reverse withoutClose)
+        in  if T.null timePart then
+                t
+            else case T.uncons rest of
+                Just ('(', afterParen) ->
+                    case T.uncons afterParen of
+                        Just (' ', desc) -> T.stripEnd (T.reverse desc)
+                        _ -> t
+                _ -> t
 
 
 -- | Extract the test suite duration from hspec summary output.

--- a/tricorder/src/Tricorder/UI/Keys.hs
+++ b/tricorder/src/Tricorder/UI/Keys.hs
@@ -66,6 +66,7 @@ import Tricorder.UI.State
 import Atelier.Effects.Console qualified as Console
 
 
+-- When adding a new event here, also list it in the README under "Custom Key Bindings".
 data KeyEvent
     = ToggleDaemonInfoView
     | Quit

--- a/tricorder/src/Tricorder/UI/Keys.hs
+++ b/tricorder/src/Tricorder/UI/Keys.hs
@@ -53,7 +53,15 @@ import Data.Text qualified as T
 
 import Atelier.Effects.Console (Console)
 import Tricorder.UI.Misc (warn)
-import Tricorder.UI.State (State (..), Viewports (..), invertCollapsible)
+import Tricorder.UI.State
+    ( ActiveView (..)
+    , State (..)
+    , Viewports (..)
+    , currentView
+    , cycleTestView
+    , popView
+    , pushView
+    )
 
 import Atelier.Effects.Console qualified as Console
 
@@ -61,9 +69,11 @@ import Atelier.Effects.Console qualified as Console
 data KeyEvent
     = ToggleDaemonInfoView
     | Quit
+    | ExitView
     | ScrollUp
     | ScrollDown
     | ToggleHelp
+    | CycleTestView
     deriving stock (Bounded, Enum, Eq, Ord, Show)
 
 
@@ -84,19 +94,23 @@ keys =
     keyEvents
         [ ("toggle daemon info", ToggleDaemonInfoView)
         , ("quit", Quit)
+        , ("exit view", ExitView)
         , ("scroll up", ScrollUp)
         , ("scroll down", ScrollDown)
         , ("toggle help", ToggleHelp)
+        , ("cycle test view", CycleTestView)
         ]
 
 
 bindings :: [(KeyEvent, [Binding])]
 bindings =
     [ (ToggleDaemonInfoView, [bind 'g'])
-    , (Quit, [bind 'q', ctrl 'c', binding KEsc []])
+    , (Quit, [bind 'q', ctrl 'c'])
+    , (ExitView, [binding KEsc []])
     , (ScrollUp, [binding KUp []])
     , (ScrollDown, [binding KDown []])
     , (ToggleHelp, [bind 'h'])
+    , (CycleTestView, [bind 't'])
     ]
 
 
@@ -149,19 +163,44 @@ dispatcher cfg =
         $ keyDispatcher
             cfg
             [ onEvent ToggleDaemonInfoView "Toggle daemon info view" do
-                modify \s -> s {daemonInfoView = invertCollapsible s.daemonInfoView}
+                modify \s ->
+                    if currentView s == Just ViewDaemonInfo then
+                        popView s
+                    else
+                        pushView ViewDaemonInfo s
             , onEvent Quit "Exit" do
                 halt
-            , onEvent ScrollUp "Scroll diagnostic upwards" do
-                showingHelp <- gets (.showHelp)
-                unless showingHelp
-                    $ vScrollBy (viewportScroll DiagnosticViewport) (-1)
-            , onEvent ScrollDown "Scroll diagnostic downwards" do
-                showingHelp <- gets (.showHelp)
-                unless showingHelp
-                    $ vScrollBy (viewportScroll DiagnosticViewport) 1
+            , onEvent ExitView "Exit or go back" do
+                stack <- gets (.viewStack)
+                if null stack then halt else modify popView
+            , onEvent ScrollUp "Scroll up" do
+                av <- gets currentView
+                unless (av == Just ViewHelp) do
+                    let vp = case av of
+                            Just (ViewTestResults _) -> TestViewport
+                            _ -> DiagnosticViewport
+                    vScrollBy (viewportScroll vp) (-1)
+            , onEvent ScrollDown "Scroll down" do
+                av <- gets currentView
+                unless (av == Just ViewHelp) do
+                    let vp = case av of
+                            Just (ViewTestResults _) -> TestViewport
+                            _ -> DiagnosticViewport
+                    vScrollBy (viewportScroll vp) 1
             , onEvent ToggleHelp "Toggle help" do
-                modify \s -> s {showHelp = not s.showHelp}
+                modify \s ->
+                    if currentView s == Just ViewHelp then
+                        popView s
+                    else
+                        pushView ViewHelp s
+            , onEvent CycleTestView "Cycle test results view" do
+                modify \s -> case currentView s of
+                    Just (ViewTestResults tv) ->
+                        if tv == maxBound then
+                            popView s
+                        else
+                            pushView (ViewTestResults (cycleTestView tv)) (popView s)
+                    _ -> pushView (ViewTestResults minBound) s
             ]
   where
     stringify =

--- a/tricorder/src/Tricorder/UI/State.hs
+++ b/tricorder/src/Tricorder/UI/State.hs
@@ -3,8 +3,12 @@ module Tricorder.UI.State
     , State (..)
     , Processed (..)
     , init
-    , Collapsible (..)
-    , invertCollapsible
+    , ActiveView (..)
+    , TestView (..)
+    , currentView
+    , pushView
+    , popView
+    , cycleTestView
     ) where
 
 import Atelier.Effects.Clock (Clock, TimeZone)
@@ -17,14 +21,14 @@ import Atelier.Effects.Clock qualified as Clock
 data Viewports
     = MainViewport
     | DiagnosticViewport
+    | TestViewport
     deriving stock (Eq, Ord, Show)
 
 
 data State = State
     { buildState :: Processed Text BuildState
     , timeZone :: TimeZone
-    , daemonInfoView :: Collapsible
-    , showHelp :: Bool
+    , viewStack :: [ActiveView]
     }
 
 
@@ -34,15 +38,31 @@ data Processed e a
     | Success a
 
 
-data Collapsible
-    = Expanded
-    | Collapsed
+data ActiveView
+    = ViewHelp
+    | ViewDaemonInfo
+    | ViewTestResults TestView
     deriving stock (Eq)
 
 
-invertCollapsible :: Collapsible -> Collapsible
-invertCollapsible Expanded = Collapsed
-invertCollapsible Collapsed = Expanded
+data TestView = TestViewFailOnly | TestViewFull
+    deriving stock (Bounded, Enum, Eq)
+
+
+currentView :: State -> Maybe ActiveView
+currentView = viaNonEmpty head . (.viewStack)
+
+
+pushView :: ActiveView -> State -> State
+pushView v s = s {viewStack = v : s.viewStack}
+
+
+popView :: State -> State
+popView s = s {viewStack = drop 1 s.viewStack}
+
+
+cycleTestView :: TestView -> TestView
+cycleTestView v = if v == maxBound then minBound else succ v
 
 
 init :: (Clock :> es) => Eff es State
@@ -52,6 +72,5 @@ init = do
         State
             { buildState = Waiting
             , timeZone = tz
-            , daemonInfoView = Collapsed
-            , showHelp = False
+            , viewStack = []
             }

--- a/tricorder/src/Tricorder/UI/View.hs
+++ b/tricorder/src/Tricorder/UI/View.hs
@@ -275,15 +275,19 @@ viewTestRun (TestRunCompleted c) = hBox [txt c.target, txt "  ", viewCompletionS
 
 
 viewCompletionStatus :: TestRunCompletion -> Widget n
-viewCompletionStatus c
-    | null c.testCases = if c.passed then ok (txt "passed") else err (txt "failed")
-    | otherwise =
-        let total = length c.testCases
-            failed = length $ filter isCaseFailed c.testCases
-        in  if failed == 0 then
-                ok $ txt $ "passed (" <> show total <> ")"
-            else
-                err $ txt $ show failed <> "/" <> show total <> " failed"
+viewCompletionStatus c = case c.durationMs of
+    Nothing -> statusWidget
+    Just ms -> hBoxSpaced 1 [statusWidget, subtle $ viewDuration ms]
+  where
+    statusWidget
+        | null c.testCases = if c.passed then ok (txt "passed") else err (txt "failed")
+        | otherwise =
+            let total = length c.testCases
+                failed = length $ filter isCaseFailed c.testCases
+            in  if failed == 0 then
+                    ok $ txt $ "passed (" <> show total <> ")"
+                else
+                    err $ txt $ show failed <> "/" <> show total <> " failed"
 
 
 viewTimestamp :: TimeZone -> UTCTime -> Widget n

--- a/tricorder/src/Tricorder/UI/View.hs
+++ b/tricorder/src/Tricorder/UI/View.hs
@@ -29,6 +29,7 @@ import System.FilePath (isAbsolute)
 import Data.Text qualified as T
 
 import Atelier.Effects.Clock (TimeZone)
+import Atelier.Time (Millisecond, toMicroseconds)
 import Tricorder.BuildState
     ( BuildPhase (..)
     , BuildProgress (..)
@@ -208,7 +209,7 @@ viewBuildResult tz result
         hBoxSpaced
             1
             [ ok $ txt "All good."
-            , viewBuildSummary result.moduleCount result.durationMs
+            , viewBuildSummary result.moduleCount result.duration
             , viewTimestamp tz result.completedAt
             ]
     | otherwise =
@@ -225,7 +226,7 @@ viewBuildResult tz result
                 [ hBoxSpaced
                     1
                     [ header
-                    , viewDuration result.durationMs
+                    , viewDuration result.duration
                     , viewTimestamp tz result.completedAt
                     ]
                 , withClickableVScrollBars (\_ _ -> DiagnosticViewport)
@@ -259,8 +260,8 @@ severityToAttrName SError = attrName "error"
 severityToAttrName SWarning = attrName "warning"
 
 
-viewDuration :: Int -> Widget n
-viewDuration ms = txt $ "(" <> formatDuration ms <> ")"
+viewDuration :: Millisecond -> Widget n
+viewDuration d = txt $ "(" <> formatDuration d <> ")"
 
 
 viewTestRuns :: [TestRun] -> Widget n
@@ -275,9 +276,9 @@ viewTestRun (TestRunCompleted c) = hBox [txt c.target, txt "  ", viewCompletionS
 
 
 viewCompletionStatus :: TestRunCompletion -> Widget n
-viewCompletionStatus c = case c.durationMs of
+viewCompletionStatus c = case c.duration of
     Nothing -> statusWidget
-    Just ms -> hBoxSpaced 1 [statusWidget, subtle $ viewDuration ms]
+    Just d -> hBoxSpaced 1 [statusWidget, subtle $ viewDuration d]
   where
     statusWidget
         | null c.testCases = if c.passed then ok (txt "passed") else err (txt "failed")
@@ -294,17 +295,18 @@ viewTimestamp :: TimeZone -> UTCTime -> Widget n
 viewTimestamp tz t = txt $ "— " <> toText (formatTime defaultTimeLocale "%H:%M:%S" $ utcToLocalTime tz t)
 
 
-viewBuildSummary :: Int -> Int -> Widget n
-viewBuildSummary moduleCount durationMs =
-    txt $ "(" <> show moduleCount <> " modules, " <> formatDuration durationMs <> ")"
+viewBuildSummary :: Int -> Millisecond -> Widget n
+viewBuildSummary moduleCount duration =
+    txt $ "(" <> show moduleCount <> " modules, " <> formatDuration duration <> ")"
 
 
-formatDuration :: Int -> Text
-formatDuration ms =
-    if ms < 1000 then
-        show ms <> "ms"
-    else
-        show (ms `div` 1000) <> "." <> show ((ms `mod` 1000) `div` 100) <> "s"
+formatDuration :: Millisecond -> Text
+formatDuration d =
+    let ms = toMicroseconds d `div` 1000
+    in  if ms < 1000 then
+            show ms <> "ms"
+        else
+            show (ms `div` 1000) <> "." <> show ((ms `mod` 1000) `div` 100) <> "s"
 
 
 -- | Single-line build status with no scrollable diagnostics list, used as a
@@ -324,7 +326,7 @@ viewBuildResultLine tz result
         hBoxSpaced
             1
             [ ok $ txt "All good."
-            , viewBuildSummary result.moduleCount result.durationMs
+            , viewBuildSummary result.moduleCount result.duration
             , viewTimestamp tz result.completedAt
             ]
     | otherwise =
@@ -335,7 +337,7 @@ viewBuildResultLine tz result
                     err $ txt $ show errCount <> " error(s), " <> show warnCount <> " warning(s)"
                 else
                     warn $ txt $ show warnCount <> " warning(s)"
-        in  hBoxSpaced 1 [header, viewDuration result.durationMs, viewTimestamp tz result.completedAt]
+        in  hBoxSpaced 1 [header, viewDuration result.duration, viewTimestamp tz result.completedAt]
 
 
 phaseTestRuns :: BuildPhase -> [TestRun]

--- a/tricorder/src/Tricorder/UI/View.hs
+++ b/tricorder/src/Tricorder/UI/View.hs
@@ -37,13 +37,16 @@ import Tricorder.BuildState
     , DaemonInfo (..)
     , Diagnostic (..)
     , Severity (..)
+    , TestCase (..)
+    , TestCaseOutcome (..)
     , TestRun (..)
     , TestRunCompletion (..)
     , TestRunError (..)
     )
+import Tricorder.TestOutput (stripGhciNoise)
 import Tricorder.UI.Keys (KeyEvent, viewKeybindings)
 import Tricorder.UI.Misc (emphasis, err, hBoxSpaced, ok, subtle, vBoxSpaced, warn)
-import Tricorder.UI.State (Collapsible (..), Processed (..), State (..), Viewports (..))
+import Tricorder.UI.State (ActiveView (..), Processed (..), State (..), TestView (..), Viewports (..), currentView)
 
 import Tricorder.UI.Keys qualified as Keys
 import Tricorder.Version qualified as Version
@@ -51,24 +54,27 @@ import Tricorder.Version qualified as Version
 
 view :: KeyConfig KeyEvent -> State -> [Widget Viewports]
 view kc ws =
-    [ if ws.showHelp then
-        viewHelp kc
-      else case ws.buildState of
-        Waiting ->
-            vBoxSpaced
-                1
-                [ txt "Waiting for build..."
-                , viewHint
-                ]
-        Failure reason ->
-            vBoxSpaced
-                1
-                [ txt $ "Error when contacting daemon: " <> reason
-                , viewHint
-                ]
-        Success bs ->
-            viewBuildState ws bs
+    [ case currentView ws of
+        Just ViewHelp ->
+            viewHelp kc
+        Just ViewDaemonInfo ->
+            withBuildState ws (viewDaemonInfoPanel ws.timeZone)
+        Just (ViewTestResults tv) ->
+            withBuildState ws (viewTestResultsPanel ws.timeZone tv)
+        Nothing ->
+            withBuildState ws (viewDefaultPanel ws.timeZone)
     ]
+
+
+withBuildState :: State -> (BuildState -> Widget Viewports) -> Widget Viewports
+withBuildState ws render =
+    case ws.buildState of
+        Waiting ->
+            vBoxSpaced 1 [txt "Waiting for build...", viewHint]
+        Failure reason ->
+            vBoxSpaced 1 [txt $ "Error when contacting daemon: " <> reason, viewHint]
+        Success bs ->
+            render bs
 
 
 viewHelp :: KeyConfig KeyEvent -> Widget n
@@ -83,24 +89,26 @@ viewHelp kc =
     handlers = (.khHandler) . snd <$> keyDispatcherToList (Keys.dispatcher kc)
 
 
-viewBuildState :: State -> BuildState -> Widget Viewports
-viewBuildState state bs =
+viewDefaultPanel :: TimeZone -> BuildState -> Widget Viewports
+viewDefaultPanel tz bs = vBoxSpaced 1 [viewBuildPhase tz bs.phase, viewHint]
+
+
+viewDaemonInfoPanel :: TimeZone -> BuildState -> Widget Viewports
+viewDaemonInfoPanel tz bs =
     vBoxSpaced
         1
-        [ viewBuildPhase state.timeZone bs.phase
-        , viewDaemonInfo state bs.daemonInfo
+        [ viewBuildPhaseLine tz bs.phase
+        , padBottom (Pad 1) $ viewExpandedDaemonInfo bs.daemonInfo
+        , viewHint
         ]
 
 
-viewDaemonInfo :: State -> DaemonInfo -> Widget n
-viewDaemonInfo state di =
-    vBox
-        [ case state.daemonInfoView of
-            Expanded ->
-                padBottom (Pad 1)
-                    $ viewExpandedDaemonInfo di
-            Collapsed ->
-                emptyWidget
+viewTestResultsPanel :: TimeZone -> TestView -> BuildState -> Widget Viewports
+viewTestResultsPanel tz tv bs =
+    vBoxSpaced
+        1
+        [ viewBuildPhaseLine tz bs.phase
+        , viewTestPanel tv (phaseTestRuns bs.phase)
         , viewHint
         ]
 
@@ -263,8 +271,19 @@ viewTestRuns runs = vBox $ viewTestRun <$> runs
 viewTestRun :: TestRun -> Widget n
 viewTestRun (TestRunning t) = hBox [txt t, txt "  ", warn $ txt "running..."]
 viewTestRun (TestRunErrored e) = hBox [txt e.target, txt "  ", err $ txt "error: ", txt e.message]
-viewTestRun (TestRunCompleted c) =
-    hBox [txt c.target, txt "  ", if c.passed then ok (txt "passed") else err (txt "failed")]
+viewTestRun (TestRunCompleted c) = hBox [txt c.target, txt "  ", viewCompletionStatus c]
+
+
+viewCompletionStatus :: TestRunCompletion -> Widget n
+viewCompletionStatus c
+    | null c.testCases = if c.passed then ok (txt "passed") else err (txt "failed")
+    | otherwise =
+        let total = length c.testCases
+            failed = length $ filter isCaseFailed c.testCases
+        in  if failed == 0 then
+                ok $ txt $ "passed (" <> show total <> ")"
+            else
+                err $ txt $ show failed <> "/" <> show total <> " failed"
 
 
 viewTimestamp :: TimeZone -> UTCTime -> Widget n
@@ -282,3 +301,117 @@ formatDuration ms =
         show ms <> "ms"
     else
         show (ms `div` 1000) <> "." <> show ((ms `mod` 1000) `div` 100) <> "s"
+
+
+-- | Single-line build status with no scrollable diagnostics list, used as a
+-- compact header when a secondary panel (test results, daemon info) is open.
+viewBuildPhaseLine :: TimeZone -> BuildPhase -> Widget n
+viewBuildPhaseLine tz = \case
+    Building Nothing -> warn $ txt "Building..."
+    Building (Just p) -> warn $ txt $ "Building (" <> show p.compiled <> "/" <> show p.total <> ")..."
+    Restarting -> warn $ txt "Restarting..."
+    Testing result -> viewBuildResultLine tz result
+    Done result -> viewBuildResultLine tz result
+
+
+viewBuildResultLine :: TimeZone -> BuildResult -> Widget n
+viewBuildResultLine tz result
+    | null result.diagnostics =
+        hBoxSpaced
+            1
+            [ ok $ txt "All good."
+            , viewBuildSummary result.moduleCount result.durationMs
+            , viewTimestamp tz result.completedAt
+            ]
+    | otherwise =
+        let errCount = length $ filter (\m -> m.severity == SError) result.diagnostics
+            warnCount = length $ filter (\m -> m.severity == SWarning) result.diagnostics
+            header =
+                if errCount > 0 then
+                    err $ txt $ show errCount <> " error(s), " <> show warnCount <> " warning(s)"
+                else
+                    warn $ txt $ show warnCount <> " warning(s)"
+        in  hBoxSpaced 1 [header, viewDuration result.durationMs, viewTimestamp tz result.completedAt]
+
+
+phaseTestRuns :: BuildPhase -> [TestRun]
+phaseTestRuns (Testing r) = r.testRuns
+phaseTestRuns (Done r) = r.testRuns
+phaseTestRuns _ = []
+
+
+viewTestPanel :: TestView -> [TestRun] -> Widget Viewports
+viewTestPanel _ [] = subtle $ txt "No test results."
+viewTestPanel TestViewFailOnly runs =
+    if null failedRuns then
+        vBoxSpaced
+            1
+            [ ok $ txt "All passed."
+            , padLeft (Pad 2) $ vBox $ subtle . txt . testRunTarget <$> runs
+            ]
+    else
+        scrollableRuns TestViewFailOnly failedRuns
+  where
+    failedRuns = filter isFailedRun runs
+viewTestPanel TestViewFull runs = scrollableRuns TestViewFull runs
+
+
+scrollableRuns :: TestView -> [TestRun] -> Widget Viewports
+scrollableRuns tv runs =
+    withClickableVScrollBars (\_ _ -> TestViewport)
+        $ withVScrollBarHandles
+        $ withVScrollBars OnRight
+        $ viewport TestViewport Vertical
+        $ vBox
+        $ viewTestRunDetail tv <$> runs
+
+
+viewTestRunDetail :: TestView -> TestRun -> Widget n
+viewTestRunDetail _ (TestRunning t) = hBox [txt t, txt "  ", warn $ txt "running..."]
+viewTestRunDetail _ (TestRunErrored e) = hBoxSpaced 1 [txt e.target, err $ txt "error:", txt e.message]
+viewTestRunDetail tv (TestRunCompleted c) =
+    vBox
+        [ hBox [txt c.target, txt "  ", viewCompletionStatus c]
+        , viewTestOutput tv c
+        ]
+
+
+viewTestOutput :: TestView -> TestRunCompletion -> Widget n
+viewTestOutput TestViewFull c =
+    padLeft (Pad 2) $ vBox $ txt <$> stripGhciNoise (T.lines c.output)
+viewTestOutput TestViewFailOnly c
+    | null c.testCases =
+        padLeft (Pad 2)
+            $ vBox
+                [ subtle $ txt "(unrecognised test runner — showing full output)"
+                , vBox $ txt <$> stripGhciNoise (T.lines c.output)
+                ]
+    | otherwise =
+        padLeft (Pad 2) $ vBox $ viewFailedCase <$> filter isCaseFailed c.testCases
+
+
+isFailedRun :: TestRun -> Bool
+isFailedRun (TestRunCompleted c) = not c.passed
+isFailedRun (TestRunErrored _) = True
+isFailedRun (TestRunning _) = False
+
+
+testRunTarget :: TestRun -> Text
+testRunTarget (TestRunning t) = t
+testRunTarget (TestRunErrored e) = e.target
+testRunTarget (TestRunCompleted c) = c.target
+
+
+isCaseFailed :: TestCase -> Bool
+isCaseFailed (TestCase _ (TestCaseFailed _)) = True
+isCaseFailed _ = False
+
+
+viewFailedCase :: TestCase -> Widget n
+viewFailedCase tc =
+    vBox
+        [ err $ txt tc.description
+        , case tc.outcome of
+            TestCaseFailed details -> padLeft (Pad 2) $ txtWrap details
+            TestCasePassed -> emptyWidget
+        ]

--- a/tricorder/test/Unit/Tricorder/BuildStateSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuildStateSpec.hs
@@ -60,7 +60,7 @@ mkBuildState :: [Diagnostic] -> BuildState
 mkBuildState msgs =
     BuildState
         { buildId = BuildId 1
-        , phase = Done (BuildResult {completedAt = epoch, durationMs = 0, moduleCount = 0, diagnostics = msgs, testRuns = []})
+        , phase = Done (BuildResult {completedAt = epoch, duration = 0, moduleCount = 0, diagnostics = msgs, testRuns = []})
         , daemonInfo = DaemonInfo {targets = [], watchDirs = [], sockPath = "", logFile = "", metricsPort = Nothing}
         }
   where

--- a/tricorder/test/Unit/Tricorder/BuildStoreSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuildStoreSpec.hs
@@ -139,7 +139,7 @@ buildingAt n = BuildState (BuildId n) (Building Nothing) emptyDaemonInfo
 
 
 doneAt :: Int -> BuildState
-doneAt n = BuildState (BuildId n) (Done (BuildResult {completedAt = epoch, durationMs = 0, moduleCount = 0, diagnostics = [], testRuns = []})) emptyDaemonInfo
+doneAt n = BuildState (BuildId n) (Done (BuildResult {completedAt = epoch, duration = 0, moduleCount = 0, diagnostics = [], testRuns = []})) emptyDaemonInfo
 
 
 epoch :: UTCTime

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -163,7 +163,7 @@ testCompileLoadResultsIntoBuildResults = do
                                 , diagnostics = []
                                 }
                         }
-        fmap (.durationMs) r `shouldMatchList` [10_000]
+        fmap (.duration) r `shouldMatchList` [10_000]
     it "merges with existing results" do
         let (m, _) =
                 runTest (Map.fromList [(errMsg.file, [errMsg])])
@@ -199,7 +199,7 @@ testCompileLoadResultsIntoBuildResults = do
             expected =
                 BuildResult
                     { completedAt = addUTCTime 10 epoch
-                    , durationMs = 10_000
+                    , duration = 10_000
                     , moduleCount = 2
                     , diagnostics = [warnMsg]
                     , testRuns = []
@@ -276,7 +276,7 @@ testRequestTestRunsForNewBuildResults = do
     expected =
         BuildResult
             { completedAt = addUTCTime 10 epoch
-            , durationMs = 10_000
+            , duration = 10_000
             , moduleCount = 2
             , diagnostics = [warnMsg]
             , testRuns = []
@@ -289,7 +289,7 @@ testRequestTestRunsForNewBuildResults = do
                 , passed = True
                 , output = ""
                 , testCases = []
-                , durationMs = Nothing
+                , duration = Nothing
                 }
 
 

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -289,6 +289,7 @@ testRequestTestRunsForNewBuildResults = do
                 , passed = True
                 , output = ""
                 , testCases = []
+                , durationMs = Nothing
                 }
 
 

--- a/tricorder/test/Unit/Tricorder/TestOutputSpec.hs
+++ b/tricorder/test/Unit/Tricorder/TestOutputSpec.hs
@@ -3,7 +3,7 @@ module Unit.Tricorder.TestOutputSpec (spec_TestOutput) where
 import Test.Hspec
 
 import Tricorder.BuildState (TestCase (..), TestCaseOutcome (..))
-import Tricorder.TestOutput (parseHspecOutput, stripGhciNoise)
+import Tricorder.TestOutput (parseHspecDuration, parseHspecOutput, stripGhciNoise)
 
 
 spec_TestOutput :: Spec
@@ -67,6 +67,34 @@ spec_TestOutput = do
                            , TestCase {description = "fails:", outcome = TestCaseFailed "reason"}
                            , TestCase {description = "also passes:", outcome = TestCasePassed}
                            ]
+
+    describe "parseHspecDuration" do
+        it "returns Nothing for empty output" do
+            parseHspecDuration "" `shouldBe` Nothing
+
+        it "returns Nothing when no timing line is present" do
+            parseHspecDuration "2 examples, 0 failures\n" `shouldBe` Nothing
+
+        it "parses duration from passing summary line" do
+            parseHspecDuration "All 177 tests passed (0.05s)\n"
+                `shouldBe` Just 50
+
+        it "parses duration from failing summary line" do
+            parseHspecDuration "1 out of 177 tests failed (0.06s)\n"
+                `shouldBe` Just 60
+
+        it "does not match indented individual test timing lines" do
+            parseHspecDuration "      entry is evicted after cleanup thread fires past TTL:  OK (0.05s)\n"
+                `shouldBe` Nothing
+
+        it "parses duration embedded in full hspec output" do
+            let output =
+                    "  Suite\n"
+                        <> "    passes:                                          OK\n"
+                        <> "    slow test:                                       OK (0.05s)\n"
+                        <> "\n"
+                        <> "All 2 tests passed (0.5s)\n"
+            parseHspecDuration output `shouldBe` Just 500
 
     describe "stripGhciNoise" do
         it "passes through empty list" do

--- a/tricorder/test/Unit/Tricorder/TestOutputSpec.hs
+++ b/tricorder/test/Unit/Tricorder/TestOutputSpec.hs
@@ -68,6 +68,26 @@ spec_TestOutput = do
                            , TestCase {description = "also passes:", outcome = TestCasePassed}
                            ]
 
+        it "parses a passing test with a timing annotation" do
+            let output = "  slow test:                                          OK (0.05s)\n"
+            parseHspecOutput output
+                `shouldBe` [TestCase {description = "slow test:", outcome = TestCasePassed}]
+
+        it "parses a passing test with a millisecond annotation" do
+            let output = "  fast property:                                      OK (12ms)\n"
+            parseHspecOutput output
+                `shouldBe` [TestCase {description = "fast property:", outcome = TestCasePassed}]
+
+        it "parses a failing test with a timing annotation" do
+            let output = "  slow fail:                                          FAIL (0.03s)\n"
+            parseHspecOutput output
+                `shouldBe` [TestCase {description = "slow fail:", outcome = TestCaseFailed ""}]
+
+        it "does not strip a non-timing parenthetical in the description" do
+            let output = "  test (corner case):                                 OK\n"
+            parseHspecOutput output
+                `shouldBe` [TestCase {description = "test (corner case):", outcome = TestCasePassed}]
+
     describe "parseHspecDuration" do
         it "returns Nothing for empty output" do
             parseHspecDuration "" `shouldBe` Nothing

--- a/tricorder/test/Unit/Tricorder/TestRunnerSpec.hs
+++ b/tricorder/test/Unit/Tricorder/TestRunnerSpec.hs
@@ -122,6 +122,7 @@ passingRun =
             , passed = True
             , output = "2 examples, 0 failures\n"
             , testCases = []
+            , durationMs = Nothing
             }
 
 
@@ -133,6 +134,7 @@ failingRun =
             , passed = False
             , output = "1 example, 1 failure\n"
             , testCases = []
+            , durationMs = Nothing
             }
 
 

--- a/tricorder/test/Unit/Tricorder/TestRunnerSpec.hs
+++ b/tricorder/test/Unit/Tricorder/TestRunnerSpec.hs
@@ -122,7 +122,7 @@ passingRun =
             , passed = True
             , output = "2 examples, 0 failures\n"
             , testCases = []
-            , durationMs = Nothing
+            , duration = Nothing
             }
 
 
@@ -134,7 +134,7 @@ failingRun =
             , passed = False
             , output = "1 example, 1 failure\n"
             , testCases = []
-            , durationMs = Nothing
+            , duration = Nothing
             }
 
 


### PR DESCRIPTION
- add test results view to UI under T key
  - Replaces separate `daemonInfoView`/`showHelp` fields with a `[ActiveView]` stack so any view can be layered and `Esc` always pops one level
  - `t` cycles through fail-only → full → off by pushing/replacing/popping on the stack; `g` and `h` push/pop their views the same way
  - All layer dispatch is consolidated in `view`; adding a new view only requires a new `ActiveView` constructor and one new branch there
  - `TestView` uses `Bounded`/`Enum` deriving so cycling is free from the constructor order rather than explicit pattern matches
  - Suite summary lines show `passed (N)` or `X/N failed` when `testCases` is populated (hspec output); falls back to plain pass/fail otherwise
- exclude compilation time from test timeout
  - Adds `durationMs :: Maybe Int` to `TestRunCompletion`, populated by `parseHspecDuration`
  - Parses non-indented summary lines ending with `(Xs)`, matching both
    `All N tests passed (0.33s)` and `N out of M tests failed (0.06s)`
  - CLI `status` and `test-results` append the formatted duration to the pass/fail text
  - TUI `viewCompletionStatus` shows it as a dimmed suffix widget
  - Streams `cabal repl` stdout via `createPipe` instead of buffering
  - Prepends a sentinel expression (`putStrLn "#~TRI-TEST-READY~#"`) to
    stdin; `drainUntilReady` accumulates output until the sentinel appears,
    covering the full startup and compilation phase without a timeout
  - `testTimeout` now applies only to the remaining stdout read after the
    sentinel — i.e. test execution only
  - Switches to `TIO.hGetLine`/`TIO.hGetContents` (Text-based IO), removing
    the `BSL` encode/decode round-trip for the combined output
- exclude compilation time from test timeout
  - Streams `cabal repl` stdout via `createPipe` instead of buffering
  - Prepends a sentinel expression (`putStrLn "#~TRI-TEST-READY~#"`) to
    stdin; `drainUntilReady` accumulates output until the sentinel appears,
    covering the full startup and compilation phase without a timeout
  - `testTimeout` now applies only to the remaining stdout read after the
    sentinel — i.e. test execution only
  - Switches to `TIO.hGetLine`/`TIO.hGetContents` (Text-based IO), removing
    the `BSL` encode/decode round-trip for the combined output

