### PR TITLE
feat: add Yield and Await

### DIFF
--- a/atelier/src/Atelier/Effects/Await.hs
+++ b/atelier/src/Atelier/Effects/Await.hs
@@ -1,0 +1,21 @@
+module Atelier.Effects.Await
+    ( -- * Effect
+      Await
+
+      -- * Operations
+    , await
+    , takeAwait
+
+      -- * Interpreters
+    , eachAwait
+    , awaitYield
+    ) where
+
+import Atelier.Effects.Internal.Coroutine
+    ( Await
+    , await
+    , awaitYield
+    , eachAwait
+    , takeAwait
+    )
+

--- a/atelier/src/Atelier/Effects/Conc.hs
+++ b/atelier/src/Atelier/Effects/Conc.hs
@@ -7,6 +7,7 @@ module Atelier.Effects.Conc
     , await
     , awaitAll
     , forkTry
+    , race
 
       -- * Scope
     , Scope (..)
@@ -29,9 +30,10 @@ import Effectful
     , Limit (..)
     , Persistence (..)
     , UnliftStrategy (..)
-    , raise
+    , inject
     , withEffToIO
     )
+import Effectful.Concurrent.MVar (Concurrent, newEmptyMVar, putMVar, takeMVar)
 import Effectful.Concurrent.STM (atomically, runConcurrent)
 import Effectful.Dispatch.Dynamic
     ( EffectHandler
@@ -55,6 +57,9 @@ data Conc :: Effect where
     Await :: Thread a -> Conc m a
     AwaitAll :: Conc m ()
     ForkTry :: (Exception e) => m a -> Conc m (Thread (Either e a))
+    -- | Races two computations concurrently and returns the result of the
+    -- operation that finished first.
+    Race :: m a -> m b -> Conc m (Either a b)
     Scoped :: m a -> Conc m a
 
 
@@ -94,10 +99,10 @@ restartableForkLoop initial signal action = go initial
 --
 -- Does not handle trace context propagation. Use 'Atelier.Effects.Conc.Traced.runConc'
 -- for automatic span link propagation across forks.
-runConcBase :: forall es a. (IOE :> es) => Scope -> Eff (Conc : es) a -> Eff es a
+runConcBase :: forall es a. (Concurrent :> es, IOE :> es) => Scope -> Eff (Conc : es) a -> Eff es a
 runConcBase (Scope scope0) = interpret $ handler @es scope0
   where
-    handler :: forall es'. (IOE :> es') => Ki.Scope -> EffectHandler Conc es'
+    handler :: forall es'. (Concurrent :> es', IOE :> es') => Ki.Scope -> EffectHandler Conc es'
     handler scope env = \case
         Fork action ->
             localUnliftIO env concStrat \unlift ->
@@ -112,23 +117,37 @@ runConcBase (Scope scope0) = interpret $ handler @es scope0
             runConcurrent . atomically $ Ki.await thread
         AwaitAll ->
             runConcurrent . atomically $ Ki.awaitAll scope
+        Race ma mb ->
+            localLend @'[Concurrent] env concStrat \lend ->
+                localUnliftIO env concStrat \unlift ->
+                    Ki.scoped \raceScope -> do
+                        ref <- unlift $ inject $ lend newEmptyMVar
+                        void
+                            $ Ki.fork raceScope
+                            $ unlift
+                            $ lend . putMVar ref . Left =<< ma
+                        void
+                            $ Ki.fork raceScope
+                            $ unlift
+                            $ lend . putMVar ref . Right =<< mb
+                        unlift $ lend $ takeMVar ref
         Scoped m ->
             localUnlift env concStrat \unliftEff ->
-                localLend @'[IOE] env concStrat \lend ->
+                localLend @'[IOE, Concurrent] env concStrat \lend ->
                     withEffToIO concStrat \unliftIO ->
                         Ki.scoped \subScope ->
                             unliftIO
                                 . unliftEff
                                 . lend
                                 . interpose (handler subScope)
-                                . raise @IOE
+                                . inject
                                 $ m
 
 
 -- | Run 'Conc' in a new Ki scope without trace context propagation.
 --
 -- Suitable for tests and contexts where tracing is not needed.
