### PR TITLE
fix: always :reload on Added/Modified, never :add

### DIFF
--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -386,16 +386,23 @@ reloadOnSourceChange readyToBuildSem controls (SourceChangeDetected fp event) = 
                     publish $ NewLoadResult {startTime, endTime, loadResult}
   where
     -- Dispatch on (is the file currently loaded in GHCi?, FileEvent).
-    -- The module map is the source of truth: GHCi's `:show modules` was the
-    -- last word on which files are tracked. The FileEvent is a hint.
+    --
+    -- `Added` and `Modified` always map to `:reload`, even when the file is
+    -- missing from the module map. GHCi drops failed-compile modules from
+    -- `:show modules`, so an `unknown` lookup conflates "file GHCi never saw"
+    -- with "file that failed last cycle". Dispatching `:add` in that state was
+    -- a no-op (the file is already a target) and left stale diagnostics in
+    -- place; `:reload` recovers cleanly. Note that most editors save atomically
+    -- (write temp + rename), so what looks like a Modified event actually
+    -- arrives as Added — both branches must do the right thing.
     dispatch = \case
         Just lm -> Just $ case event of
-            Added -> controls.reload -- re-adding a known file is just a reload
+            Added -> controls.reload
             Modified -> controls.reload
             Removed -> controls.unadd lm.moduleName
         Nothing -> case event of
-            Added -> Just (controls.add fp)
-            Modified -> Just (controls.add fp) -- editor wrote a not-yet-loaded file
+            Added -> Just controls.reload
+            Modified -> Just controls.reload
             Removed -> Nothing -- nothing to remove
 
 

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -96,16 +96,24 @@ testReloadOnSourceChange = do
                 results `shouldMatchList` [NewLoadResult epoch epoch reloadLr]
 
         describe "when the file is not loaded in GHCi" do
-            it "calls controls.add (the editor just wrote a new file)" do
+            -- Regression for stale-results bug: GHCi drops failed-compile
+            -- modules from `:show modules`, so a fixed file looks "unknown" to
+            -- the dispatcher. Dispatching `:add` in that state was a no-op and
+            -- left stale diagnostics in place. `Modified` must always reload.
+            it "calls controls.reload (recovers files that failed to compile last cycle)" do
                 (results, _) <- runTest Map.empty distinctCtrls (SourceChangeDetected "/abs/path/New.hs" Modified)
-                results `shouldMatchList` [NewLoadResult epoch epoch addLr]
+                results `shouldMatchList` [NewLoadResult epoch epoch reloadLr]
 
     describe "Added" do
-        describe "when the file is not loaded" $ it "calls controls.add" do
+        -- Atomic-save editors (vim, neovim, etc.) write via tmpfile+rename,
+        -- which fsnotify reports as Added even for an existing file. So this
+        -- branch needs the same failed-compile-recovery semantics as Modified:
+        -- always reload, never trust the module map for `unknown` lookups.
+        describe "when the file is not loaded" $ it "calls controls.reload" do
             (results, _) <- runTest Map.empty distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Added)
-            results `shouldMatchList` [NewLoadResult epoch epoch addLr]
+            results `shouldMatchList` [NewLoadResult epoch epoch reloadLr]
 
-        describe "when the file is already loaded" $ it "calls controls.reload (re-add is a reload)" do
+        describe "when the file is already loaded" $ it "calls controls.reload" do
             (results, _) <- runTest knownFoo distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Added)
             results `shouldMatchList` [NewLoadResult epoch epoch reloadLr]
 


### PR DESCRIPTION
GHCi drops failed-compile modules from `:show modules`. The dispatcher introduced in 6dbe778 used that as the source of truth, so after any failed reload the affected files looked "unknown" and the next Added/Modified event dispatched `:add` — a no-op for already-tracked targets. The previous diagnostics never got cleared, producing stale results until the daemon was restarted.

Compounding the issue, atomic-save editors (vim, neovim, etc.) write via tmpfile+rename, which fsnotify reports as `Added` rather than `Modified`, so both branches were affected in practice.

Both `Added` and `Modified` now unconditionally `:reload`. `Removed` keeps the `:unadd` path. Updated `BuilderSpec` to match and added comments documenting the regression so the unknown-Modified branch isn't reverted again.

---

I'm working on a proper implementation using `:show targets` instead of `:show modules`.