### PR TITLE
feat: function-level source lookup via Module#function syntax

### DIFF
--- a/tricorder/src/Tricorder/Arguments.hs
+++ b/tricorder/src/Tricorder/Arguments.hs
@@ -15,9 +15,11 @@ import Effectful.Reader.Static (Reader, runReader)
 import Options.Applicative
     ( Parser
     , ParserInfo
+    , ReadM
     , argument
     , auto
     , command
+    , eitherReader
     , execParser
     , flag
     , fullDesc
@@ -32,10 +34,11 @@ import Options.Applicative
     , option
     , progDesc
     , short
-    , str
     )
 
-import Tricorder.GhcPkg.Types (ModuleName (..))
+import Data.Text qualified as T
+
+import Tricorder.GhcPkg.Types (ModuleName (..), SourceQuery (..))
 
 import Tricorder.Version qualified as Version
 
@@ -85,7 +88,7 @@ data Command
     | Test TestOptions
     | UI
     | Log FollowMode
-    | Source [ModuleName]
+    | Source [SourceQuery]
 
 
 runArguments :: (IOE :> es) => Eff (Reader Command : es) a -> Eff es a
@@ -190,5 +193,15 @@ testParser =
 
 sourceParser :: Parser Command
 sourceParser =
-    Source
-        <$> some (argument (fromString <$> str) (metavar "MODULE" <> help "Dotted module name, e.g. Data.Map.Strict"))
+    Source <$> some (argument queryReader (metavar "MODULE[#FUNCTION]" <> help "Module or Module#function"))
+
+
+queryReader :: ReadM SourceQuery
+queryReader = eitherReader $ \s ->
+    let t = toText s
+        (m, rest) = T.break (== '#') t
+    in  Right
+            $ SourceQuery
+                { moduleName = ModuleName m
+                , function = if T.null rest then Nothing else Just (T.tail rest)
+                }

--- a/tricorder/src/Tricorder/CLI.hs
+++ b/tricorder/src/Tricorder/CLI.hs
@@ -45,7 +45,7 @@ import Tricorder.CLI.Render
     , renderSourceResults
     )
 import Tricorder.Effects.UnixSocket (UnixSocket)
-import Tricorder.GhcPkg.Types (ModuleName)
+import Tricorder.GhcPkg.Types (SourceQuery)
 import Tricorder.Runtime (SocketPath (..))
 import Tricorder.Socket.Client
     ( querySource
@@ -242,11 +242,11 @@ showSource
        , Reader SocketPath :> es
        , UnixSocket :> es
        )
-    => [ModuleName]
+    => [SourceQuery]
     -> Eff es ()
-showSource moduleNames = do
+showSource queries = do
     SocketPath sockPath <- ask
-    result <- querySource sockPath moduleNames
+    result <- querySource sockPath queries
     case result of
         Left err -> Console.putTextLn $ "Error: " <> err
         Right results -> renderSourceResults results

--- a/tricorder/src/Tricorder/CLI/Render.hs
+++ b/tricorder/src/Tricorder/CLI/Render.hs
@@ -7,13 +7,15 @@ module Tricorder.CLI.Render
     , renderSourceResults
     ) where
 
+import Data.Text qualified as T
+
 import Atelier.Effects.Console (Console)
 import Tricorder.BuildState
     ( Diagnostic (..)
     , Severity (..)
     )
 import Tricorder.GhcPkg.Types (ModuleName (..), PackageId (..))
-import Tricorder.SourceLookup (ModuleSourceResult (..))
+import Tricorder.SourceLookup (ModuleSourceResult (..), ReExport (..), SourceQuery (..))
 
 import Atelier.Effects.Console qualified as Console
 
@@ -52,19 +54,39 @@ diagnosticBlock d = diagnosticLine d <> "\n" <> d.text
 renderSourceResults :: (Console :> es) => [ModuleSourceResult] -> Eff es ()
 renderSourceResults results = mapM_ renderOne results
   where
-    renderOne (SourceFound modName src) = do
-        when (length results > 1) $ Console.putTextLn $ "-- " <> unModuleName modName
+    renderOne (SourceFound query src reExports) = do
+        when (length results > 1) $ Console.putTextLn $ header query
         Console.putText src
+        unless (null reExports || isJust query.function)
+            $ Console.putTextLn
+            $ "\n-- Re-exports: " <> T.intercalate ", " (map renderReExport reExports)
         when (length results > 1) $ Console.putStrLn ""
-    renderOne (SourceNotFound modName) =
+    renderOne (SourceNotFound query) =
         Console.putTextLn
-            $ "Not found: " <> unModuleName modName <> " (module not in any installed package)"
-    renderOne (SourceNoHaddock modName pkgId) =
+            $ "Not found: "
+                <> unModuleName query.moduleName
+                <> " (module not in any installed package)"
+    renderOne (SourceNoHaddock query pkgId) =
         Console.putTextLn
             $ "No source available: "
-                <> unModuleName modName
+                <> unModuleName query.moduleName
                 <> " (package "
                 <> unPackageId pkgId
                 <> " was built without documentation; try `cabal get "
                 <> unPackageId pkgId
                 <> "`)"