-runConc :: (IOE :> es) => Eff (Conc : es) a -> Eff es a
+runConc :: (Concurrent :> es, IOE :> es) => Eff (Conc : es) a -> Eff es a
 runConc eff = withEffToIO concStrat $ \unlift ->
     Ki.scoped $ \scope ->
         unlift $ runConcBase (Scope scope) eff

--- a/atelier/src/Atelier/Effects/Conc/Traced.hs
+++ b/atelier/src/Atelier/Effects/Conc/Traced.hs
@@ -14,6 +14,7 @@ module Atelier.Effects.Conc.Traced
 where
 
 import Effectful (IOE, raise, withEffToIO)
+import Effectful.Concurrent (Concurrent)
 import Effectful.Dispatch.Dynamic (interpose, localLend, localUnlift, passthrough)
 import Effectful.Reader.Static (Reader, asks)
 
@@ -27,7 +28,7 @@ import Atelier.Effects.Monitoring.Tracing qualified as Tracing
 
 
 -- | Run 'Conc' effect with automatic trace context propagation in a new scope.
-runConc :: (IOE :> es, Tracing :> es) => Eff (Conc : es) a -> Eff es a
+runConc :: (Concurrent :> es, IOE :> es, Tracing :> es) => Eff (Conc : es) a -> Eff es a
 runConc eff = withEffToIO concStrat $ \unlift ->
     Ki.scoped $ \scope ->
         unlift $ runConcTraced (Scope scope) eff
@@ -37,7 +38,13 @@ runConc eff = withEffToIO concStrat $ \unlift ->
 --
 -- If tracing is enabled, uses 'runConc' for automatic span link propagation.
 -- If tracing is disabled, falls back to 'Conc.runConc' to skip the overhead.
-runConcByConfig :: (IOE :> es, Reader TracingConfig :> es, Tracing :> es) => Eff (Conc : es) a -> Eff es a
+runConcByConfig
+    :: ( Concurrent :> es
+       , IOE :> es
+       , Reader TracingConfig :> es
+       , Tracing :> es
+       )
+    => Eff (Conc : es) a -> Eff es a
 runConcByConfig eff = do
     tracingEnabled <- asks @TracingConfig (.enabled)
     if tracingEnabled then runConc eff else Conc.runConc eff
@@ -48,7 +55,12 @@ runConcByConfig eff = do
 -- All fork variants ('fork', 'fork_', 'forkTry') use span links, i.e. forked
 -- threads start a fresh trace whose root spans carry a link back to the
 -- originating span.
-runConcTraced :: (IOE :> es, Tracing :> es) => Scope -> Eff (Conc : es) a -> Eff es a
+runConcTraced
+    :: ( Concurrent :> es
+       , IOE :> es
+       , Tracing :> es
+       )
+    => Scope -> Eff (Conc : es) a -> Eff es a
 runConcTraced scope = runConcBase scope . withConcTracingLinks
 
 

