### PR TITLE
refactor: add Stream effect and eliminate State from withSubSession

### DIFF
--- a/atelier/src/Atelier/Effects/Conc.hs
+++ b/atelier/src/Atelier/Effects/Conc.hs
@@ -12,6 +12,7 @@ module Atelier.Effects.Conc
     , Scope (..)
     , scoped
     , restartableForkWith
+    , restartableForkLoop
 
       -- * Interpreters
     , runConcBase
@@ -75,6 +76,18 @@ restartableForkWith signal setup action = forever $ scoped do
     r <- setup
     _ <- fork (action r)
     signal
+
+
+-- | Like 'restartableForkWith', but threads a value across iterations: the
+-- signal returns the next @r@, which is passed to the next fork. The initial
+-- @r@ seeds the first fork.
+restartableForkLoop :: (Conc :> es) => r -> Eff es r -> (r -> Eff es a) -> Eff es Void
+restartableForkLoop initial signal action = go initial
+  where
+    go r = scoped do
+        _ <- fork (action r)
+        r' <- signal
+        go r'
 
 
 -- | Base interpreter: resolves 'Conc' operations using Ki.

--- a/atelier/src/Atelier/Effects/Stream.hs
+++ b/atelier/src/Atelier/Effects/Stream.hs
@@ -1,0 +1,52 @@
+module Atelier.Effects.Stream
+    ( Stream
+    , next
+    , fromEvents
+    , filter
+    , changes
+    ) where
+
+import Atelier.Effects.Chan (Chan)
+import Atelier.Effects.Conc (Conc)
+import Atelier.Effects.Publishing (Sub)
+import Prelude hiding (filter)
+
+import Atelier.Effects.Chan qualified as Chan
+import Atelier.Effects.Conc qualified as Conc
+import Atelier.Effects.Publishing qualified as Sub
+
+
+-- | An infinite pull-based stream of values.
+newtype Stream es a = Stream {next :: Eff es a}
+    deriving (Functor) via (Eff es)
+
+
+-- | Run a continuation with a buffered stream of 'Sub' events. The stream
+-- subscribes before the continuation runs, so no events are missed. The
+-- internal listener thread is scoped to the continuation.
+fromEvents
+    :: forall event es a
+     . (Chan :> es, Conc :> es, Sub event :> es)
+    => (Stream es event -> Eff es a)
+    -> Eff es a
+fromEvents use = Conc.scoped do
+    (inChan, outChan) <- Chan.newChan
+    Conc.fork_ $ Sub.listen_ (Chan.writeChan inChan)
+    use $ Stream (Chan.readChan outChan)
+
+
+filter :: (a -> Bool) -> Stream es a -> Stream es a
+filter p (Stream n) = Stream loop
+  where
+    loop = do
+        x <- n
+        if p x then pure x else loop
+
+
+-- | Only emit values that differ from the previous one.
+changes :: (Eq a) => a -> Stream es a -> Stream es a
+changes initial stream = Stream (loop initial)
+  where
+    loop prev = do
+        x <- next (filter (/= prev) stream)
+        pure x

--- a/tricorder.cabal
+++ b/tricorder.cabal
@@ -147,6 +147,7 @@ library atelier
       Atelier.Effects.Posix.Daemons
       Atelier.Effects.Posix.IO
       Atelier.Effects.Publishing
+      Atelier.Effects.Stream
       Atelier.Effects.Tally
       Atelier.Effects.UUID
       Atelier.Exception

--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -27,6 +27,7 @@ import System.FilePath (isAbsolute, (</>))
 import Data.Map.Strict qualified as Map
 
 import Atelier.Component (Component (..), defaultComponent)
+import Atelier.Effects.Chan (Chan)
 import Atelier.Effects.Clock (Clock, UTCTime)
 import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.Debounce (Debounce, debounced)
