### PR TITLE
feat: dispatch :add/:unadd to GHCi from file events

### DIFF
--- a/atelier/src/Atelier/Effects/Debounce.hs
+++ b/atelier/src/Atelier/Effects/Debounce.hs
@@ -2,20 +2,23 @@
 --
 -- == Overview
 --
--- @debounced key action@ schedules @action@ to run after the settle window,
--- but cancels it if another call with the same @key@ arrives before the
--- window expires. This coalesces rapid bursts (e.g. two inotify events for
--- the same file) into a single callback.
+-- 'debouncedWith' is the fundamental operation: it accumulates rapid successive
+-- calls with the same key using a merge function, then fires the callback once
+-- after the settle window with the merged result.
+--
+-- 'debounced' is a convenience wrapper for the common case where only timing
+-- matters and the last-registered action should fire.
 --
 -- == Example
 --
 -- @
--- watchFilePaths watches \path ->
---     debounced path (markDirty (changeKindFor path))
+-- watchFilePaths watches \path event ->
+--     debouncedWith 100 mergeFileEvent path event (handleChange path)
 -- @
 module Atelier.Effects.Debounce
     ( -- * Effect
       Debounce
+    , debouncedWith
     , debounced
 
       -- * Interpreters
@@ -23,6 +26,7 @@ module Atelier.Effects.Debounce
     , runDebounceNoOp
     ) where
 
+import Data.Dynamic (Dynamic, fromDynamic, toDyn)
 import Effectful (Effect)
 import Effectful.Concurrent (Concurrent)
 import Effectful.Concurrent.STM (STM)
@@ -40,17 +44,33 @@ import Atelier.Effects.Delay qualified as Delay
 
 
 data Debounce key :: Effect where
-    -- | Schedule @action@ to run after the settle window unless a newer call
-    -- with the same @key@ arrives first.
-    Debounced :: Millisecond -> key -> m () -> Debounce key m ()
+    -- | Schedule @callback merged@ after the settle window. If another call
+    -- with the same @key@ arrives before the window expires, the two values are
+    -- combined with @merge old new@ and the timer resets. The callback fires at
+    -- most once per burst.
+    DebouncedWith
+        :: (Typeable value)
+        => Millisecond
+        -> (value -> value -> value)
+        -> key
+        -> value
+        -> (value -> m ())
+        -> Debounce key m ()
 
 
 makeEffect ''Debounce
 
 
+-- | Schedule @action@ to run after the settle window unless a newer call with
+-- the same @key@ arrives first. The last-registered action fires.
+debounced :: (Debounce key :> es) => Millisecond -> key -> Eff es () -> Eff es ()
+debounced settleMs key action = debouncedWith settleMs (\() () -> ()) key () (\() -> action)
+
+
 -- | Run the 'Debounce' effect.
 --