--- a/atelier/src/Atelier/Effects/Internal/Coroutine.hs
+++ b/atelier/src/Atelier/Effects/Internal/Coroutine.hs
@@ -1,0 +1,219 @@
+module Atelier.Effects.Internal.Coroutine
+    ( -- * Yield
+      Yield (..)
+
+      -- ** Operations
+    , yield
+    , inFoldable
+    , yieldEvents
+    , cycleToYield
+
+      -- ** Interpreters
+    , forEach
+    , yieldToList
+    , yieldToReverseList
+    , withYieldToList
+    , ignoreYield
+    , enumerate
+    , enumerateFrom
+    , map
+    , mapMaybe
+    , catMaybes
+
+      -- * Await
+    , Await (..)
+
+      -- ** Operations
+    , await
+
+      -- ** Interpreters
+    , eachAwait
+
+      -- * Shared
+
+      -- ** Operations
+    , takeAwait
+
+      -- ** Interpreters
+    , awaitYield
+    ) where
+
+import Effectful (Effect, UnliftStrategy (..), inject, raiseWith)
+import Effectful.Dispatch.Dynamic (interpretWith_, interpret_, reinterpretWith_, reinterpret_)
+import Effectful.State.Static.Shared (evalState, get, modify, runState, state)
+import Effectful.TH (makeEffect)
+
+import Atelier.Effects.Chan (Chan)
+import Atelier.Effects.Conc (Conc)
+import Atelier.Effects.Publishing (Sub)
+import Prelude hiding (catMaybes, map, mapMaybe)
+
+import Atelier.Effects.Chan qualified as Chan
+import Atelier.Effects.Conc qualified as Conc
+import Atelier.Effects.Publishing qualified as Sub
+
+
+-- * Yield
+
+
+-- | Yield values to the effect system. The producing side of the
+-- 'Yield'/'Await' pair. Analogous to 'Writer' and 'Output' effects.
+data Yield a :: Effect where
+    Yield :: a -> Yield a m ()
+
+
+makeEffect ''Yield
+
+
+-- ** Yield operations
+
+
+-- | 'Yield' all elements of a foldable.
+inFoldable :: forall a t es. (Foldable t, Yield a :> es) => t a -> Eff es ()
+inFoldable =
+    foldl'
+        ( \prev x -> do
+            prev
+            yield x
+        )
+        (pure ())
+
+
+-- | 'Yield' all elements of a foldable, cycling it 'forever'.
+cycleToYield :: forall a f es. (Foldable f, Yield a :> es) => f a -> Eff es ()
+cycleToYield = forever . inFoldable
+
+
+-- | 'Yield' all events captured from a 'Sub' effect.
+yieldEvents :: forall a es. (Conc :> es, Sub a :> es, Yield a :> es) => Eff es ()
+yieldEvents = Conc.scoped do
+    Conc.fork_ $ Sub.listen_ yield
+    pure ()
+
+
+-- ** Yield interpreters
+
+
+-- | Perform an action for each value of a 'Yield' stream.
+forEach :: (a -> Eff es b) -> Eff (Yield a : es) r -> Eff es r
+forEach f = interpret_ \(Yield x) -> void $ f x
+
+
+-- | Collect all 'Yield'ed values into a list.
+yieldToList :: Eff (Yield a : es) r -> Eff es (r, [a])
+yieldToList = fmap (second reverse) . yieldToReverseList
+
+
+-- | Collect all 'Yield'ed values into a list. This function is more optimal to
+-- use than 'yieldToList' if the reversed order is acceptable.
+yieldToReverseList :: Eff (Yield a : es) r -> Eff es (r, [a])
+yieldToReverseList = reinterpret_ (runState []) \(Yield x) -> modify (x :)
+
+
+-- | Allows a computation to 'Yield' values before performing a function over
+-- the 'yield'ed values as a list.
+withYieldToList :: Eff (Yield a : es) ([a] -> r) -> Eff es r
+withYieldToList act = evalState [] do
+    f <- interpretWith_ (inject act) \(Yield x) -> modify (x :)
+    xs <- get
+    pure $ f $ reverse xs
+
+
+-- | Ignore all 'Yield'ed values, discarding them.
+ignoreYield :: Eff (Yield a : es) r -> Eff es r
+ignoreYield = interpret_ \(Yield _) -> pure ()
+
+
+-- | Pair each 'Yield'ed value with its index in the sequence of yielded
+-- values.
+enumerate :: Eff (Yield a : es) r -> Eff (Yield (Int, a) : es) r
+enumerate = enumerateFrom 0
+
+
+-- | Pair each 'Yield'ed value with its index in the sequence of yielded
+-- values, starting from `initial`.
+enumerateFrom :: Int -> Eff (Yield a : es) r -> Eff (Yield (Int, a) : es) r
+enumerateFrom initial act = raiseWith SeqUnlift \unlift ->
+    reinterpretWith_ (evalState initial) act \(Yield x) -> do
+        i <- state \s -> (s, s + 1)
+        inject $ unlift $ yield (i, x)
+
+
+-- | Map a 'Yield' stream of values into a different 'Yield' stream of values.
+-- The consumed stream will not be visible to downstream computations, and the
+-- produced stream will not be visible to upstream computations.
+map :: (a -> b) -> Eff (Yield a : es) r -> Eff (Yield b : es) r
+map f act = raiseWith SeqUnlift \unlift ->
+    interpretWith_ act \(Yield x) -> unlift $ yield $ f x
+
+
+-- | Map a 'Yield'  stream of values. Values returned as 'Just' will be
+-- included in the resulting 'Yield' stream. Values returned as 'Nothing' will
+-- be discarded.
+mapMaybe :: (a -> Maybe b) -> Eff (Yield a : es) r -> Eff (Yield b : es) r
+mapMaybe f act =
+    raiseWith SeqUnlift \unlift -> interpretWith_ act \(Yield x) ->
+        case f x of
+            Just y -> unlift $ yield y
+            Nothing -> pure ()
+
+
+-- | Eliminate 'Nothing's from a 'Yield' stream, resulting in a 'Yield' stream
+-- with all the 'Just' values.
+catMaybes :: Eff (Yield (Maybe a) : es) r -> Eff (Yield a : es) r
+catMaybes act = raiseWith SeqUnlift \unlift -> interpretWith_ act \case
+    Yield (Just x) -> unlift $ yield x
+    Yield Nothing -> pure ()
+
+
+-- * Await
+
+
+-- | Request a value from the effect system. The consuming side of the
+-- 'Yield'/'Await' pair. Analogous to 'Reader' and 'Input'.
+data Await a :: Effect where
+    Await :: Await a m a
+
+
+makeEffect ''Await
+
+
+-- ** Await operations
+
+
+-- | Take 'n' values from an 'Await' effect and re-'yield' them to a new
+-- 'Yield' event.
+--
+-- This operation is of dubious value given how Effectful's effect system
+-- works, but it is included here for brevity's sake.
+takeAwait :: (Await a :> es, Yield a :> es) => Int -> Eff es ()
+takeAwait 0 = pure ()
+takeAwait c = do
+    await >>= yield
+    takeAwait (c - 1)
+
+
+-- ** Await interpreters
+
+
+-- | Answers each `Await` with the passed action's result.
+eachAwait :: forall a es r. Eff es a -> Eff (Await a : es) r -> Eff es r
+eachAwait mk = interpret_ \Await -> mk
+
+
+-- | Supplies the `Await` effect of one computation with the `Yield` effect of
+-- another.
+awaitYield
+    :: forall a es r
+     . (Chan :> es, Conc :> es)
+    => Eff (Yield a : es) r
+    -> Eff (Await a : es) r
+    -> Eff es r
+awaitYield yields awaits = Conc.scoped do
+    (inChan, outChan) <- Chan.newChan @a
+    let yielder = interpretWith_ yields \(Yield x) -> Chan.writeChan inChan x
+        awaiter = interpretWith_ awaits \Await -> Chan.readChan outChan
+    -- Ensure the awaiter runs first.
+    awaitThread <- Conc.fork awaiter
+    yieldThread <- Conc.fork yielder
+    either id id <$> Conc.race (Conc.await awaitThread) (Conc.await yieldThread)