@@ -72,6 +73,7 @@ type DiagnosticMap = Map FilePath [Diagnostic]
 -- from the watcher.
 component
     :: ( BuildStore :> es
+       , Chan :> es
        , Clock :> es
        , Conc :> es
        , Concurrent :> es
@@ -129,7 +131,8 @@ instance Default BuilderSession where
 -- | Tracks the parts of 'Session' that 'Builder' cares about, and restarts the
 -- passed function whenever those parts change.
 withBuilderSession
-    :: ( Conc :> es
+    :: ( Chan :> es
+       , Conc :> es
        , SessionStore :> es
        , Sub SessionStoreReloaded :> es
        )

--- a/tricorder/src/Tricorder/Effects/SessionStore.hs
+++ b/tricorder/src/Tricorder/Effects/SessionStore.hs
@@ -10,7 +10,7 @@ module Tricorder.Effects.SessionStore
     , runSessionStoreConst
     ) where
 
-import Effectful (Effect, inject)
+import Effectful (Effect)
 import Effectful.Dispatch.Dynamic (interpret_, reinterpretWith_)
 import Effectful.Reader.Static (Reader)
 import Effectful.TH (makeEffect)
@@ -19,6 +19,7 @@ import Relude.Extra.Tuple (dup)
 import Effectful.State.Static.Shared qualified as State
 
 import Atelier.Config (LoadedConfig)
+import Atelier.Effects.Chan (Chan)
 import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.FileSystem (FileSystem)
 import Atelier.Effects.Publishing (Pub, Sub, publish)
@@ -27,6 +28,7 @@ import Tricorder.Session (Session, loadSession)
 
 import Atelier.Effects.Conc qualified as Conc
 import Atelier.Effects.Publishing qualified as Sub
+import Atelier.Effects.Stream qualified as Stream
 
 
 data SessionStore :: Effect where
@@ -66,7 +68,8 @@ withSession act =
 -- 'Eq' instance.
 withSubSession
     :: forall subSession es a
-     . ( Conc :> es
+     . ( Chan :> es
+       , Conc :> es
        , Eq subSession
        , SessionStore :> es
        , Sub SessionStoreReloaded :> es
@@ -76,18 +79,16 @@ withSubSession
     -> (Reloader es -> subSession -> Eff es a)
     -> Eff es Void
 withSubSession mkSubSession initialSession action =
-    State.evalState (mkSubSession initialSession)
-        $ Conc.restartableForkWith awaitChange State.get \cfg ->
-            inject $ action (Reloader rawReload) cfg
-  where
-    awaitChange = do
-        SessionStoreReloaded newSession <- Sub.listenOnce_ @SessionStoreReloaded
-        let newSubSession = mkSubSession newSession
-        oldSubSession <- State.get @subSession
-        if newSubSession == oldSubSession then
-            awaitChange
-        else
-            State.put newSubSession
+    Stream.fromEvents @SessionStoreReloaded \stream ->
+        let initialSubSession = mkSubSession initialSession
+            subStream =
+                Stream.changes
+                    initialSubSession
+                    (fmap (\(SessionStoreReloaded s) -> mkSubSession s) stream)
+        in  Conc.restartableForkLoop
+                initialSubSession
+                (Stream.next subStream)
+                \cfg -> action (Reloader rawReload) cfg
 
 
 data SessionStoreReloaded = SessionStoreReloaded Session

--- a/tricorder/src/Tricorder/Watcher.hs
+++ b/tricorder/src/Tricorder/Watcher.hs
@@ -9,6 +9,7 @@ import Effectful.Reader.Static (Reader, ask)
 import System.FilePath (takeExtension, takeFileName)
 
 import Atelier.Component (Component (..), defaultComponent)
+import Atelier.Effects.Chan (Chan)
 import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.Debounce (Debounce)
 import Atelier.Effects.FileWatcher
@@ -42,6 +43,7 @@ import Tricorder.Effects.SessionStore qualified as SessionStore
 -- or session restart accordingly.
 component
     :: ( BuildStore :> es
+       , Chan :> es
        , Conc :> es
        , Debounce FilePath :> es
        , FileWatcher :> es
@@ -87,7 +89,8 @@ data WatcherSession = WatcherSession
 
 
 withWatcherSession
-    :: ( Conc :> es
+    :: ( Chan :> es
+       , Conc :> es
        , SessionStore :> es
        , Sub SessionStoreReloaded :> es
        )
@@ -99,7 +102,8 @@ withWatcherSession =
 
 
 watchFiles
-    :: ( Conc :> es
+    :: ( Chan :> es
+       , Conc :> es
        , Debounce FilePath :> es
        , FileWatcher :> es
        , Pub WatchedFile :> es


### PR DESCRIPTION
- Add `Atelier.Effects.Stream`: an infinite pull-based stream backed by a buffered `Sub` subscription via `withStream`, with `map`, `filter`, and `changes` combinators
- Add `Conc.restartableForkLoop`: threads a value across restart iterations — the signal returns the next `r`, seeding the following fork directly
- Rewrite `withSubSession` using `Stream.withStream`, `Stream.changes`, and `restartableForkLoop`, eliminating internal `State subSession` entirely; the sub-session value is now threaded through the loop rather than stored
- `withStream` scopes the listener thread to the continuation, fixing the event subscription window between fork start and signal subscribe