--- @settleMs@ is the quiet window — how long to wait for silence before firing.
+-- Each key maintains a generation counter. Rapid calls for the same key merge
+-- their values and reset the settle timer; only the last generation fires.
 runDebounce
     :: forall key es a
      . ( Conc :> es
@@ -61,28 +81,33 @@ runDebounce
     => Eff (Debounce key : es) a
     -> Eff es a
 runDebounce eff = do
-    counters <- STM.atomically (Map.new :: STM (Map.Map key Int))
+    state <- STM.atomically (Map.new :: STM (Map.Map key (Int, Maybe Dynamic)))
     interpretWith eff \env -> \case
-        Debounced settleMs key action ->
+        DebouncedWith settleMs merge key value callback ->
             localUnlift env concStrat \unlift -> do
                 n <- STM.atomically $ do
-                    current <- Map.lookup key counters
-                    let n = maybe 0 (+ 1) current
-                    Map.insert n key counters
+                    current <- Map.lookup key state
+                    let n = maybe 0 ((+ 1) . fst) current
+                    let prior = current >>= \(_, mDyn) -> mDyn >>= fromDynamic
+                    let merged = case prior of
+                            Just p -> merge p value
+                            Nothing -> value
+                    Map.insert (n, Just (toDyn merged)) key state
                     pure n
                 void $ fork $ do
                     Delay.wait settleMs
-                    shouldFire <- STM.atomically $ do
-                        current <- Map.lookup key counters
-                        if current == Just n then
-                            Map.delete key counters $> True
+                    mValue <- STM.atomically $ do
+                        current <- Map.lookup key state
+                        if fmap fst current == Just n then do
+                            Map.delete key state
+                            pure $ current >>= \(_, mDyn) -> mDyn >>= fromDynamic
                         else
-                            pure False
-                    when shouldFire (unlift action)
+                            pure Nothing
+                    for_ mValue (unlift . callback)
 
 
--- | No-op interpreter — fires every action immediately without debouncing.
--- Useful for tests where timing is controlled externally.
+-- | No-op interpreter — fires every callback immediately with its value, without
+-- debouncing. Useful for tests where timing is controlled externally.
 runDebounceNoOp :: Eff (Debounce key : es) a -> Eff es a
 runDebounceNoOp eff = interpretWith eff \env -> \case
-    Debounced _ _ action -> localSeqUnlift env \unlift -> unlift action
+    DebouncedWith _ _ _ value callback -> localSeqUnlift env \unlift -> unlift (callback value)

--- a/atelier/src/Atelier/Effects/FileWatcher.hs
+++ b/atelier/src/Atelier/Effects/FileWatcher.hs
@@ -49,6 +49,10 @@ module Atelier.Effects.FileWatcher
     , excluding
     , containing
 
+      -- * File events
+    , FileEvent (..)
+    , mergeFileEvent
+
       -- * Effect
     , FileWatcher
     , watchFilePaths
@@ -77,9 +81,36 @@ import System.FSNotify (eventPath, watchTree, withManager)
 import System.FilePath (takeExtension)
 
 import Data.Text qualified as T
+import System.FSNotify qualified as FSN
 
 import Atelier.Effects.Conc (concStrat)
-import Atelier.Effects.Debounce (Debounce, debounced)
+import Atelier.Effects.Debounce (Debounce, debouncedWith)
+
+
+-- | The kind of filesystem change that triggered a watch callback.
+data FileEvent
+    = -- | A new file was created.
+      Added
+    | -- | An existing file was modified.
+      Modified
+    | -- | A file was deleted.
+      Removed
+    deriving stock (Eq, Show)
+
+
+-- | Merge two 'FileEvent's for the same path within a debounce window.
+--
+-- Rules (old, new) → result:
+--
+-- * @(_, Removed)@ → @Removed@: deletion always wins.
+-- * @(Removed, Added)@ → @Added@: explicit re-creation after deletion.
+-- * @(Added, _)@ → @Added@: a create-then-write is still a creation.
+-- * Otherwise → the newer event.
+mergeFileEvent :: FileEvent -> FileEvent -> FileEvent
+mergeFileEvent _ Removed = Removed
+mergeFileEvent Removed Added = Added
+mergeFileEvent Added _ = Added
+mergeFileEvent _ event = event
 
 
 -- | Specification of a directory to watch recursively, with a file predicate.
@@ -131,11 +162,11 @@ containing fragment f = fragment `T.isInfixOf` toText f
 
 data FileWatcher :: Effect where
     -- | Watch the given directories for changes, calling the callback with
-    -- each matching file path. Registers the minimal set of OS watchers needed
-    -- to cover all entries (deduplication by path prefix). The callback is
-    -- invoked at most once per raw filesystem event regardless of how many
-    -- entries match. Never returns.
-    WatchFilePaths :: [Watch] -> (FilePath -> m a) -> FileWatcher m Void
+    -- each matching file path and the kind of change that occurred. Registers
+    -- the minimal set of OS watchers needed to cover all entries (deduplication
+    -- by path prefix). The callback is invoked at most once per raw filesystem
+    -- event regardless of how many entries match. Never returns.
+    WatchFilePaths :: [Watch] -> (FilePath -> FileEvent -> m a) -> FileWatcher m Void
 
 
 makeEffect ''FileWatcher
@@ -147,10 +178,11 @@ makeEffect ''FileWatcher
 watchFilePathsDebounced
     :: (Debounce FilePath :> es, FileWatcher :> es)
     => [Watch]
-    -> (FilePath -> Eff es ())
+    -> (FilePath -> FileEvent -> Eff es ())
     -> Eff es Void
 watchFilePathsDebounced watches callback =
-    watchFilePaths watches \path -> debounced 100 path (callback path)
+    watchFilePaths watches \path event ->
+        debouncedWith 100 mergeFileEvent path event (callback path)
 
 
 -- | Production interpreter backed by fsnotify.
@@ -163,26 +195,37 @@ runFileWatcherIO eff = interpretWith eff \env -> \case
             withManager \mgr -> do
                 let dedupedDirs = deduplicateDirs [p | Watch p _ <- absWatches]
                 for_ dedupedDirs \d ->
-                    watchTree mgr d (matchesAny absWatches . eventPath) \event ->
-                        void $ unliftIO $ callback (eventPath event)
+                    watchTree mgr d (matchesAny absWatches . eventPath) \fsEvent ->
+                        void $ unliftIO $ callback (eventPath fsEvent) (toFileEvent fsEvent)
                 forever $ threadDelay 1_000_000
 
 
 -- | Scripted interpreter for testing.
--- Delivers all scripted paths to the callback in order, then blocks
+-- Delivers all scripted events to the callback in order, then blocks
 -- indefinitely — matching the blocking semantics of 'runFileWatcherIO'.
--- The 'Watch' specification is ignored; the caller controls what paths are fed in.
-runFileWatcherScripted :: (Concurrent :> es) => [FilePath] -> Eff (FileWatcher : es) a -> Eff es a
-runFileWatcherScripted paths = reinterpret (evalState paths) \env -> \case
+-- The 'Watch' specification is ignored; the caller controls what events are fed in.
+runFileWatcherScripted :: (Concurrent :> es) => [(FilePath, FileEvent)] -> Eff (FileWatcher : es) a -> Eff es a
+runFileWatcherScripted events = reinterpret (evalState events) \env -> \case
     WatchFilePaths _ callback ->
         localSeqUnlift env \unlift -> do
-            paths' <- get
+            events' <- get
             put []
-            for_ paths' (unlift . callback)
+            for_ events' \(path, fileEvent) -> unlift $ callback path fileEvent
             atomically retry
 
 
 -- Helpers
+
+toFileEvent :: FSN.Event -> FileEvent
+toFileEvent = \case
+    FSN.Added {} -> Added
+    FSN.Modified {} -> Modified
+    FSN.ModifiedAttributes {} -> Modified
+    FSN.CloseWrite {} -> Modified
+    FSN.Removed {} -> Removed
+    FSN.WatchedDirectoryRemoved {} -> Removed
+    FSN.Unknown {} -> Modified
+
 
 -- | Remove dirs that are proper subdirectories of another dir in the list.
 deduplicateDirs :: [FilePath] -> [FilePath]

--- a/atelier/test/Unit/Atelier/Effects/FileWatcherSpec.hs
+++ b/atelier/test/Unit/Atelier/Effects/FileWatcherSpec.hs
@@ -12,7 +12,7 @@ import Test.Hspec.Hedgehog (hedgehog)
 import Hedgehog.Gen qualified as Gen
 import Hedgehog.Range qualified as Range
 
-import Atelier.Effects.FileWatcher (FileWatcher, Watch, deduplicateDirs, dir, dirWhere, matchesAny, runFileWatcherScripted, watchFilePaths)
+import Atelier.Effects.FileWatcher (FileEvent (..), FileWatcher, Watch, deduplicateDirs, dir, dirWhere, matchesAny, runFileWatcherScripted, watchFilePaths)
 
 
 spec_FileWatcher :: Spec
@@ -94,8 +94,8 @@ collectPathsWith :: [Watch] -> [FilePath] -> IO [FilePath]
 collectPathsWith watches scripted = do
     ref <- newIORef []
     sem <- newQSem 0
-    tid <- forkIO $ void $ runScripted scripted $ watchFilePaths watches \p -> liftIO do
-        modifyIORef ref (<> [p])
+    tid <- forkIO $ void $ runScripted scripted $ watchFilePaths watches \filePath _fileEvent -> liftIO do
+        modifyIORef ref (<> [filePath])
         signalQSem sem
     replicateM_ (length scripted) (waitQSem sem)
     killThread tid
@@ -103,7 +103,7 @@ collectPathsWith watches scripted = do
 
 
 runScripted :: [FilePath] -> Eff '[FileWatcher, Concurrent, IOE] a -> IO a
-runScripted paths = runEff . runConcurrent . runFileWatcherScripted paths
+runScripted paths = runEff . runConcurrent . runFileWatcherScripted (map (,Modified) paths)
 
 
 --------------------------------------------------------------------------------

--- a/tricorder/src/Tricorder/BuildState.hs
+++ b/tricorder/src/Tricorder/BuildState.hs
@@ -29,6 +29,7 @@ import Effectful.Concurrent.STM (TVar)
 import Effectful.Reader.Static (Reader, ask, runReader)
 import System.FilePath (makeRelative)
 
+import Atelier.Effects.FileWatcher (FileEvent)
 import Atelier.Time (Millisecond)
 import Tricorder.Effects.SessionStore (SessionStore)
 import Tricorder.Runtime (LogPath (..), ProjectRoot (..), SocketPath (..))
@@ -207,7 +208,7 @@ data ChangeKind = SourceChange | CabalChange deriving stock (Eq, Ord, Show)
 
 data CabalChangeDetected = CabalChangeDetected
     deriving stock (Eq, Show)
-data SourceChangeDetected = SourceChangeDetected
+data SourceChangeDetected = SourceChangeDetected FilePath FileEvent
     deriving stock (Eq, Show)
 
 

--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -22,7 +22,7 @@ import Effectful.Exception (bracket_, trySync)
 import Effectful.Reader.Static (Reader, ask)
 import Effectful.State.Static.Shared (State, execState, get, put, state)
 import Relude.Extra.Tuple (dup)
-import System.FilePath (isAbsolute, (</>))
+import System.FilePath (isAbsolute, normalise, (</>))
 
 import Data.Map.Strict qualified as Map
 
@@ -31,6 +31,7 @@ import Atelier.Effects.Chan (Chan)
 import Atelier.Effects.Clock (Clock, UTCTime)
 import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.Debounce (Debounce, debounced)
+import Atelier.Effects.FileWatcher (FileEvent (..))
 import Atelier.Effects.Log (Log)
 import Atelier.Effects.Publishing (Pub, Sub, publish)
 import Atelier.Time (Millisecond, nominalDiffTime)
@@ -48,7 +49,7 @@ import Tricorder.BuildState
     , TestRun (..)
     )
 import Tricorder.Effects.BuildStore (BuildStore)