--- a/atelier/src/Atelier/Effects/Yield.hs
+++ b/atelier/src/Atelier/Effects/Yield.hs
@@ -1,0 +1,59 @@
+module Atelier.Effects.Yield
+    ( -- * Effect
+      Yield
+
+      -- * Operations
+    , yield
+    , inFoldable
+    , yieldEvents
+    , cycleToYield
+
+      -- * Interpreters
+    , forEach
+    , yieldToList
+    , yieldToReverseList
+    , withYieldToList
+    , ignoreYield
+    , enumerate
+    , enumerateFrom
+    , map
+    , mapMaybe
+    , catMaybes
+    , changes
+    , filter
+    ) where
+
+import Effectful.Dispatch.Dynamic (impose_, interpose_)
+import Effectful.State.Static.Shared (evalState, get)
+
+import Atelier.Effects.Internal.Coroutine
+    ( Yield (..)
+    , catMaybes
+    , cycleToYield
+    , enumerate
+    , enumerateFrom
+    , forEach
+    , ignoreYield
+    , inFoldable
+    , map
+    , mapMaybe
+    , withYieldToList
+    , yield
+    , yieldEvents
+    , yieldToList
+    , yieldToReverseList
+    )
+import Prelude hiding (catMaybes, filter, map, mapMaybe)
+
+
+filter :: (a -> Bool) -> Eff (Yield a : es) r -> Eff (Yield a : es) r
+filter p = interpose_ \(Yield x) ->
+    when (p x) do
+        yield x
+
+
+changes :: forall a es r. (Eq a) => a -> Eff (Yield a : es) r -> Eff (Yield a : es) r
+changes initial = impose_ (evalState initial) \(Yield x) -> do
+    curr <- get
+    when (curr /= x) do
+        yield x