+    renderOne (FunctionNotFound query) =
+        Console.putTextLn
+            $ "tricorder: "
+                <> unModuleName query.moduleName
+                <> "#"
+                <> fromMaybe "" query.function
+                <> ": function not found in module source"
+
+    header query =
+        "-- "
+            <> unModuleName query.moduleName
+            <> maybe "" ("#" <>) query.function
+
+    renderReExport (ReExportModule m) = "module " <> m
+    renderReExport (ReExportName name src) = name <> " (from " <> src <> ")"

--- a/tricorder/src/Tricorder/Daemon/Main.hs
+++ b/tricorder/src/Tricorder/Daemon/Main.hs
@@ -39,6 +39,7 @@ import Tricorder.Builder qualified as Builder
 import Tricorder.GhcPkg.Types qualified as GhcPkg
 import Tricorder.Observability qualified as Observability
 import Tricorder.Socket.Server qualified as SocketServer
+import Tricorder.SourceLookup qualified as SourceLookup
 import Tricorder.Version qualified as Version
 import Tricorder.Watcher qualified as Watcher
 
@@ -81,7 +82,7 @@ main =
         . runLogging
         . runTestRunnerIO
         . runCacheTtl @GhcPkg.ModuleName @GhcPkg.PackageId
-        . runCacheTtl @(GhcPkg.PackageId, GhcPkg.ModuleName) @Text
+        . runCacheTtl @(GhcPkg.PackageId, GhcPkg.SourceQuery) @(Text, [SourceLookup.ReExport])
         . runBuildStore
         . runGhcPkgIO
         . runUnixSocketIO

--- a/tricorder/src/Tricorder/GhcPkg/Types.hs
+++ b/tricorder/src/Tricorder/GhcPkg/Types.hs
@@ -1,6 +1,7 @@
 module Tricorder.GhcPkg.Types
     ( ModuleName (..)
     , PackageId (..)
+    , SourceQuery (..)
     ) where
 
 import Data.Aeson (FromJSON, ToJSON)
@@ -14,3 +15,12 @@ newtype ModuleName = ModuleName {unModuleName :: Text}
 -- | A @ghc-pkg@ package identifier, e.g. @"containers-0.6.8"@.
 newtype PackageId = PackageId {unPackageId :: Text}
     deriving newtype (Eq, FromJSON, Hashable, IsString, Ord, Show, ToJSON)
+
+
+-- | A query for module source: optionally scoped to a single top-level binding.
+data SourceQuery = SourceQuery
+    { moduleName :: ModuleName
+    , function :: Maybe Text -- Nothing = whole module, Just fn = single binding
+    }
+    deriving stock (Eq, Generic, Show)
+    deriving anyclass (FromJSON, Hashable, ToJSON)

--- a/tricorder/src/Tricorder/Socket/Client.hs
+++ b/tricorder/src/Tricorder/Socket/Client.hs
@@ -24,7 +24,7 @@ import Atelier.Effects.Posix.Daemons (Daemons)
 import Atelier.Time (Millisecond)
 import Tricorder.BuildState (BuildState, Diagnostic)
 import Tricorder.Effects.UnixSocket (UnixSocket, withConnection)
-import Tricorder.GhcPkg.Types (ModuleName)
+import Tricorder.GhcPkg.Types (SourceQuery)
 import Tricorder.Runtime (PidFile)
 import Tricorder.Socket.Protocol (ClientMessage (..), DiagnosticQuery (..), Query (..), StatusQuery (..))
 import Tricorder.SourceLookup (ModuleSourceResult)
@@ -99,10 +99,10 @@ queryWatch sockPath handler = evalState retryLimit retryLoop
 querySource
     :: (File :> es, UnixSocket :> es)
     => FilePath
-    -> [ModuleName]
+    -> [SourceQuery]
     -> Eff es (Either Text [ModuleSourceResult])
-querySource sockPath moduleNames = withConnection sockPath \h -> do
-    sendQuery h (Source moduleNames)
+querySource sockPath queries = withConnection sockPath \h -> do
+    sendQuery h (Source queries)
     line <- File.hGetLine h
     case eitherDecode (BSL.fromStrict (encodeUtf8 (toText line))) of
         Left err -> pure $ Left (toText err)

--- a/tricorder/src/Tricorder/Socket/Protocol.hs
+++ b/tricorder/src/Tricorder/Socket/Protocol.hs
@@ -8,7 +8,7 @@ module Tricorder.Socket.Protocol
 
 import Data.Aeson (FromJSON, ToJSON)
 
-import Tricorder.GhcPkg.Types (ModuleName)
+import Tricorder.GhcPkg.Types (SourceQuery)
 
 
 data StatusQuery = StatusQuery {awaitDone :: Bool}
@@ -24,7 +24,7 @@ newtype DiagnosticQuery = DiagnosticQuery {index :: Int}
 data Query
     = Status StatusQuery
     | Watch
-    | Source [ModuleName]
+    | Source [SourceQuery]
     | DiagnosticAt DiagnosticQuery
     | Quit
     deriving stock (Eq, Generic, Show)

--- a/tricorder/src/Tricorder/Socket/Server.hs
+++ b/tricorder/src/Tricorder/Socket/Server.hs
@@ -26,9 +26,10 @@ import Tricorder.Effects.UnixSocket
     , removeSocketFile
     , sendLine
     )