-import Tricorder.Effects.GhciSession (GhciSession, LoadResult (..))
+import Tricorder.Effects.GhciSession (GhciSession, LoadResult (..), LoadedModule (..))
 import Tricorder.Effects.SessionStore (SessionStore, SessionStoreReloaded)
 import Tricorder.Effects.TestRunner (TestRunner)
 import Tricorder.Runtime (ProjectRoot (..))
@@ -86,6 +87,7 @@ component
        , Pub NewLoadResult :> es
        , Reader ProjectRoot :> es
        , SessionStore :> es
+       , State (Map FilePath LoadedModule) :> es
        , State BuildId :> es
        , State DiagnosticMap :> es
        , Sub BuildResult :> es
@@ -164,6 +166,7 @@ restartableListeners
        , Pub EnteringNewPhase :> es
        , Pub NewLoadResult :> es
        , Reader ProjectRoot :> es
+       , State (Map FilePath LoadedModule) :> es
        , State BuildId :> es
        , State DiagnosticMap :> es
        , Sub BuildResult :> es
@@ -220,6 +223,7 @@ buildWithGhciOnChange
        , Pub EnteringNewPhase :> es
        , Pub NewLoadResult :> es
        , Reader ProjectRoot :> es
+       , State (Map FilePath LoadedModule) :> es
        , State BuildId :> es
        , State DiagnosticMap :> es
        , Sub CabalChangeDetected :> es
@@ -229,7 +233,8 @@ buildWithGhciOnChange
     -> BuilderSession
     -> Eff es Void
 buildWithGhciOnChange reloader config = forever do
-    put Map.empty
+    put @DiagnosticMap Map.empty
+    put @(Map FilePath LoadedModule) Map.empty
     projectRoot <- ask
     BuildId n <- get
     Log.info $ "Starting GHCi session #" <> show n <> ": " <> config.command
@@ -238,6 +243,7 @@ buildWithGhciOnChange reloader config = forever do
     GhciSession.withGhci config.command projectRoot \initialLoad controls -> do
         initialEndTime <- Clock.currentTime
         handleInitialBuild config initialStartTime initialEndTime initialLoad
+        put @(Map FilePath LoadedModule) initialLoad.loadedModules
         rebuildOnChange reloader controls
 
 
@@ -282,6 +288,7 @@ rebuildOnChange
        , Log :> es
        , Pub EnteringNewPhase :> es
        , Pub NewLoadResult :> es
+       , State (Map FilePath LoadedModule) :> es
        , State BuildId :> es
        , Sub CabalChangeDetected :> es
        , Sub SourceChangeDetected :> es
@@ -308,6 +315,7 @@ handleSourceChanges
        , Log :> es
        , Pub EnteringNewPhase :> es
        , Pub NewLoadResult :> es
+       , State (Map FilePath LoadedModule) :> es
        , State BuildId :> es
        , Sub SourceChangeDetected :> es
        )
@@ -344,26 +352,51 @@ reloadOnSourceChange
        , Log :> es
        , Pub EnteringNewPhase :> es
        , Pub NewLoadResult :> es