--- a/atelier/test/Unit/Atelier/Effects/AwaitSpec.hs
+++ b/atelier/test/Unit/Atelier/Effects/AwaitSpec.hs
@@ -1,0 +1,89 @@
+module Unit.Atelier.Effects.AwaitSpec (spec_Await) where
+
+import Effectful (runEff, runPureEff)
+import Effectful.Concurrent (runConcurrent)
+import Effectful.State.Static.Shared (evalState, state)
+import Effectful.Writer.Static.Shared (runWriter, tell)
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+import Atelier.Effects.Chan (runChan)
+import Atelier.Effects.Conc (runConc)
+
+import Atelier.Effects.Await qualified as Await
+import Atelier.Effects.Yield qualified as Yield
+import Atelier.Types.Semaphore qualified as Sem
+
+
+spec_Await :: Spec
+spec_Await = do
+    describe "eachAwait" testEachAwait
+    describe "takeAwait" testTakeAwait
+    describe "awaitYield" testAwaitYield
+
+
+testEachAwait :: Spec
+testEachAwait = do
+    it "answers each await with the given action's result" do
+        let xs =
+                runPureEff
+                    . evalState @Int 0
+                    . Await.eachAwait (state \s -> (s, s + 1))
+                    $ replicateM 4 Await.await
+        xs `shouldBe` [0, 1, 2, 3]
+
+
+testTakeAwait :: Spec
+testTakeAwait = do
+    it "yields exactly N values from the await stream" do
+        let (_, xs) =
+                runPureEff
+                    . evalState @Int 0
+                    . Yield.yieldToList
+                    . Await.eachAwait @Int (state \s -> (s, s + 1))
+                    $ Await.takeAwait 3
+        xs `shouldBe` [0, 1, 2]
+
+    describe "when N is zero" $ it "yields nothing" do
+        let (_, xs) =
+                runPureEff
+                    . Yield.yieldToList
+                    . Await.eachAwait @Int (pure 7)
+                    $ Await.takeAwait 0
+        xs `shouldBe` []
+
+
+testAwaitYield :: Spec
+testAwaitYield = do
+    it "pipes yielded values into the await stream" do
+        (_, result) <-
+            runTest
+                $ Await.awaitYield (Yield.inFoldable @Int [1, 2, 3] >> (Sem.wait =<< Sem.new))
+                $ replicateM 3 Await.await >>= tell
+
+        result `shouldBe` [1, 2, 3]
+
+    it "returns the result of the awaiting computation" do
+        (_, result) <-
+            runTest
+                $ Await.awaitYield @Int (Yield.yield 99)
+                $ fmap (* 2) Await.await >>= tell . one
+        result `shouldBe` [198]
+
+    describe "when the awaiter finishes before the yielder"
+        $ it "terminates with the awaiter's result" do
+            (result, _) <-
+                runTest . runConcurrent $ do
+                    Await.awaitYield @Int
+                        (Yield.inFoldable [1 .. 100] >> (Sem.wait =<< Sem.new) >> pure 2)
+                        Await.await
+            result `shouldBe` 1
+
+    describe "when the yielder finishes before the awaiter"
+        $ it "terminates with the yielder's result" do
+            (result :: Int, _) <-
+                runTest
+                    $ Await.awaitYield @Int (Yield.yield 1 >> pure 2)
+                    $ Await.await >> Await.await >> pure 1
+            result `shouldBe` 2
+  where
+    runTest = runEff . runConcurrent . runConc . runChan . runWriter

