### PR TITLE
refactor: replace semaphore-based restart with `restartableForkWith`

### DIFF
--- a/atelier/src/Atelier/Effects/Conc.hs
+++ b/atelier/src/Atelier/Effects/Conc.hs
@@ -11,6 +11,7 @@ module Atelier.Effects.Conc
       -- * Scope
     , Scope (..)
     , scoped
+    , restartableForkWith
 
       -- * Interpreters
     , runConcBase
@@ -63,6 +64,17 @@ newtype Thread a = Thread (Ki.Thread a)
 
 
 makeEffect ''Conc
+
+
+-- | Forks an action in a loop, with a setup step that runs in the scope before
+-- each fork. Each time @signal@ returns, the current fork is cancelled, and
+-- setup and fork are run again. The setup result is passed to the forked
+-- action, structurally guaranteeing it completes before the fork starts.
+restartableForkWith :: (Conc :> es) => Eff es () -> Eff es r -> (r -> Eff es a) -> Eff es Void
+restartableForkWith signal setup action = forever $ scoped do
+    r <- setup
+    _ <- fork (action r)
+    signal
 
 
 -- | Base interpreter: resolves 'Conc' operations using Ki.

--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -130,7 +130,6 @@ instance Default BuilderSession where
 -- passed function whenever those parts change.
 withBuilderSession
     :: ( Conc :> es
-       , Concurrent :> es
        , SessionStore :> es
        , Sub SessionStoreReloaded :> es
        )

--- a/tricorder/src/Tricorder/Effects/SessionStore.hs
+++ b/tricorder/src/Tricorder/Effects/SessionStore.hs
@@ -11,7 +11,6 @@ module Tricorder.Effects.SessionStore
     ) where
 
 import Effectful (Effect, inject)
-import Effectful.Concurrent (Concurrent)
 import Effectful.Dispatch.Dynamic (interpret_, reinterpretWith_)
 import Effectful.Reader.Static (Reader)
 import Effectful.TH (makeEffect)
@@ -28,7 +27,6 @@ import Tricorder.Session (Session, loadSession)
 
 import Atelier.Effects.Conc qualified as Conc
 import Atelier.Effects.Publishing qualified as Sub
-import Atelier.Types.Semaphore qualified as Sem
 
 
 data SessionStore :: Effect where
@@ -58,16 +56,9 @@ withSession
        )
     => (ActiveSession es -> Eff es a)
     -> Eff es Void
-withSession act = forever $ Conc.scoped do
-    session <- get
-    _ <-
-        Conc.fork
-            $ act
-            $ ActiveSession
-                { session
-                , reloader = Reloader rawReload
-                }
-    void $ Sub.listenOnce_ @SessionStoreReloaded
+withSession act =
+    Conc.restartableForkWith (void $ Sub.listenOnce_ @SessionStoreReloaded) get \session ->
+        act ActiveSession {session, reloader = Reloader rawReload}
 
 
 -- | Tracks the parts of 'Session' that the caller cares about, and restarts
@@ -76,7 +67,6 @@ withSession act = forever $ Conc.scoped do
 withSubSession
     :: forall subSession es a
      . ( Conc :> es
-       , Concurrent :> es
        , Eq subSession
        , SessionStore :> es
        , Sub SessionStoreReloaded :> es
@@ -86,28 +76,18 @@ withSubSession
     -> (Reloader es -> subSession -> Eff es a)
     -> Eff es Void
 withSubSession mkSubSession initialSession action =
-    State.evalState (mkSubSession initialSession) do
-        -- Used to signal the thread running the passed function to restart
-        -- the function.
-        restartSem <- Sem.new
-
-        Conc.fork_ $ withSession \activeSession -> do
-            let newSubSession = mkSubSession activeSession.session
-            oldSubSession <- State.get @subSession
-            when (newSubSession /= oldSubSession) do
-                State.put newSubSession
-                -- Sub session is changed. Signal the thread managing the
-                -- passed function to restart said function.
-                Sem.signal restartSem
-
-        -- Run the passed function and wait for the signal to restart.
-        forever $ Conc.scoped do
-            cfg <- State.get
-            _ <- Conc.fork $ inject $ action (Reloader rawReload) cfg
-            -- Passing this 'Sem.wait' ends the scope, killing all
-            -- associated threads, and restarts the passed function again,
-            -- fetching a new, fresh `subSession`.
-            Sem.wait restartSem
+    State.evalState (mkSubSession initialSession)
+        $ Conc.restartableForkWith awaitChange State.get \cfg ->
+            inject $ action (Reloader rawReload) cfg
+  where
+    awaitChange = do
+        SessionStoreReloaded newSession <- Sub.listenOnce_ @SessionStoreReloaded
+        let newSubSession = mkSubSession newSession
+        oldSubSession <- State.get @subSession
+        if newSubSession == oldSubSession then
+            awaitChange
+        else
+            State.put newSubSession
 
 
 data SessionStoreReloaded = SessionStoreReloaded Session

--- a/tricorder/src/Tricorder/Watcher.hs
+++ b/tricorder/src/Tricorder/Watcher.hs
@@ -5,7 +5,6 @@ module Tricorder.Watcher
     , markWatchedFiles
     ) where
 
-import Effectful.Concurrent (Concurrent)
 import Effectful.Reader.Static (Reader, ask)
 import System.FilePath (takeExtension, takeFileName)
 
@@ -44,7 +43,6 @@ import Tricorder.Effects.SessionStore qualified as SessionStore
 component
     :: ( BuildStore :> es
        , Conc :> es
-       , Concurrent :> es
        , Debounce FilePath :> es
        , FileWatcher :> es
        , Pub CabalChangeDetected :> es
@@ -90,7 +88,6 @@ data WatcherSession = WatcherSession
 
 withWatcherSession
     :: ( Conc :> es
-       , Concurrent :> es
        , SessionStore :> es
        , Sub SessionStoreReloaded :> es
        )
@@ -103,7 +100,6 @@ withWatcherSession =
 
 watchFiles
     :: ( Conc :> es
-       , Concurrent :> es
        , Debounce FilePath :> es
        , FileWatcher :> es
        , Pub WatchedFile :> es


### PR DESCRIPTION
- Add `Conc.restartableForkWith`: a structured-concurrency primitive that runs a setup step in the scope before each fork, structurally guaranteeing the setup completes before the forked action starts
- Rewrite `withSession` and `withSubSession` to use it, eliminating the semaphore, the nested `withSession` fork, and the `Concurrent` constraint
- `withSubSession` now subscribes to `SessionStoreReloaded` directly via a recursive `awaitChange` filter, restarting only when the projected sub-session fields actually change