+       , State (Map FilePath LoadedModule) :> es
        , State BuildId :> es
        )
     => Semaphore -> GhciSession.Controls (Eff es) -> SourceChangeDetected -> Eff es ()
-reloadOnSourceChange readyToBuildSem controls SourceChangeDetected = do
-    Log.debug $ "Builder: dirty flag set, reloading"
-    buildId <- get
-    publish $ EnteringNewPhase buildId $ Building Nothing
+reloadOnSourceChange readyToBuildSem controls (SourceChangeDetected fp event) = do
+    Log.debug $ "Builder: source change detected " <> show event <> " " <> toText fp
+    moduleMap <- get @(Map FilePath LoadedModule)
+    let known = Map.lookup (normalise fp) moduleMap
+    case dispatch known of
+        Nothing ->
+            Log.debug
+                $ "Builder: no-op for "
+                    <> show event
+                    <> " of file not loaded in GHCi: "
+                    <> toText fp
+        Just action -> do
+            buildId <- get
+            publish $ EnteringNewPhase buildId $ Building Nothing
 
-    res <- trySync $ Sem.withSemaphore readyToBuildSem do
-        startTime <- Clock.currentTime
-        res <- controls.reload
-        endTime <- Clock.currentTime
-        pure (startTime, endTime, res)
+            res <- trySync $ Sem.withSemaphore readyToBuildSem do
+                startTime <- Clock.currentTime
+                res <- action
+                endTime <- Clock.currentTime
+                pure (startTime, endTime, res)
 
-    case res of
-        Left e -> do
-            now <- Clock.currentTime
-            Log.err $ show now <> " Reload errored: " <> show e
-        Right (startTime, endTime, loadResult) ->
-            publish $ NewLoadResult {startTime, endTime, loadResult}
+            case res of
+                Left e -> do
+                    now <- Clock.currentTime
+                    Log.err $ show now <> " Reload errored: " <> show e
+                Right (startTime, endTime, loadResult) -> do
+                    put loadResult.loadedModules
+                    publish $ NewLoadResult {startTime, endTime, loadResult}
+  where
+    -- Dispatch on (is the file currently loaded in GHCi?, FileEvent).
+    -- The module map is the source of truth: GHCi's `:show modules` was the
+    -- last word on which files are tracked. The FileEvent is a hint.
+    dispatch = \case
+        Just lm -> Just $ case event of
+            Added -> controls.reload -- re-adding a known file is just a reload
+            Modified -> controls.reload
+            Removed -> controls.unadd lm.moduleName
+        Nothing -> case event of
+            Added -> Just (controls.add fp)
+            Modified -> Just (controls.add fp) -- editor wrote a not-yet-loaded file
+            Removed -> Nothing -- nothing to remove
 
 
 data NewLoadResult = NewLoadResult

--- a/tricorder/src/Tricorder/Config.hs
+++ b/tricorder/src/Tricorder/Config.hs
@@ -74,7 +74,7 @@ restartOnConfigChange act = do
 
         Conc.fork_ $ FileWatcher.watchFilePathsDebounced
             [FileWatcher.dirWhere projectRoot (configFileName `isSuffixOf`)]
-            \_ -> putMVar ref Nothing
+            \_ _ -> putMVar ref Nothing
 
         takeMVar ref
     case var of

--- a/tricorder/src/Tricorder/Daemon/Main.hs
+++ b/tricorder/src/Tricorder/Daemon/Main.hs
@@ -25,7 +25,7 @@ import Tricorder.BuildState (BuildId (..), runDaemonInfo)
 import Tricorder.Config (restartOnConfigChange, runLoadedConfig)
 import Tricorder.Effects.BuildStore (runBuildStore)
 import Tricorder.Effects.GhcPkg (runGhcPkgIO)
-import Tricorder.Effects.GhciSession (runGhciSession)
+import Tricorder.Effects.GhciSession (LoadedModule, runGhciSession)
 import Tricorder.Effects.Logging (runLogging)
 import Tricorder.Effects.SessionStore (runSessionStore)
 import Tricorder.Effects.TestRunner (runTestRunnerIO)
@@ -92,6 +92,7 @@ main =
         . runGhciSession
         . evalState (BuildId 1)
         . evalState @Builder.DiagnosticMap mempty
+        . evalState @(Map FilePath LoadedModule) mempty
         $ do
             Log.info $ "Starting tricorder " <> Version.gitHash
             runSystem

--- a/tricorder/src/Tricorder/Effects/GhciSession.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession.hs
@@ -6,6 +6,7 @@ module Tricorder.Effects.GhciSession
 
       -- * Types
     , LoadResult (..)
+    , LoadedModule (..)
 
       -- * Interpreters
     , runGhciSession
@@ -44,9 +45,10 @@ import Tricorder.Effects.BuildStore (BuildStore, getState, setPhase)
 import Tricorder.Effects.GhciSession.GhciParser
     ( GhciLoading (..)
     , LoadResult (..)
+    , LoadedModule (..)
     , extractTitle
     )
-import Tricorder.Effects.GhciSession.GhciProcess (collectGhciResult, interruptGhci, reloadGhci, withGhciProcess)
+import Tricorder.Effects.GhciSession.GhciProcess (addGhci, collectGhciResult, interruptGhci, reloadGhci, unaddGhci, withGhciProcess)
 import Tricorder.Runtime (ProjectRoot (..))
 
 
@@ -61,6 +63,8 @@ data GhciSession :: Effect where
 data Controls m = Controls
     { reload :: m LoadResult
     , interrupt :: m ()
+    , add :: FilePath -> m LoadResult
+    , unadd :: Text -> m LoadResult
     }
 
 
@@ -93,6 +97,8 @@ runGhciSessionScripted results = reinterpret (evalState results) $ \env ->
                                 Controls
                                     { reload = liftEff popResult
                                     , interrupt = pure ()
+                                    , add = \_ -> liftEff popResult
+                                    , unadd = \_ -> liftEff popResult
                                     }
 
 