--- a/atelier/test/Unit/Atelier/Effects/YieldSpec.hs
+++ b/atelier/test/Unit/Atelier/Effects/YieldSpec.hs
@@ -1,0 +1,257 @@
+module Unit.Atelier.Effects.YieldSpec (spec_Yield) where
+
+import Effectful (runEff, runPureEff)
+import Effectful.Concurrent (runConcurrent)
+import Effectful.State.Static.Shared (execState, modify)
+import Effectful.Writer.Static.Shared (execWriter, tell)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldMatchList)
+
+import Atelier.Effects.Chan (runChan)
+import Atelier.Effects.Conc (runConc)
+
+import Atelier.Effects.Await qualified as Await
+import Atelier.Effects.Yield qualified as Yield
+
+
+spec_Yield :: Spec
+spec_Yield = do
+    describe "yieldToList" testYieldToList
+    describe "yieldToReverseList" testYieldToReverseList
+    describe "forEach" testForEach
+    describe "ignoreYield" testIgnoreYield
+    describe "inFoldable" testInFoldable
+    describe "cycleToYield" testCycleToYield
+    describe "withYieldToList" testWithYieldToList
+    describe "enumerate" testEnumerate
+    describe "enumerateFrom" testEnumerateFrom
+    describe "map" testMap
+    describe "mapMaybe" testMapMaybe
+    describe "catMaybes" testCatMaybes
+    describe "filter" testFilter
+    describe "changes" testChanges
+
+
+testYieldToList :: Spec
+testYieldToList = do
+    it "collects yields in order" do
+        let ((), xs) = runPureEff $ Yield.yieldToList @Int do
+                Yield.yield 1
+                Yield.yield 2
+                Yield.yield 3
+        xs `shouldMatchList` [1, 2, 3]
+
+    it "returns empty list when nothing is yielded" do
+        let (_, xs) = runPureEff $ Yield.yieldToList @Int $ pure ()
+        xs `shouldMatchList` []
+
+    it "also returns the result of the computation" do
+        let (r :: Text, xs) = runPureEff $ Yield.yieldToList do
+                Yield.yield (1 :: Int)
+                pure "result"
+        r `shouldBe` "result"
+        xs `shouldMatchList` [1]
+
+
+testYieldToReverseList :: Spec
+testYieldToReverseList = do
+    it "collects yields in reverse order" do
+        let ((), xs) = runPureEff $ Yield.yieldToReverseList @Int do
+                Yield.yield 1
+                Yield.yield 2
+                Yield.yield 3
+        xs `shouldBe` [3, 2, 1]
+
+
+testForEach :: Spec
+testForEach = do
+    it "calls the action for each yielded value" do
+        let xs = runPureEff
+                $ execState @[Int] mempty
+                $ Yield.forEach (\x -> modify (x :)) do
+                    Yield.yield 1
+                    Yield.yield 2
+                    Yield.yield 3
+        xs `shouldBe` [3, 2, 1]
+
+    it "can discard values" do
+        let xs = runPureEff $ Yield.forEach @Int (const $ pure ()) do
+                Yield.yield 1
+        xs `shouldBe` ()
+
+
+testIgnoreYield :: Spec
+testIgnoreYield = do
+    it "discards all yielded values" do
+        let x = runPureEff $ Yield.ignoreYield @Int do
+                Yield.yield 1
+                Yield.yield 2
+        x `shouldBe` ()
+
+
+testInFoldable :: Spec
+testInFoldable = do
+    it "yields all elements of a list in order" do
+        let ((), xs) = runPureEff $ Yield.yieldToList $ Yield.inFoldable @Int [1, 2, 3]
+        xs `shouldBe` [1, 2, 3]
+
+    it "yields nothing for an empty list" do
+        let ((), xs) = runPureEff $ Yield.yieldToList $ Yield.inFoldable @Int []
+        xs `shouldBe` []
+
+
+testCycleToYield :: Spec
+testCycleToYield = do
+    it "yields elements of a list repeatedly in order" do
+        xs <-
+            runTest
+                $ Await.awaitYield
+                    (Yield.cycleToYield @Int [1, 2, 3])
+                    (replicateM_ 7 (Await.await >>= \x -> tell [x]))
+        xs `shouldBe` [1, 2, 3, 1, 2, 3, 1]
+  where
+    runTest = runEff . runConcurrent . runConc . runChan . execWriter
+
+
+testWithYieldToList :: Spec
+testWithYieldToList = do
+    it "passes the collected yields to the returned function" do
+        let result = runPureEff $ Yield.withYieldToList @Int do
+                Yield.yield 1
+                Yield.yield 2
+                Yield.yield 3
+                pure length
+        result `shouldBe` 3
+
+    it "passes yields in order to the function" do
+        let result = runPureEff $ Yield.withYieldToList @Int do
+                Yield.yield 1
+                Yield.yield 2
+                Yield.yield 3
+                pure id
+        result `shouldBe` [1, 2, 3]
+
+    it "passes an empty list when nothing is yielded" do
+        let result = runPureEff $ Yield.withYieldToList @Int do
+                pure null
+        result `shouldBe` True
+
+
+testEnumerate :: Spec
+testEnumerate = do
+    it "pairs each value with its zero-based index" do
+        let ((), xs) = runPureEff $ Yield.yieldToList $ Yield.enumerate do
+                Yield.yield 'a'
+                Yield.yield 'b'
+                Yield.yield 'c'
+        xs `shouldBe` [(0, 'a'), (1, 'b'), (2, 'c')]
+
+
+testEnumerateFrom :: Spec
+testEnumerateFrom = do
+    it "pairs each value with its index starting from the given value" do
+        let ((), xs) = runPureEff $ Yield.yieldToList $ Yield.enumerateFrom 5 do
+                Yield.yield 'x'
+                Yield.yield 'y'
+        xs `shouldBe` [(5, 'x'), (6, 'y')]
+
+
+testMap :: Spec
+testMap = do
+    it "transforms each yielded value" do
+        let (_, xs) = runPureEff $ Yield.yieldToList $ Yield.map @Int (* 2) do
+                Yield.yield 1
+                Yield.yield 2
+                Yield.yield 3
+        xs `shouldBe` [2, 4, 6]
+
+    it "preserves order" do
+        let (_, xs :: [Text]) = runPureEff $ Yield.yieldToList $ Yield.map show do
+                Yield.yield @Int 1
+                Yield.yield 2
+        xs `shouldBe` ["1", "2"]
+
+
+testMapMaybe :: Spec
+testMapMaybe = do
+    describe "when the function returns Just" $ it "yields transformed values" do
+        let ((), xs) = runPureEff $ Yield.yieldToList $ Yield.mapMaybe (\x -> if even x then Just (x * 10) else Nothing) do
+                Yield.yield @Int 1
+                Yield.yield 2
+                Yield.yield 3
+                Yield.yield 4
+        xs `shouldMatchList` [20, 40]
+
+    describe "when the function always returns Nothing" $ it "yields nothing" do
+        let (_, xs) = runPureEff $ Yield.yieldToList $ Yield.mapMaybe @Int @Int (const Nothing) do
+                Yield.yield 1
+        xs `shouldMatchList` []
+
+
+testCatMaybes :: Spec
+testCatMaybes = do
+    it "unwraps Just values and drops Nothings" do
+        let (_, xs) = runPureEff $ Yield.yieldToList $ Yield.catMaybes do
+                Yield.yield (Just 1)
+                Yield.yield Nothing
+                Yield.yield (Just 2)
+        xs `shouldBe` [1 :: Int, 2]
+
+    it "yields nothing when all values are Nothing" do
+        let (_, xs) = runPureEff $ Yield.yieldToList $ Yield.catMaybes do
+                Yield.yield (Nothing :: Maybe Int)
+                Yield.yield Nothing
+        xs `shouldBe` []
+
+
+testFilter :: Spec
+testFilter = do
+    it "passes values satisfying the predicate" do
+        let (_, xs) = runPureEff $ Yield.yieldToList $ Yield.filter even do
+                Yield.yield 1
+                Yield.yield 2
+                Yield.yield 3
+                Yield.yield 4
+        xs `shouldBe` [2 :: Int, 4]
+
+    it "drops all values when predicate is always false" do
+        let (_, xs) = runPureEff $ Yield.yieldToList $ Yield.filter (const False) do
+                Yield.yield (1 :: Int)
+        xs `shouldBe` []
+
+    it "passes all values when predicate is always true" do
+        let (_, xs) = runPureEff $ Yield.yieldToList $ Yield.filter (const True) do
+                Yield.yield 1
+                Yield.yield 2
+        xs `shouldBe` [1 :: Int, 2]
+
+
+testChanges :: Spec
+testChanges = do
+    it "suppresses yields equal to the initial value" do
+        let (_, xs) = runPureEff $ Yield.yieldToList $ Yield.changes 0 do
+                Yield.yield 0
+                Yield.yield 1
+        xs `shouldBe` [1 :: Int]
+
+    it "passes values that differ from the initial value" do
+        let (_, xs) = runPureEff $ Yield.yieldToList $ Yield.changes 0 do
+                Yield.yield 1
+                Yield.yield 2
+        xs `shouldBe` [1 :: Int, 2]
+
+    it "suppresses initial value interspersed with other values" do
+        let (_, xs) = runPureEff $ Yield.yieldToList $ Yield.changes 0 do
+                Yield.yield 0
+                Yield.yield 1
+                Yield.yield 0
+                Yield.yield 2
+                Yield.yield 0
+                Yield.yield 3
+        xs `shouldBe` [1 :: Int, 2, 3]
+
+    it "does not suppress non-initial values even if they repeat" do
+        let (_, xs) = runPureEff $ Yield.yieldToList $ Yield.changes 0 do
+                Yield.yield 1
+                Yield.yield 1
+                Yield.yield 2
+        xs `shouldBe` [1 :: Int, 1, 2]

