### PR TITLE
refactor: rename Stream to Iterator

### DIFF
--- a/atelier/src/Atelier/Effects/Iterator.hs
+++ b/atelier/src/Atelier/Effects/Iterator.hs
@@ -1,5 +1,5 @@
-module Atelier.Effects.Stream
-    ( Stream
+module Atelier.Effects.Iterator
+    ( Iterator
     , next
     , fromEvents
     , filter
@@ -16,37 +16,39 @@ import Atelier.Effects.Conc qualified as Conc
 import Atelier.Effects.Publishing qualified as Sub
 
 
--- | An infinite pull-based stream of values.
-newtype Stream es a = Stream {next :: Eff es a}
+-- | An pull-based iterator of (potentially infinite) values.
+newtype Iterator es a = Iterator {next :: Eff es a}
     deriving (Functor) via (Eff es)
 
 
--- | Run a continuation with a buffered stream of 'Sub' events. The stream
+-- | Run a continuation with a buffered iterator of 'Sub' events. The iterator
 -- subscribes before the continuation runs, so no events are missed. The
--- internal listener thread is scoped to the continuation.
+-- internal listener thread is scoped to the continuation, and is killed when
+-- the continuation returns.
 fromEvents
     :: forall event es a
      . (Chan :> es, Conc :> es, Sub event :> es)
-    => (Stream es event -> Eff es a)
+    => (Iterator es event -> Eff es a)
     -> Eff es a
 fromEvents use = Conc.scoped do
     (inChan, outChan) <- Chan.newChan
     Conc.fork_ $ Sub.listen_ (Chan.writeChan inChan)
-    use $ Stream (Chan.readChan outChan)
+    use $ Iterator (Chan.readChan outChan)
 
 
-filter :: (a -> Bool) -> Stream es a -> Stream es a
-filter p (Stream n) = Stream loop
+-- | Iterate only over values that pass a predicate.
+filter :: (a -> Bool) -> Iterator es a -> Iterator es a
+filter p (Iterator n) = Iterator loop
   where
     loop = do
         x <- n
         if p x then pure x else loop
 
 
--- | Only emit values that differ from the previous one.
-changes :: (Eq a) => a -> Stream es a -> Stream es a
-changes initial stream = Stream (loop initial)
+-- | Iterate only values that differ from the previous one.
+changes :: (Eq a) => a -> Iterator es a -> Iterator es a
+changes initial iterator = Iterator (loop initial)
   where
     loop prev = do
-        x <- next (filter (/= prev) stream)
+        x <- next (filter (/= prev) iterator)
         pure x

--- a/atelier/test/Unit/Atelier/Effects/IteratorSpec.hs
+++ b/atelier/test/Unit/Atelier/Effects/IteratorSpec.hs
@@ -1,0 +1,118 @@
+module Unit.Atelier.Effects.IteratorSpec (spec_Iterator) where
+
+import Control.Concurrent (threadDelay)
+import Effectful (IOE, runEff)
+import Effectful.Concurrent (Concurrent, runConcurrent)
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+import Atelier.Effects.Chan (Chan, runChan)
+import Atelier.Effects.Clock (Clock, runClock)
+import Atelier.Effects.Conc (Conc, fork, runConc)
+import Atelier.Effects.Monitoring.Tracing (Tracing, runTracingNoOp)
+import Atelier.Effects.Publishing (Pub, Sub, publish, runPubSub)
+
+import Atelier.Effects.Iterator qualified as Iter
+
+
+spec_Iterator :: Spec
+spec_Iterator = do
+    describe "fromEvents" testFromEvents
+    describe "filter" testFilter
+    describe "changes" testChanges
+
+
+testFromEvents :: Spec
+testFromEvents = do
+    it "yields a published event" do
+        result <- runTest $ do
+            Iter.fromEvents @Int \iter -> do
+                _ <- fork do
+                    liftIO $ threadDelay 10
+                    publish (42 :: Int)
+                Iter.next iter
+        result `shouldBe` 42
+
+    it "yields events in publication order" do
+        result <- runTest $ do
+            Iter.fromEvents @Int \iter -> do
+                _ <- fork do
+                    liftIO $ threadDelay 10
+                    traverse_ publish [1, 2, 3]
+                replicateM 3 (Iter.next iter)
+        result `shouldBe` [1, 2, 3]
+
+    it "buffers events so next can catch up" do
+        result <- runTest $ do
+            Iter.fromEvents @Int \iter -> do
+                _ <- fork do
+                    liftIO $ threadDelay 10
+                    traverse_ publish [1, 2, 3]
+                liftIO $ threadDelay 5_000
+                replicateM 3 (Iter.next iter)
+        result `shouldBe` [1, 2, 3]
+
+
+testFilter :: Spec
+testFilter = do
+    it "passes values that satisfy the predicate" do
+        result <- runTest $ do
+            Iter.fromEvents @Int \iter -> do
+                _ <- fork do
+                    liftIO $ threadDelay 10
+                    traverse_ publish [1 .. 4]
+                Iter.next (Iter.filter even iter)
+        result `shouldBe` 2
+
+    it "skips values that do not satisfy the predicate" do
+        result <- runTest $ do
+            Iter.fromEvents @Int \iter -> do
+                _ <- fork do
+                    liftIO $ threadDelay 10
+                    traverse_ publish [1 .. 6]
+                replicateM 3 (Iter.next (Iter.filter even iter))
+        result `shouldBe` [2, 4, 6]
+
+
+testChanges :: Spec
+testChanges = do
+    it "skips values equal to the initial value" do
+        result <- runTest $ do
+            Iter.fromEvents @Int \iter -> do
+                _ <- fork do
+                    liftIO $ threadDelay 10
+                    traverse_ publish [0, 0, 1]
+                Iter.next (Iter.changes 0 iter)
+        result `shouldBe` 1
+
+    it "yields values that differ from the initial value" do
+        result <- runTest $ do
+            Iter.fromEvents @Int \iter -> do
+                _ <- fork do
+                    liftIO $ threadDelay 10
+                    traverse_ publish [1, 2, 3]
+                replicateM 3 (Iter.next (Iter.changes 0 iter))
+        result `shouldBe` [1, 2, 3]
+
+    it "skips initial values interspersed with non-initial values" do
+        result <- runTest $ do
+            Iter.fromEvents @Int \iter -> do
+                _ <- fork do
+                    liftIO $ threadDelay 10
+                    traverse_ publish [0, 1, 0, 2, 0, 3]
+                replicateM 3 (Iter.next (Iter.changes 0 iter))
+        result `shouldBe` [1, 2, 3]
+
+
+--------------------------------------------------------------------------------
+-- Test Helpers
+--------------------------------------------------------------------------------
+
+runTest :: Eff '[Pub Int, Sub Int, Chan, Clock, Tracing, Conc, Concurrent, IOE] a -> IO a
+runTest =
+    runEff
+        . runConcurrent
+        . runConc
+        . runTracingNoOp
+        . runClock
+        . runChan
+        . runPubSub @Int

--- a/tricorder.cabal
+++ b/tricorder.cabal
@@ -138,6 +138,7 @@ library atelier
       Atelier.Effects.File
       Atelier.Effects.FileSystem
       Atelier.Effects.FileWatcher
+      Atelier.Effects.Iterator
       Atelier.Effects.Log
       Atelier.Effects.Monitoring.Metrics
       Atelier.Effects.Monitoring.Metrics.Registry
@@ -147,7 +148,6 @@ library atelier
       Atelier.Effects.Posix.Daemons
       Atelier.Effects.Posix.IO
       Atelier.Effects.Publishing
-      Atelier.Effects.Stream
       Atelier.Effects.Tally
       Atelier.Effects.UUID
       Atelier.Exception
@@ -395,6 +395,7 @@ test-suite atelier-test
       Unit.Atelier.Effects.DelaySpec
       Unit.Atelier.Effects.FileSystemSpec
       Unit.Atelier.Effects.FileWatcherSpec
+      Unit.Atelier.Effects.IteratorSpec
       Unit.Atelier.Effects.LogSpec
       Unit.Atelier.Effects.PublishingSpec
       Unit.Atelier.Effects.TallySpec

--- a/tricorder/src/Tricorder/Effects/SessionStore.hs
+++ b/tricorder/src/Tricorder/Effects/SessionStore.hs
@@ -27,8 +27,8 @@ import Tricorder.Runtime (ProjectRoot)
 import Tricorder.Session (Session, loadSession)
 
 import Atelier.Effects.Conc qualified as Conc
+import Atelier.Effects.Iterator qualified as Iter
 import Atelier.Effects.Publishing qualified as Sub
-import Atelier.Effects.Stream qualified as Stream
 
 
 data SessionStore :: Effect where
@@ -79,15 +79,15 @@ withSubSession
     -> (Reloader es -> subSession -> Eff es a)
     -> Eff es Void
 withSubSession mkSubSession initialSession action =
-    Stream.fromEvents @SessionStoreReloaded \stream ->
+    Iter.fromEvents @SessionStoreReloaded \iter ->
         let initialSubSession = mkSubSession initialSession
-            subStream =
-                Stream.changes
+            subIter =
+                Iter.changes
                     initialSubSession
-                    (fmap (\(SessionStoreReloaded s) -> mkSubSession s) stream)
+                    (fmap (\(SessionStoreReloaded s) -> mkSubSession s) iter)
         in  Conc.restartableForkLoop
                 initialSubSession
-                (Stream.next subStream)
+                (Iter.next subIter)
                 \cfg -> action (Reloader rawReload) cfg
 
 


### PR DESCRIPTION
The current `Atelier.Effects.Stream` module's `Stream` `newtype` behaves more like an iterator than a stream. In the case where we would like to add a proper `Stream` effect in the future, and to better communicate the behavior of `Stream`, it should be renamed to `Iterator`.

This PR also adds some specs for the renamed `Iterator` module.