@@ -112,4 +118,12 @@ runGhciSession = interpret $ \env -> \case
                                 $ BuildProgress {compiled = loading.index, total = loading.total}
                         doReload = liftEff $ reloadGhci process dir onProgress
                     initialResult <- unlift $ liftEff $ collectGhciResult process startupLines dir onProgress
-                    unlift $ handler initialResult Controls {reload = doReload, interrupt = liftEff (interruptGhci process)}
+                    unlift
+                        $ handler
+                            initialResult
+                            Controls
+                                { reload = doReload
+                                , interrupt = liftEff (interruptGhci process)
+                                , add = \fp -> liftEff $ addGhci process fp dir onProgress
+                                , unadd = \mn -> liftEff $ unaddGhci process mn dir onProgress
+                                }

--- a/tricorder/src/Tricorder/Effects/GhciSession/GhciParser.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession/GhciParser.hs
@@ -4,21 +4,24 @@ module Tricorder.Effects.GhciSession.GhciParser
     , GhciMessage (..)
     , GhciSeverity (..)
     , LoadResult (..)
+    , LoadedModule (..)
     , Position (..)
     , collectResultCustom
     , parseReload
     , parseShowModules
     , stripAnsi
     , extractTitle
+    , toAbsolute
     , toRelative
     ) where
 
 import Data.Char (isAlpha, isDigit, isSpace, toLower)
-import System.FilePath (isAbsolute, makeRelative, splitDirectories, (</>))
+import System.FilePath (isAbsolute, makeRelative, normalise, splitDirectories, (</>))
 import Text.Megaparsec
 import Text.Megaparsec.Char (char, string)
 
 import Data.List qualified as List
+import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 import Data.Text qualified as T
 import Text.Megaparsec.Char.Lexer qualified as L
@@ -75,12 +78,24 @@ data GhciLoad
     deriving stock (Eq, Show)
 
 
+-- | A module currently loaded in the GHCi session.
+data LoadedModule = LoadedModule
+    { relPath :: FilePath
+    -- ^ Path relative to the project root (e.g. @"./src/Foo.hs"@).
+    , moduleName :: Text
+    }
+    deriving stock (Eq, Show)
+
+
 -- | The result of a GHCi load or reload operation.
 data LoadResult = LoadResult
     { moduleCount :: Int
     , compiledFiles :: Set FilePath
     -- ^ Files compiled in this cycle (derived from 'GLoading' items).
     -- Used by the session layer to decide which files' previous diagnostics to replace vs. retain.
+    , loadedModules :: Map FilePath LoadedModule
+    -- ^ Map from canonical absolute path to module metadata, derived from @:show modules@ output.
+    -- Acts as the source of truth for what GHCi currently knows.
     , diagnostics :: [Diagnostic]
     }
     deriving stock (Eq, Show)
@@ -370,6 +385,14 @@ toRelative base path
         rel -> "." </> List.foldr1 (</>) rel
 
 