--- a/tricorder.cabal
+++ b/tricorder.cabal
@@ -120,6 +120,7 @@ library atelier
   exposed-modules:
       Atelier.Component
       Atelier.Config
+      Atelier.Effects.Await
       Atelier.Effects.Cache
       Atelier.Effects.Cache.Config
       Atelier.Effects.Cache.Singleflight
@@ -138,6 +139,7 @@ library atelier
       Atelier.Effects.File
       Atelier.Effects.FileSystem
       Atelier.Effects.FileWatcher
+      Atelier.Effects.Internal.Coroutine
       Atelier.Effects.Iterator
       Atelier.Effects.Log
       Atelier.Effects.Monitoring.Metrics
@@ -150,6 +152,7 @@ library atelier
       Atelier.Effects.Publishing
       Atelier.Effects.Tally
       Atelier.Effects.UUID
+      Atelier.Effects.Yield
       Atelier.Exception
       Atelier.Time
       Atelier.Types.Base64
@@ -385,6 +388,7 @@ test-suite atelier-test
   main-is: Driver.hs
   other-modules:
       Unit.Atelier.ConfigSpec
+      Unit.Atelier.Effects.AwaitSpec
       Unit.Atelier.Effects.Cache.SingleflightSpec
       Unit.Atelier.Effects.CacheSpec
       Unit.Atelier.Effects.ChanSpec