+import Tricorder.GhcPkg.Types (SourceQuery (..))
 import Tricorder.Runtime (SocketPath (..))
 import Tricorder.Socket.Protocol (ClientMessage (..), DiagnosticQuery (..), ErrorResponse (..), Query (..), StatusQuery (..))
-import Tricorder.SourceLookup (ModuleName, PackageId, lookupModuleSource)
+import Tricorder.SourceLookup (ModuleName, PackageId, ReExport, lookupModuleSource)
 import Tricorder.Version (VersionMismatch (..), checkVersion)
 
 import Atelier.Effects.Conc qualified as Conc
@@ -44,7 +45,7 @@ data SocketRemoved = SocketRemoved
 -- Listens on a Unix socket and responds to status/watch/source queries.
 component
     :: ( BuildStore :> es
-       , Cache (PackageId, ModuleName) Text :> es
+       , Cache (PackageId, SourceQuery) (Text, [ReExport]) :> es
        , Cache ModuleName PackageId :> es
        , Conc :> es
        , Delay :> es
@@ -68,7 +69,7 @@ component =
 
 acceptTrigger
     :: ( BuildStore :> es
-       , Cache (PackageId, ModuleName) Text :> es
+       , Cache (PackageId, SourceQuery) (Text, [ReExport]) :> es
        , Cache ModuleName PackageId :> es
        , Conc :> es
        , Delay :> es
@@ -91,7 +92,7 @@ acceptTrigger = do
 
 handleConnection
     :: ( BuildStore :> es
-       , Cache (PackageId, ModuleName) Text :> es
+       , Cache (PackageId, SourceQuery) (Text, [ReExport]) :> es
        , Cache ModuleName PackageId :> es
        , Delay :> es
        , Exit :> es
@@ -117,7 +118,7 @@ handleConnection h = do
 
 dispatch
     :: ( BuildStore :> es
-       , Cache (PackageId, ModuleName) Text :> es
+       , Cache (PackageId, SourceQuery) (Text, [ReExport]) :> es
        , Cache ModuleName PackageId :> es
        , Delay :> es
        , Exit :> es
@@ -210,18 +211,18 @@ respondDiagnostic idx h = do
 
 -- | Look up source for each requested module and send the results as a JSON array.
 respondSource
-    :: ( Cache (PackageId, ModuleName) Text :> es
+    :: ( Cache (PackageId, SourceQuery) (Text, [ReExport]) :> es
        , Cache ModuleName PackageId :> es
        , FileSystem :> es
        , GhcPkg :> es
        , Log :> es
        , UnixSocket :> es
        )
-    => [ModuleName]
+    => [SourceQuery]
     -> Handle
     -> Eff es ()
-respondSource moduleNames h = do
-    results <- mapM lookupModuleSource moduleNames
+respondSource queries h = do
+    results <- mapM lookupModuleSource queries
     sendJson h results
 
 

--- a/tricorder/src/Tricorder/SourceLookup.hs
+++ b/tricorder/src/Tricorder/SourceLookup.hs
@@ -2,18 +2,24 @@ module Tricorder.SourceLookup
     ( -- * Types
       ModuleName
     , PackageId
+    , SourceQuery (..)
     , ModuleSourceResult (..)
+    , ReExport (..)
 
       -- * Lookup
     , lookupModuleSource
 
       -- * HTML extraction
     , extractSource
+    , extractFunctionSource
+    , extractReExports
+    , stripAnnotations
     , stripTags
     , unescapeEntities
     ) where
 
 import Data.Aeson (FromJSON, ToJSON)
+import Data.List (findIndex)
 import System.FilePath ((</>))
 
 import Data.ByteString.Lazy qualified as BSL
@@ -23,20 +29,32 @@ import Atelier.Effects.Cache (Cache, cacheInsert, cacheLookup)
 import Atelier.Effects.FileSystem (FileSystem, doesFileExist, readFileLbs)
 import Atelier.Effects.Log (Log)
 import Tricorder.Effects.GhcPkg (GhcPkg)
-import Tricorder.GhcPkg.Types (ModuleName (..), PackageId (..))
+import Tricorder.GhcPkg.Types (ModuleName (..), PackageId (..), SourceQuery (..))
 
 import Atelier.Effects.Log qualified as Log
 import Tricorder.Effects.GhcPkg qualified as GhcPkg
 
 
+-- | A re-exported name or module from a module's export list.
+data ReExport
+    = -- | Whole-module re-export: @module GHC.Enum@
+      ReExportModule Text
+    | -- | Single name re-export: (name, source-module)
+      ReExportName Text Text
+    deriving stock (Eq, Generic, Show)
+    deriving anyclass (FromJSON, ToJSON)
+
+
 -- | The result of a source lookup for a single module.
 data ModuleSourceResult
-    = -- | Source was found; contains the stripped Haskell source text.
-      SourceFound ModuleName Text
+    = -- | Source was found; contains the stripped Haskell source text and re-exports.
+      SourceFound SourceQuery Text [ReExport]
     | -- | The module is not provided by any installed package.
-      SourceNotFound ModuleName
+      SourceNotFound SourceQuery
     | -- | The package was found but has no haddock-html field (built without docs).
-      SourceNoHaddock ModuleName PackageId
+      SourceNoHaddock SourceQuery PackageId
+    | -- | The module was found but the requested function was not in the source.
+      FunctionNotFound SourceQuery
     deriving stock (Eq, Generic, Show)
     deriving anyclass (FromJSON, ToJSON)
 
@@ -47,59 +65,70 @@ data ModuleSourceResult
 --
 -- Checks both cache levels before issuing any shell-outs.
 lookupModuleSource
-    :: ( Cache (PackageId, ModuleName) Text :> es
+    :: ( Cache (PackageId, SourceQuery) (Text, [ReExport]) :> es
        , Cache ModuleName PackageId :> es
        , FileSystem :> es
        , GhcPkg :> es
        , Log :> es
        )
-    => ModuleName
+    => SourceQuery
     -> Eff es ModuleSourceResult
-lookupModuleSource modName = do
-    mCachedPkg <- cacheLookup @ModuleName @PackageId modName
+lookupModuleSource query = do
+    mCachedPkg <- cacheLookup @ModuleName @PackageId query.moduleName
     pkgId <- case mCachedPkg of
         Just p -> do
-            Log.debug $ "Source: " <> unModuleName modName <> " → " <> unPackageId p <> " (cached)"
+            Log.debug $ "Source: " <> unModuleName query.moduleName <> " → " <> unPackageId p <> " (cached)"
             pure (Just p)
         Nothing -> do
-            result <- GhcPkg.findModule modName
-            Log.debug $ "Source: find-module " <> unModuleName modName <> " → " <> show result
+            result <- GhcPkg.findModule query.moduleName
+            Log.debug $ "Source: find-module " <> unModuleName query.moduleName <> " → " <> show result
             case result of
                 Nothing -> pure Nothing
                 Just p -> do
-                    cacheInsert @ModuleName @PackageId modName p
+                    cacheInsert @ModuleName @PackageId query.moduleName p
                     pure (Just p)
     case pkgId of
-        Nothing -> pure (SourceNotFound modName)
+        Nothing -> pure (SourceNotFound query)
         Just p -> do
-            mCachedSrc <- cacheLookup @(PackageId, ModuleName) @Text (p, modName)
+            mCachedSrc <- cacheLookup @(PackageId, SourceQuery) @(Text, [ReExport]) (p, query)
             case mCachedSrc of
-                Just src -> do
-                    Log.debug $ "Source: " <> unModuleName modName <> " source hit (cached)"
-                    pure (SourceFound modName src)
+                Just (src, reExports) -> do
+                    Log.debug $ "Source: " <> unModuleName query.moduleName <> " source hit (cached)"
+                    pure (SourceFound query src reExports)
                 Nothing -> do
                     mHtmlRoot <- GhcPkg.getHaddockHtml p
                     Log.debug $ "Source: haddock-html for " <> unPackageId p <> " → " <> show mHtmlRoot
                     case mHtmlRoot of
-                        Nothing -> pure (SourceNoHaddock modName p)
+                        Nothing -> pure (SourceNoHaddock query p)
                         Just htmlRoot -> do
                             -- Haddock generates hyperlinked source in one of two layouts:
                             --   dotted:  src/Data.Map.Strict.html   (newer Haddock / haskell.nix)
                             --   slashed: src/Data/Map/Strict.html   (older Haddock / cabal local)
-                            let htmlPathDotted = htmlRoot </> "src" </> toString (unModuleName modName) <> ".html"
-                                htmlPathSlashed = htmlRoot </> "src" </> toString (T.map dotToSlash (unModuleName modName)) <> ".html"
+                            let htmlPathDotted = htmlRoot </> "src" </> toString (unModuleName query.moduleName) <> ".html"
+                                htmlPathSlashed = htmlRoot </> "src" </> toString (T.map dotToSlash (unModuleName query.moduleName)) <> ".html"
                             Log.debug $ "Source: reading " <> toText htmlPathDotted
-                            mSrc <-
-                                readHaddockSource htmlPathDotted >>= \case
-                                    Just src -> pure (Just src)
-                                    Nothing -> readHaddockSource htmlPathSlashed
-                            case mSrc of
+                            mHtml <-
+                                readHaddockHtml htmlPathDotted >>= \case
+                                    Just html -> pure (Just html)
+                                    Nothing -> readHaddockHtml htmlPathSlashed
+                            case mHtml of
                                 Nothing -> do
                                     Log.debug $ "Source: file not found: " <> toText htmlPathDotted
-                                    pure (SourceNoHaddock modName p)
-                                Just src -> do
-                                    cacheInsert @(PackageId, ModuleName) @Text (p, modName) src
-                                    pure (SourceFound modName src)
+                                    pure (SourceNoHaddock query p)
+                                Just html -> do
+                                    let reExports = extractReExports query.moduleName html
+                                    case query.function of
+                                        Nothing -> do
+                                            let src = extractSource html
+                                            cacheInsert @(PackageId, SourceQuery) @(Text, [ReExport]) (p, query) (src, reExports)
+                                            pure (SourceFound query src reExports)
+                                        Just fn ->
+                                            case extractFunctionSource fn html of
+                                                Just src -> do
+                                                    cacheInsert @(PackageId, SourceQuery) @(Text, [ReExport]) (p, query) (src, reExports)
+                                                    pure (SourceFound query src reExports)
+                                                Nothing ->
+                                                    pure (FunctionNotFound query)
   where
     dotToSlash '.' = '/'
     dotToSlash c = c
@@ -107,36 +136,142 @@ lookupModuleSource modName = do
 
 -- ── HTML extraction ────────────────────────────────────────────────────────
 
--- | Read the Haddock hyperlinked-source HTML file and strip HTML to recover source.
-readHaddockSource :: (FileSystem :> es) => FilePath -> Eff es (Maybe Text)
-readHaddockSource htmlPath = do
+-- | Read the raw Haddock hyperlinked-source HTML file.
+readHaddockHtml :: (FileSystem :> es) => FilePath -> Eff es (Maybe Text)
+readHaddockHtml htmlPath = do
     exists <- doesFileExist htmlPath
     if not exists then
         pure Nothing
     else
-        Just . extractSource . decodeUtf8 . BSL.toStrict <$> readFileLbs htmlPath
+        Just . decodeUtf8 . BSL.toStrict <$> readFileLbs htmlPath
 
 
 -- | Extract the raw Haskell source from Haddock hyperlinked-source HTML.
---
--- 1. Finds the @\<pre id=\"src\"\>@ element.
--- 2. Takes everything up to the matching @\<\/pre\>@.
--- 3. Strips all @\<...\>@ tags.
--- 4. Unescapes HTML entities.
+-- Line spans are split and their numeric prefixes stripped before annotation
+-- removal so that 'stripAnnotations' sees well-formed per-line chunks.
 extractSource :: Text -> Text
 extractSource html =
-    let (_, after) = T.breakOn "<pre id=\"src\"" html
+    let (_, after) = T.breakOn "<pre" html
     in  if T.null after then
-            -- Fallback: strip the whole file (shouldn't happen for valid haddock HTML)
-            unescapeEntities (stripTags html)
+            unescapeEntities (stripTags (stripAnnotations html))
         else
-            let
-                -- Drop up to and including the closing '>' of the opening <pre ...> tag
-                afterOpen = T.drop 1 $ T.dropWhile (/= '>') after
-                -- Take everything up to </pre>
+            let afterOpen = T.drop 1 $ T.dropWhile (/= '>') after
                 content = fst $ T.breakOn "</pre>" afterOpen
-            in
-                unescapeEntities (stripTags content)
+                lineChunks = T.splitOn "<span id=\"line-" content
+                -- hd is pre-span preamble (no N"> prefix); only tail chunks need stripping.
+                stripped = case lineChunks of
+                    [] -> ""
+                    (hd : tl) -> T.concat (hd : map stripLineNumPrefix tl)
+            in  unescapeEntities (stripTags (stripAnnotations stripped))
+
+
+-- | Strip the @N"\>@ prefix from a chunk produced by splitting on @\<span id=\"line-@.
+stripLineNumPrefix :: Text -> Text
+stripLineNumPrefix chunk = T.drop 1 $ T.dropWhile (/= '>') chunk
+
+
+-- | Extract the source of a single top-level binding from Haddock source HTML.
+-- Finds the span with id matching the function name, then expands to the
+-- surrounding blank-line-delimited block (type sig + docstring above, body below).
+extractFunctionSource :: Text -> Text -> Maybe Text
+extractFunctionSource funcName html =
+    let (_, after) = T.breakOn "<pre" html
+        afterOpen = T.drop 1 $ T.dropWhile (/= '>') after
+        content = fst $ T.breakOn "</pre>" afterOpen
+        lineChunks = T.splitOn "<span id=\"line-" content
+        target = "id=\"" <> funcName <> "\""
+    in  case findIndex (T.isInfixOf target) lineChunks of
+            Nothing -> Nothing
+            Just i ->
+                let (pre, rest) = splitAt i lineChunks
+                in  case rest of
+                        [] -> Nothing
+                        (defLine : post) ->
+                            let before = reverse $ takeWhile (not . isBlankChunk) $ reverse pre
+                                after' = takeWhile (not . isBlankChunk) post
+                                selected = before <> [defLine] <> after'
+                            in  Just $ unescapeEntities $ stripTags $ stripAnnotations $ T.concat (map stripLineNumPrefix selected)
+  where
+    isBlankChunk chunk =
+        T.null (T.strip (stripTags (stripLineNumPrefix chunk)))
+
+
+-- | Extract re-exported names\/modules from Haddock source HTML.
+extractReExports :: ModuleName -> Text -> [ReExport]
+extractReExports modName html =
+    let afterMod = snd $ T.breakOn "<span class=\"hs-keyword\">module</span>" html
+        exportRgn = fst $ T.breakOn "<span class=\"hs-keyword\">where</span>" afterMod
+    in  go exportRgn
+  where
+    modFile = unModuleName modName <> ".html"
+
+    go :: Text -> [ReExport]
+    go region
+        | T.null region = []
+        | otherwise =
+            let (before, rest) = T.breakOn "<a href=\"" region
+            in  if T.null rest then
+                    []
+                else
+                    let afterHref = T.drop (T.length "<a href=\"") rest
+                        (href, rest2) = T.breakOn "\"" afterHref
+                        afterClose = T.drop 1 rest2
+                        isModRe = T.isInfixOf "<span class=\"hs-keyword\">module</span>" before
+                        (_, rest3) = T.breakOn ">" afterClose
+                        innerHtml = fst $ T.breakOn "</a>" (T.drop 1 rest3)
+                        name = T.strip $ stripTags innerHtml
+                        entry
+                            | T.null name = Nothing
+                            | isLocal href = Nothing
+                            | isModRe = Just (ReExportModule name)
+                            | otherwise = Just (reExportName href name)
+                        rest' = T.drop (T.length "</a>") $ snd $ T.breakOn "</a>" rest
+                    in  maybeToList entry <> go rest'
+
+    isLocal :: Text -> Bool
+    isLocal href =
+        let modPart = T.dropEnd 5 modFile
+            sf = T.map (\c -> if c == '.' then '/' else c) modPart <> ".html"
+            hrefBase = fst $ T.breakOn "#" href -- strip fragment before comparing
+        in  modFile `T.isSuffixOf` hrefBase || sf `T.isSuffixOf` hrefBase
+
+    reExportName :: Text -> Text -> ReExport
+    reExportName href name = ReExportName name (deriveModuleName href)
+      where
+        deriveModuleName h =
+            let allParts = T.splitOn "/" h
+                fileName = fromMaybe h $ viaNonEmpty last $ filter (not . T.null) allParts
+                fileOnly = fst $ T.breakOn "#" fileName
+                dotted' = fst $ T.breakOn ".html" fileOnly
+            in  if T.isInfixOf "." dotted' then
+                    dotted'
+                else
+                    let revParts = reverse allParts
+                        modDirs = takeWhile isModComponent (drop 1 revParts)
+                        prefix = T.intercalate "." (reverse modDirs)
+                    in  if T.null prefix then dotted' else prefix <> "." <> dotted'
+
+        isModComponent t =
+            not (T.null t) && not (T.isPrefixOf "." t) && isUpper (T.head t)
+          where
+            isUpper c = c >= 'A' && c <= 'Z'
+
+
+-- | Remove @\<span class=\"annottext\"\>...\<\/span\>@ blocks including their content.
+-- Haddock embeds elaborated GHC types as hover tooltips; they must be excised
+-- before 'stripTags' so they don't pollute the plain-text source output.
+stripAnnotations :: Text -> Text
+stripAnnotations t
+    | T.null t = t
+    | otherwise =
+        let marker = "<span class=\"annottext\">"
+            (before, rest) = T.breakOn marker t
+        in  if T.null rest then
+                before
+            else
+                let afterOpen = T.drop (T.length marker) rest
+                    afterClose = T.drop (T.length "</span>") $ snd $ T.breakOn "</span>" afterOpen
+                in  before <> stripAnnotations afterClose
 
 
 -- | Remove all @\<...\>@ sequences from text.

--- a/tricorder/test/Unit/Tricorder/SourceLookupSpec.hs
+++ b/tricorder/test/Unit/Tricorder/SourceLookupSpec.hs
@@ -11,8 +11,8 @@ import Atelier.Effects.Cache (Cache, runCacheForever)
 import Atelier.Effects.FileSystem (FileSystem (..))
 import Atelier.Effects.Log (Log, runLogNoOp)
 import Tricorder.Effects.GhcPkg (GhcPkg, GhcPkgScript (..), runGhcPkgScripted)
-import Tricorder.GhcPkg.Types (ModuleName, PackageId)
-import Tricorder.SourceLookup (ModuleSourceResult (..), lookupModuleSource)
+import Tricorder.GhcPkg.Types (ModuleName, PackageId, SourceQuery (..))
+import Tricorder.SourceLookup (ModuleSourceResult (..), ReExport, lookupModuleSource)
 
 
 spec_SourceLookup :: Spec
@@ -29,8 +29,8 @@ testLookupModuleSource = do
                 , NextGetHaddockHtml (Just "/haddock/pkg")
                 ]
                 (Map.singleton "/haddock/pkg/src/Foo.html" sampleHtml)
-                (lookupModuleSource "Foo")
-        result `shouldBe` SourceFound "Foo" "module Foo where"
+                (lookupModuleSource (wholeModule "Foo"))
+        result `shouldBe` SourceFound (wholeModule "Foo") "module Foo where" []
 
     it "returns SourceFound on second call without re-querying GhcPkg (cache hit)" do
         -- Only one NextFindModule and one NextGetHaddockHtml in the script.
@@ -41,19 +41,19 @@ testLookupModuleSource = do
             ]
             (Map.singleton "/haddock/pkg/src/Foo.html" sampleHtml)
             $ do
-                r1 <- lookupModuleSource "Foo"
-                r2 <- lookupModuleSource "Foo"
+                r1 <- lookupModuleSource (wholeModule "Foo")
+                r2 <- lookupModuleSource (wholeModule "Foo")
                 pure (r1, r2)
-        r1 `shouldBe` SourceFound "Foo" "module Foo where"
-        r2 `shouldBe` SourceFound "Foo" "module Foo where"
+        r1 `shouldBe` SourceFound (wholeModule "Foo") "module Foo where" []
+        r2 `shouldBe` SourceFound (wholeModule "Foo") "module Foo where" []
 
     it "returns SourceNotFound when findModule returns Nothing" do
         result <-
             runTest
                 [NextFindModule Nothing]
                 Map.empty
-                (lookupModuleSource "Unknown")
-        result `shouldBe` SourceNotFound "Unknown"
+                (lookupModuleSource (wholeModule "Unknown"))
+        result `shouldBe` SourceNotFound (wholeModule "Unknown")
 
     it "returns SourceNoHaddock when getHaddockHtml returns Nothing" do
         result <-
@@ -62,8 +62,8 @@ testLookupModuleSource = do
                 , NextGetHaddockHtml Nothing
                 ]
                 Map.empty
-                (lookupModuleSource "Foo")
-        result `shouldBe` SourceNoHaddock "Foo" "no-docs-1.0"
+                (lookupModuleSource (wholeModule "Foo"))
+        result `shouldBe` SourceNoHaddock (wholeModule "Foo") "no-docs-1.0"
 
     it "returns SourceNoHaddock when the html file does not exist" do
         result <-
@@ -72,8 +72,8 @@ testLookupModuleSource = do
                 , NextGetHaddockHtml (Just "/haddock/pkg")
                 ]
                 Map.empty
-                (lookupModuleSource "Foo")
-        result `shouldBe` SourceNoHaddock "Foo" "pkg-1.0"
+                (lookupModuleSource (wholeModule "Foo"))
+        result `shouldBe` SourceNoHaddock (wholeModule "Foo") "pkg-1.0"
 
     it "handles two different module names independently" do
         (r1, r2) <- runTest
@@ -88,11 +88,11 @@ testLookupModuleSource = do
                 ]
             )
             $ do
-                r1 <- lookupModuleSource "Foo"
-                r2 <- lookupModuleSource "Bar"
+                r1 <- lookupModuleSource (wholeModule "Foo")
+                r2 <- lookupModuleSource (wholeModule "Bar")
                 pure (r1, r2)
-        r1 `shouldBe` SourceFound "Foo" "module Foo where"
-        r2 `shouldBe` SourceFound "Bar" "module Bar where"
+        r1 `shouldBe` SourceFound (wholeModule "Foo") "module Foo where" []
+        r2 `shouldBe` SourceFound (wholeModule "Bar") "module Bar where" []
 
 
 --------------------------------------------------------------------------------
@@ -105,6 +105,11 @@ sampleHtml = "<html><body><pre id=\"src\"><span>module</span> Foo <span>where</s
 
 barHtml :: LByteString
 barHtml = "<html><body><pre id=\"src\"><span>module</span> Bar <span>where</span></pre></body></html>"
+
+
+-- | Helper: a whole-module query (no function filter).
+wholeModule :: ModuleName -> SourceQuery
+wholeModule m = SourceQuery {moduleName = m, function = Nothing}
 
 
 --------------------------------------------------------------------------------
@@ -121,7 +126,7 @@ runFileSystemScripted files = interpret_ \case
 runTest
     :: [GhcPkgScript]
     -> Map FilePath LByteString
-    -> Eff '[Cache ModuleName PackageId, Cache (PackageId, ModuleName) Text, FileSystem, GhcPkg, Log, Concurrent, IOE] a
+    -> Eff '[Cache ModuleName PackageId, Cache (PackageId, SourceQuery) (Text, [ReExport]), FileSystem, GhcPkg, Log, Concurrent, IOE] a
     -> IO a
 runTest pkgScript files action =
     runEff
@@ -129,6 +134,6 @@ runTest pkgScript files action =
         . runLogNoOp
         . runGhcPkgScripted pkgScript
         . runFileSystemScripted files
-        . runCacheForever @(PackageId, ModuleName) @Text
+        . runCacheForever @(PackageId, SourceQuery) @(Text, [ReExport])
         . runCacheForever @ModuleName @PackageId
         $ action

--- a/tricorder/test/Unit/Tricorder/SourceSpec.hs
+++ b/tricorder/test/Unit/Tricorder/SourceSpec.hs
@@ -2,12 +2,14 @@ module Unit.Tricorder.SourceSpec (spec_Source) where
 
 import Test.Hspec
 
-import Tricorder.SourceLookup (extractSource, stripTags, unescapeEntities)
+import Tricorder.SourceLookup (extractFunctionSource, extractSource, stripAnnotations, stripTags, unescapeEntities)
 
 
 spec_Source :: Spec
 spec_Source = do
     describe "extractSource" testExtractSource
+    describe "extractFunctionSource" testExtractFunctionSource
+    describe "stripAnnotations" testStripAnnotations
     describe "stripTags" testStripTags
     describe "unescapeEntities" testUnescapeEntities
 
@@ -26,9 +28,96 @@ testExtractSource = do
         let html = "<pre id=\"src\">&lt;Type&gt; &amp; &quot;val&quot;</pre>"
         extractSource html `shouldBe` "<Type> & \"val\""
 
-    it "falls back to stripping the whole file when <pre id=\"src\"> is absent" do
+    it "falls back to stripping the whole file when no <pre> block is present" do
         let html = "<html><body><p>hello &amp; world</p></body></html>"
         extractSource html `shouldBe` "hello & world"
+
+    -- Regression: some Haddock versions emit <pre> with no id attribute.
+    -- extractSource must still strip annottext spans in that case.
+    it "strips annottext spans from a <pre> block without an id attribute" do
+        let html =
+                "<html><body><pre>"
+                    <> "<span id=\"line-1\"></span>"
+                    <> "<span class=\"annot\"><span class=\"annottext\">foo :: Int\n</span>"
+                    <> "<span class=\"hs-identifier hs-var\">foo</span></span>"
+                    <> " = "
+                    <> "<span class=\"annot\"><span class=\"annottext\">Int\n</span>"
+                    <> "<span class=\"hs-number\">42</span></span>\n"
+                    <> "</pre></body></html>"
+        extractSource html `shouldBe` "foo = 42\n"
+
+
+testExtractFunctionSource :: Spec
+testExtractFunctionSource = do
+    it "extracts the type signature and body of a named function" do
+        extractFunctionSource "bar" sampleHtml
+            `shouldBe` Just "bar :: Int\nbar = 42\n"
+
+    it "stops at blank lines and does not include adjacent functions" do
+        let result = toString $ fromMaybe "" (extractFunctionSource "bar" sampleHtml)
+        result `shouldNotContain` "other"
+
+    it "does not leak line-number prefixes (N\"> regression)" do
+        -- Before the fix, output contained fragments like '45">{-' from the
+        -- raw line-span remainder after splitting on <span id="line-".
+        let result = toString $ fromMaybe "" (extractFunctionSource "bar" sampleHtml)
+        result `shouldNotContain` "\">"
+
+    it "returns Nothing for an unknown function name" do
+        extractFunctionSource "unknown" sampleHtml `shouldBe` Nothing
+
+    -- Regression: some Haddock versions emit <pre> with no id attribute.
+    it "works when <pre> has no id attribute" do
+        let noIdHtml =
+                "<pre>"
+                    <> "<span id=\"line-1\"></span>bar :: Int\n"
+                    <> "<span id=\"line-2\"></span><span id=\"bar\">bar</span> = 42\n"
+                    <> "</pre>"
+        extractFunctionSource "bar" noIdHtml `shouldBe` Just "bar :: Int\nbar = 42\n"
+  where
+    -- Minimal Haddock-style source HTML with two functions separated by a blank line.
+    sampleHtml =
+        "<pre id=\"src\">"
+            <> "<span id=\"line-1\"></span>other :: Bool\n"
+            <> "<span id=\"line-2\"></span><span id=\"other\">other</span> = True\n"
+            <> "<span id=\"line-3\"></span>\n"
+            <> "<span id=\"line-4\"></span>bar :: Int\n"
+            <> "<span id=\"line-5\"></span><span id=\"bar\">bar</span> = 42\n"
+            <> "<span id=\"line-6\"></span>\n"
+            <> "</pre>"
+
+
+testStripAnnotations :: Spec
+testStripAnnotations = do
+    it "removes an annottext span and its content" do
+        stripAnnotations "<span class=\"annottext\">foo :: Int\n</span>bar"
+            `shouldBe` "bar"
+
+    it "removes multiple annottext spans" do
+        stripAnnotations "a<span class=\"annottext\">X</span>b<span class=\"annottext\">Y</span>c"
+            `shouldBe` "abc"
+
+    it "leaves other spans untouched" do
+        stripAnnotations "<span class=\"hs-keyword\">module</span>"
+            `shouldBe` "<span class=\"hs-keyword\">module</span>"
+
+    it "handles text with no annotations unchanged" do
+        stripAnnotations "plain text" `shouldBe` "plain text"
+
+    -- Regression: Haddock emits elaborated types inside annottext that were
+    -- leaking into output, e.g. 'universe :: forall a. ...' appearing as a
+    -- second type signature, and 'forall a. Bounded a => a' appearing inside
+    -- the body of expressions like '[minBound .. maxBound]'.
+    it "strips elaborated type annotations from a realistic Haddock snippet" do
+        let snippet =
+                "<span class=\"annot\">"
+                    <> "<span class=\"annottext\">universe :: forall a. (Bounded a, Enum a) =&gt; [a]\n</span>"
+                    <> "<a href=\"Relude.Enum.html#universe\">"
+                    <> "<span class=\"hs-identifier hs-var\">universe</span>"
+                    <> "</a></span>"
+                    <> " = [minBound .. maxBound]"
+        stripAnnotations snippet
+            `shouldBe` "<span class=\"annot\"><a href=\"Relude.Enum.html#universe\"><span class=\"hs-identifier hs-var\">universe</span></a></span> = [minBound .. maxBound]"
 
 
 testStripTags :: Spec


### PR DESCRIPTION
Extends `tricorder source` to accept an optional `#function` suffix:

- `Relude.Enum` — whole module source (existing behaviour)
- `Relude.Enum#inverseMap` — single top-level binding

**Implementation:**

- `SourceQuery` type in `GhcPkg.Types` carries the module name and an optional function name; replaces bare `ModuleName` throughout the protocol, CLI, and daemon
- `extractFunctionSource` splits the Haddock `<pre>` block on `<span id="line-N">` markers, locates the target binding's span, then expands backward/forward to the surrounding blank-line-delimited block (type sig + docstring above, pragmas below)
- `extractReExports` parses the export list to annotate whole-module results with re-exported names/modules; suppressed in function mode
- `stripAnnotations` removes `<span class="annottext">` hover-tooltip blocks (elaborated GHC types) before `stripTags`, preventing them from polluting the plain-text output; applied via the same line-chunk pipeline in both module and function mode
- `FunctionNotFound` result variant for when the module exists but the named binding is absent from the Haddock source HTML