+-- | Make a relative path absolute by prepending the given base directory.
+-- Paths already absolute are returned unchanged.
+toAbsolute :: FilePath -> FilePath -> FilePath
+toAbsolute base path
+    | isAbsolute path = path
+    | otherwise = base </> path
+
+
 -- | Strip ANSI escape sequences of the form @ESC [ \<params\> \<letter\>@.
 stripAnsi :: Text -> Text
 stripAnsi t = case T.uncons t of
@@ -387,12 +410,18 @@ stripAnsi t = case T.uncons t of
 collectResultCustom :: FilePath -> [GhciLoad] -> [(Text, FilePath)] -> LoadResult
 collectResultCustom projectRoot loads modules =
     let rel = toRelative projectRoot
+        abs' = toAbsolute projectRoot
         compiledFiles = case [l.sourceFile | GLoading l <- loads] of
             [] -> Set.fromList (map (rel . snd) modules)
             fs -> Set.fromList (map rel fs)
+        mkEntry (mn, fp) =
+            ( normalise (abs' fp)
+            , LoadedModule {relPath = rel fp, moduleName = mn}
+            )
     in  LoadResult
             { moduleCount = length modules
             , compiledFiles
+            , loadedModules = Map.fromList (map mkEntry modules)
             , diagnostics = toDiagnostics rel loads
             }
 

--- a/tricorder/src/Tricorder/Effects/GhciSession/GhciProcess.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession/GhciProcess.hs
@@ -7,6 +7,8 @@ module Tricorder.Effects.GhciSession.GhciProcess
     , interruptGhci
     , collectGhciResult
     , reloadGhci
+    , addGhci
+    , unaddGhci
     ) where
 
 import Control.Concurrent.STM (TVar, readTVar, retry, writeTVar)
@@ -353,3 +355,31 @@ reloadGhci
 reloadGhci process projectRoot onProgress = do
     reloadLines <- execGhci process ":reload"
     collectGhciResult process reloadLines projectRoot onProgress
+
+
+-- | Execute @:add@ for the given file and return the assembled 'LoadResult',
+-- emitting a progress callback for each @[N of M] Compiling …@ line.
+addGhci
+    :: (Concurrent :> es, File :> es, IOE :> es)
+    => GhciProcess
+    -> FilePath -- the file to :add
+    -> FilePath -- projectRoot
+    -> (GhciLoading -> Eff es ())
+    -> Eff es LoadResult
+addGhci process filePath projectRoot onProgress = do
+    addLines <- execGhci process (":add " <> T.pack filePath)
+    collectGhciResult process addLines projectRoot onProgress
+
+
+-- | Execute @:unadd@ for the given module and return the assembled 'LoadResult',
+-- emitting a progress callback for each @[N of M] Compiling …@ line.
+unaddGhci
+    :: (Concurrent :> es, File :> es, IOE :> es)
+    => GhciProcess
+    -> Text -- the module name to :unadd
+    -> FilePath -- projectRoot
+    -> (GhciLoading -> Eff es ())
+    -> Eff es LoadResult
+unaddGhci process moduleName projectRoot onProgress = do
+    unaddLines <- execGhci process (":unadd " <> moduleName)
+    collectGhciResult process unaddLines projectRoot onProgress

--- a/tricorder/src/Tricorder/Effects/TestRunner.hs
+++ b/tricorder/src/Tricorder/Effects/TestRunner.hs
@@ -128,11 +128,16 @@ data GhciOutcome
 -- 'System.Exit.exitWith' on completion. GHCi surfaces this as a line
 -- matching @*** Exception: ExitSuccess@ (pass) or
 -- @*** Exception: ExitFailure N@ (fail). Any other @*** Exception:@ line
--- means the runner crashed. Absence of an exception line is treated as pass.
+-- means the runner crashed.
+--
+-- When no exception line is present, the absence is ambiguous: either the
+-- test ran and printed nothing exit-related, or @:main@ never ran at all
+-- (e.g. the test target failed to compile, so @main@ is not in scope).
+-- A line containing @": error:"@ in the captured output is treated as the
+-- latter — a GHC compile/load error that prevented the suite from running.
 detectOutcome :: Text -> GhciOutcome
 detectOutcome output =
-    case List.find ("*** Exception: " `T.isPrefixOf`) (T.lines output) of
-        Nothing -> GhciPassed
+    case List.find ("*** Exception: " `T.isPrefixOf`) outputLines of
         Just line ->
             case T.stripPrefix "*** Exception: " line of
                 Nothing -> GhciPassed
@@ -145,3 +150,12 @@ detectOutcome output =
                                 GhciFailed
                             else
                                 GhciCrashed r
+        Nothing -> case List.find isCompileErrorLine outputLines of
+            Just errLine -> GhciCrashed (T.strip errLine)
+            Nothing -> GhciPassed
+  where
+    outputLines = T.lines output
+    -- GHC compile/load errors are formatted as
+    -- @<file-or-loc>:L:C: error: …@ (with at least one space after the colon).
+    -- The substring @": error:"@ is the canonical marker for these.
+    isCompileErrorLine line = ": error:" `T.isInfixOf` line

--- a/tricorder/src/Tricorder/Watcher.hs
+++ b/tricorder/src/Tricorder/Watcher.hs
@@ -75,7 +75,7 @@ markWatchedFiles f = do
     BuildStore.markDirty change
     case change of
         CabalChange -> publish CabalChangeDetected
-        SourceChange -> publish SourceChangeDetected
+        SourceChange -> publish (SourceChangeDetected f.path f.event)
   where
     change = changeKindFor f.path
 

--- a/tricorder/src/Tricorder/Watcher.hs
+++ b/tricorder/src/Tricorder/Watcher.hs
@@ -13,7 +13,8 @@ import Atelier.Effects.Chan (Chan)
 import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.Debounce (Debounce)
 import Atelier.Effects.FileWatcher
-    ( FileWatcher
+    ( FileEvent
+    , FileWatcher
     , Watch
     , containing
     , dirExt
@@ -76,10 +77,13 @@ markWatchedFiles f = do
         CabalChange -> publish CabalChangeDetected
         SourceChange -> publish SourceChangeDetected
   where
-    change = changeKindFor . getWatchedFile $ f
+    change = changeKindFor f.path
 
 
-newtype WatchedFile = WatchedFile {getWatchedFile :: FilePath}
+data WatchedFile = WatchedFile
+    { path :: FilePath
+    , event :: FileEvent
+    }
 
 
 data WatcherSession = WatcherSession
@@ -117,7 +121,7 @@ watchFiles = do
     withWatcherSession initialSession $ \_ session -> do
         projectRoot <- ask
         let watches = sourceWatches session.watchDirs <> cabalWatches projectRoot
-        watchFilePathsDebounced watches $ publish . WatchedFile
+        watchFilePathsDebounced watches \filePath fileEvent -> publish (WatchedFile filePath fileEvent)
 
 
 sourceWatches :: [FilePath] -> [Watch]

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -101,20 +101,20 @@ testReloadOnSourceChange = do
                 results `shouldMatchList` [NewLoadResult epoch epoch addLr]
 
     describe "Added" do
-        it "calls controls.add when the file is not loaded" do
+        describe "when the file is not loaded" $ it "calls controls.add" do
             (results, _) <- runTest Map.empty distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Added)
             results `shouldMatchList` [NewLoadResult epoch epoch addLr]
 
-        it "calls controls.reload when the file is already loaded (re-add is a reload)" do
+        describe "when the file is already loaded" $ it "calls controls.reload (re-add is a reload)" do
             (results, _) <- runTest knownFoo distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Added)
             results `shouldMatchList` [NewLoadResult epoch epoch reloadLr]
 
     describe "Removed" do
-        it "calls controls.unadd when the file is loaded" do
+        describe "when the file is loaded" $ it "calls controls.unadd" do
             (results, _) <- runTest knownFoo distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Removed)
             results `shouldMatchList` [NewLoadResult epoch epoch unaddLr]
 
-        it "is a no-op when the file is not loaded" do
+        describe "when the file is not loaded" $ it "is a no-op" do
             (results, phases) <- runTest Map.empty distinctCtrls (SourceChangeDetected "/abs/path/Unknown.hs" Removed)
             results `shouldMatchList` []
             phases `shouldMatchList` []

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -14,6 +14,7 @@ import Data.Set qualified as Set
 
 import Atelier.Effects.Clock (runClockConst)
 import Atelier.Effects.Delay (runDelay)
+import Atelier.Effects.FileWatcher (FileEvent (..))
 import Atelier.Effects.Log (runLogNoOp)
 import Atelier.Effects.Publishing (runPubWriter)
 import Tricorder.BuildState
@@ -41,7 +42,7 @@ import Tricorder.Builder
     , requestTestRunsForNewBuildResults
     , setNewPhase
     )
-import Tricorder.Effects.GhciSession (Controls (..), LoadResult (..), extractTitle)
+import Tricorder.Effects.GhciSession (Controls (..), LoadResult (..), LoadedModule (..), extractTitle)
 import Tricorder.Effects.TestRunner (runTestRunnerScripted)
 import Tricorder.Runtime (ProjectRoot (..))
 