@@ -399,6 +403,7 @@ test-suite atelier-test
       Unit.Atelier.Effects.LogSpec
       Unit.Atelier.Effects.PublishingSpec
       Unit.Atelier.Effects.TallySpec
+      Unit.Atelier.Effects.YieldSpec
       Unit.Atelier.Types.SemaphoreSpec
       Unit.Atelier.Types.WithDefaultsSpec
       Paths_tricorder

--- a/tricorder/test/Unit/Tricorder/Effects/SessionStoreSpec.hs
+++ b/tricorder/test/Unit/Tricorder/Effects/SessionStoreSpec.hs
@@ -5,6 +5,7 @@ import Data.Default (def)
 import Data.IORef (IORef)
 import Data.Time (UTCTime (..), fromGregorian)
 import Effectful (IOE, runEff)
+import Effectful.Concurrent (Concurrent, runConcurrent)
 import Effectful.Dispatch.Dynamic (interpret_)
 import Effectful.Error.Static (Error, runErrorNoCallStack, throwError)
 import Test.Hspec (Spec, describe, it, shouldBe)
@@ -89,6 +90,7 @@ type TestEs =
      , Chan
      , Clock
      , Tracing
+     , Concurrent
      , IOE
      ]
 
@@ -96,6 +98,7 @@ type TestEs =
 runFixed :: Session -> Eff TestEs a -> IO (Either StopSignal a)
 runFixed session =
     runEff
+        . runConcurrent
         . runTracingNoOp
         . runClockConst epoch
         . runChan
@@ -108,6 +111,7 @@ runFixed session =
 runFlagged :: IORef Bool -> Eff TestEs a -> IO (Either StopSignal a)
 runFlagged flag =
     runEff
+        . runConcurrent
         . runTracingNoOp
         . runClockConst epoch
         . runChan
@@ -120,6 +124,7 @@ runFlagged flag =
 runMutable :: IORef Session -> Eff TestEs a -> IO (Either StopSignal a)
 runMutable ref =
     runEff
+        . runConcurrent
         . runTracingNoOp
         . runClockConst epoch
         . runChan


### PR DESCRIPTION
Add `Yield` and `Await` effects, transcribed from Bluefin's [Yield](https://hackage-content.haskell.org/package/bluefin-0.6.0.0/docs/Bluefin-Capability-Yield.html) and [Await](https://hackage-content.haskell.org/package/bluefin-0.6.0.0/docs/Bluefin-Capability-Await.html) effects.