@@ -84,19 +85,46 @@ testRestartOnCabalChange = do
 
 testReloadOnSourceChange :: Spec
 testReloadOnSourceChange = do
-    it "should publish that it is building" do
-        (_, phases) <- runTest loadResult
-        phases `shouldMatchList` [EnteringNewPhase (BuildId 1) $ Building Nothing]
+    describe "Modified" do
+        describe "when the file is loaded in GHCi" do
+            it "publishes that it is building" do
+                (_, phases) <- runTest knownFoo distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Modified)
+                phases `shouldMatchList` [EnteringNewPhase (BuildId 1) $ Building Nothing]
 
-    it "should publish NewLoadResult from the reload" do
-        (newLoadResults, _) <- runTest loadResult
-        newLoadResults `shouldMatchList` [NewLoadResult epoch epoch loadResult]
+            it "calls controls.reload" do
+                (results, _) <- runTest knownFoo distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Modified)
+                results `shouldMatchList` [NewLoadResult epoch epoch reloadLr]
+
+        describe "when the file is not loaded in GHCi" do
+            it "calls controls.add (the editor just wrote a new file)" do
+                (results, _) <- runTest Map.empty distinctCtrls (SourceChangeDetected "/abs/path/New.hs" Modified)
+                results `shouldMatchList` [NewLoadResult epoch epoch addLr]
+
+    describe "Added" do
+        it "calls controls.add when the file is not loaded" do
+            (results, _) <- runTest Map.empty distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Added)
+            results `shouldMatchList` [NewLoadResult epoch epoch addLr]
+
+        it "calls controls.reload when the file is already loaded (re-add is a reload)" do
+            (results, _) <- runTest knownFoo distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Added)
+            results `shouldMatchList` [NewLoadResult epoch epoch reloadLr]
+
+    describe "Removed" do
+        it "calls controls.unadd when the file is loaded" do
+            (results, _) <- runTest knownFoo distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Removed)
+            results `shouldMatchList` [NewLoadResult epoch epoch unaddLr]
+
+        it "is a no-op when the file is not loaded" do
+            (results, phases) <- runTest Map.empty distinctCtrls (SourceChangeDetected "/abs/path/Unknown.hs" Removed)
+            results `shouldMatchList` []
+            phases `shouldMatchList` []
   where
-    runTest lr = do
+    runTest initialModuleMap ctrls event = do
         runEff
             . runConcurrent
             . runClockConst epoch
             . evalState (BuildId 1)
+            . evalState @(Map FilePath LoadedModule) initialModuleMap
             . runLogNoOp
             . runWriter
             . runPubWriter @EnteringNewPhase
@@ -104,16 +132,36 @@ testReloadOnSourceChange = do
             . runPubWriter @NewLoadResult
             $ do
                 sem <- Sem.newSet
-                reloadOnSourceChange sem (mkCtrls lr) SourceChangeDetected
+                reloadOnSourceChange sem ctrls event
 
-    mkCtrls lr = Controls {reload = pure lr, interrupt = pure ()}
+    distinctCtrls =
+        Controls
+            { reload = pure reloadLr
+            , interrupt = pure ()
+            , add = \_ -> pure addLr
+            , unadd = \_ -> pure unaddLr
+            }
 
-    loadResult =
+    knownFoo =
+        Map.fromList
+            [
+                ( "/abs/path/Foo.hs"
+                , LoadedModule {relPath = "./src/Foo.hs", moduleName = "MyModule"}
+                )
+            ]
+
+    -- Distinct LoadResults so tests can identify which control was invoked.
+    mkLr :: Int -> LoadResult
+    mkLr n =
         LoadResult
-            { moduleCount = 2
+            { moduleCount = n
             , compiledFiles = Set.singleton errMsg.file
+            , loadedModules = Map.empty
             , diagnostics = []
             }
+    reloadLr = mkLr 10
+    addLr = mkLr 20
+    unaddLr = mkLr 30
 
 
 testSetNewPhase :: Spec
@@ -151,6 +199,7 @@ testCompileLoadResultsIntoBuildResults = do
                             LoadResult
                                 { moduleCount = 2
                                 , compiledFiles = Set.singleton errMsg.file
+                                , loadedModules = Map.empty
                                 , diagnostics = []
                                 }
                         }
@@ -165,6 +214,7 @@ testCompileLoadResultsIntoBuildResults = do
                             LoadResult
                                 { moduleCount = 2
                                 , compiledFiles = Set.singleton warnMsg.file
+                                , loadedModules = Map.empty
                                 , diagnostics = [warnMsg]
                                 }
                         }
@@ -184,6 +234,7 @@ testCompileLoadResultsIntoBuildResults = do
                             LoadResult
                                 { moduleCount = 2
                                 , compiledFiles = Set.singleton warnMsg.file
+                                , loadedModules = Map.empty
                                 , diagnostics = [warnMsg]
                                 }
                         }
@@ -297,6 +348,7 @@ testMergeDiagnostics = do
                 LoadResult
                     { moduleCount = 2
                     , compiledFiles = Set.singleton errMsg.file
+                    , loadedModules = Map.empty
                     , diagnostics = []
                     }
         let merged = mergeDiagnostics prev result
@@ -308,6 +360,7 @@ testMergeDiagnostics = do
                 LoadResult
                     { moduleCount = 1
                     , compiledFiles = Set.singleton errMsg.file
+                    , loadedModules = Map.empty
                     , diagnostics = []
                     }
         let merged = mergeDiagnostics prev result
@@ -320,6 +373,7 @@ testMergeDiagnostics = do
                 LoadResult
                     { moduleCount = 1
                     , compiledFiles = Set.singleton errMsg.file
+                    , loadedModules = Map.empty
                     , diagnostics = [newErr]
                     }
         let merged = mergeDiagnostics prev result
@@ -330,6 +384,7 @@ testMergeDiagnostics = do
                 LoadResult
                     { moduleCount = 1
                     , compiledFiles = Set.singleton warnMsg.file
+                    , loadedModules = Map.empty
                     , diagnostics = [warnMsg]
                     }
         let merged = mergeDiagnostics Map.empty result

--- a/tricorder/test/Unit/Tricorder/Effects/GhciSessionSpec.hs
+++ b/tricorder/test/Unit/Tricorder/Effects/GhciSessionSpec.hs
@@ -5,6 +5,7 @@ import Effectful (IOE, runEff)
 import Effectful.Exception (try)
 import Test.Hspec (Spec, describe, it, shouldBe, shouldSatisfy)
 
+import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 
 import Tricorder.BuildState (Diagnostic (..), Severity (..))
@@ -114,7 +115,7 @@ warnMsg =
 
 -- | Convenience constructor: a scripted result with no compiled-file info.
 simpleResult :: [Diagnostic] -> Either SomeException LoadResult
-simpleResult msgs = Right LoadResult {moduleCount = 0, compiledFiles = Set.empty, diagnostics = msgs}
+simpleResult msgs = Right LoadResult {moduleCount = 0, compiledFiles = Set.empty, loadedModules = Map.empty, diagnostics = msgs}
 
 
 runScripted :: [Either SomeException LoadResult] -> Eff '[GhciSession, IOE] a -> IO a

--- a/tricorder/test/Unit/Tricorder/TestRunnerSpec.hs
+++ b/tricorder/test/Unit/Tricorder/TestRunnerSpec.hs
@@ -66,6 +66,28 @@ testDetectOutcome = do
             detectOutcome "*** Exception: Crashed  \n"
                 `shouldBe` GhciCrashed "Crashed"
 
+    describe "compile failure (no exception line, but GHC errors present)" do
+        it "flags ':main not in scope' as crashed" do
+            detectOutcome "<interactive>:1:1: error: [GHC-76037] Not in scope: 'main'\n"
+                `shouldBe` GhciCrashed
+                    "<interactive>:1:1: error: [GHC-76037] Not in scope: 'main'"
+
+        it "flags a source-file compile error as crashed" do
+            detectOutcome "src/Foo.hs:42:5: error: Variable not in scope: foo\n"
+                `shouldBe` GhciCrashed "src/Foo.hs:42:5: error: Variable not in scope: foo"
+
+        it "reports the first error line when multiple are present" do
+            detectOutcome
+                "src/Foo.hs:42:5: error: Variable not in scope: foo\nsrc/Bar.hs:10:1: error: Parse error\n"
+                `shouldBe` GhciCrashed "src/Foo.hs:42:5: error: Variable not in scope: foo"
+
+        it "prefers exit exception over compile-error heuristic when both appear" do
+            -- A real failing run could plausibly mention 'error:' in its
+            -- captured output (e.g. logged messages); the ExitFailure line
+            -- still wins.
+            detectOutcome "log: error: something happened\n*** Exception: ExitFailure 1\n"
+                `shouldBe` GhciFailed
+
 
 --------------------------------------------------------------------------------
 -- Scripted interpreter tests

--- a/tricorder/test/Unit/Tricorder/WatcherSpec.hs
+++ b/tricorder/test/Unit/Tricorder/WatcherSpec.hs
@@ -34,7 +34,7 @@ testMarkWatchedFiles = do
 
     describe "with non-cabal file change" $ it "should publish SourceChangeDetected" do
         (_, sourceChanges) <- runTest "foo"
-        sourceChanges `shouldMatchList` [SourceChangeDetected]
+        sourceChanges `shouldMatchList` [SourceChangeDetected "foo" Modified]
 
     describe "with cabal file change" $ it "should publish CabalChangeDetected" do
         ((_, cabalChanges), _) <- runTest "foo.cabal"

--- a/tricorder/test/Unit/Tricorder/WatcherSpec.hs
+++ b/tricorder/test/Unit/Tricorder/WatcherSpec.hs
@@ -9,6 +9,7 @@ import Effectful.Writer.Static.Shared (runWriter)
 import Test.Hspec (Spec, describe, it, shouldBe, shouldMatchList)
 
 import Atelier.Effects.Delay (runDelay)
+import Atelier.Effects.FileWatcher (FileEvent (..))
 import Atelier.Effects.Publishing (runPubWriter)
 import Tricorder.BuildState
     ( CabalChangeDetected (..)
@@ -50,7 +51,7 @@ testMarkWatchedFiles = do
             . runPubWriter @CabalChangeDetected
             . mockBuildStore
             . markWatchedFiles
-            . WatchedFile
+            . (`WatchedFile` Modified)
     mockBuildStore :: Eff (BuildStore : es) a -> Eff es (Maybe ChangeKind)
     mockBuildStore = reinterpret_ (execState Nothing) \case
         MarkDirty ck -> put $ Just ck


### PR DESCRIPTION
Adds richer file events (`Added` / `Modified` / `Removed`) to the watcher and wires them through to the GHCi session so file creations/deletions update the loaded module set instead of always going through `:reload`.

The dispatcher uses the loaded-module map as the source of truth (populated from `:show modules`), so the FileEvent is just a hint — what we actually do depends on whether GHCi already knows the file:

| | Known to GHCi | Unknown |
|---|---|---|
| `Added` | `:reload` | `:add <path>` |
| `Modified` | `:reload` | `:add <path>` |
| `Removed` | `:unadd <module>` | no-op |

Unknown-Modified → `:add` covers the case where an editor writes a brand-new file that GHCi hasn't seen yet (otherwise `:reload` is a no-op for it). Unknown-Removed → no-op replaces the old fallback-to-reload.

Also fixes a pre-existing bug surfaced by testing this: a test suite that fails to compile (`cabal repl` opens, but `:main` errors with `Not in scope: 'main'`) was being silently reported as **passed** because `detectOutcome` only checked for `*** Exception: ExitFailure`. Now scans for `": error:"` in the captured output as a fallback signal:

```
test:tricorder-test  error: <interactive>:1:1: error: [GHC-76037] Not in scope: 'main'
```