### PR TITLE
refactor: use :show targets as source of truth for known files

### DIFF
--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -12,6 +12,7 @@ module Tricorder.Builder
     , handleInitialBuild
     , onRestart
     , reloadOnSourceChange
+    , resolveKnownTargets
     , setNewPhase
     ) where
 
@@ -20,11 +21,12 @@ import Data.Time (diffUTCTime)
 import Effectful.Concurrent (Concurrent)
 import Effectful.Exception (bracket_, trySync)
 import Effectful.Reader.Static (Reader, ask)
-import Effectful.State.Static.Shared (State, execState, get, put, state)
+import Effectful.State.Static.Shared (State, execState, get, modify, put, state)
 import Relude.Extra.Tuple (dup)
 import System.FilePath (isAbsolute, normalise, (</>))
 
 import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 
 import Atelier.Component (Component (..), defaultComponent)
 import Atelier.Effects.Chan (Chan)
@@ -243,7 +245,7 @@ buildWithGhciOnChange reloader config = forever do
     GhciSession.withGhci config.command projectRoot \initialLoad controls -> do
         initialEndTime <- Clock.currentTime
         handleInitialBuild config initialStartTime initialEndTime initialLoad
-        put @(Map FilePath LoadedModule) initialLoad.loadedModules
+        put @(Map FilePath LoadedModule) (resolveKnownTargets Map.empty initialLoad)
         rebuildOnChange reloader controls
 
 
@@ -382,27 +384,23 @@ reloadOnSourceChange readyToBuildSem controls (SourceChangeDetected fp event) = 
                     now <- Clock.currentTime
                     Log.err $ show now <> " Reload errored: " <> show e
                 Right (startTime, endTime, loadResult) -> do
-                    put loadResult.loadedModules
+                    modify @(Map FilePath LoadedModule) (\prev -> resolveKnownTargets prev loadResult)
                     publish $ NewLoadResult {startTime, endTime, loadResult}
   where
     -- Dispatch on (is the file currently loaded in GHCi?, FileEvent).
     --
-    -- `Added` and `Modified` always map to `:reload`, even when the file is
-    -- missing from the module map. GHCi drops failed-compile modules from
-    -- `:show modules`, so an `unknown` lookup conflates "file GHCi never saw"
-    -- with "file that failed last cycle". Dispatching `:add` in that state was
-    -- a no-op (the file is already a target) and left stale diagnostics in
-    -- place; `:reload` recovers cleanly. Note that most editors save atomically
-    -- (write temp + rename), so what looks like a Modified event actually
-    -- arrives as Added — both branches must do the right thing.
+    -- The module map is the source of truth for "is this file a tracked
+    -- target?" and it must be built from `:show targets` (which survives
+    -- failed compiles), not `:show modules` (which drops them). See
+    -- 'resolveKnownTargets' for how the map is maintained.
     dispatch = \case
         Just lm -> Just $ case event of
-            Added -> controls.reload
+            Added -> controls.reload -- re-adding a known file is just a reload
             Modified -> controls.reload
             Removed -> controls.unadd lm.moduleName
         Nothing -> case event of
-            Added -> Just controls.reload
-            Modified -> Just controls.reload
+            Added -> Just (controls.add fp)
+            Modified -> Just (controls.add fp) -- editor wrote a not-yet-loaded file
             Removed -> Nothing -- nothing to remove
 
 
@@ -507,6 +505,35 @@ mergeDiagnostics prev LoadResult {compiledFiles, diagnostics} =
     let cleared = foldr Map.delete prev compiledFiles
         newByFile = Map.fromListWith (++) [(d.file, [d]) | d <- diagnostics]
     in  Map.union newByFile cleared
+
+
+-- | Compute the next "known targets" map by joining this cycle's
+-- @:show modules@ (definitive path↔name mapping for successful loads) with
+-- the prior map (carryover for targets that failed to compile and are
+-- therefore absent from @:show modules@).
+--
+-- Targets that have never compiled successfully — so we have no entry for
+-- them in either source — are dropped here: with neither @:show modules@ nor
+-- prior knowledge we can't resolve their dotted name to a file path, and the
+-- dispatcher keys on file paths. They'll be picked up next cycle via the
+-- @unknown → :add@ branch.
+resolveKnownTargets
+    :: Map FilePath LoadedModule
+    -- ^ Previous known-targets map (carryover source).
+    -> LoadResult
+    -> Map FilePath LoadedModule
+resolveKnownTargets prev lr =
+    let primary = lr.loadedModules
+        primaryNames = Set.fromList [lm.moduleName | lm <- Map.elems primary]
+        prevByName = Map.fromList [(lm.moduleName, (path, lm)) | (path, lm) <- Map.toList prev]
+        carryover =
+            Map.fromList
+                [ (path, lm)
+                | name <- lr.targetNames
+                , not (Set.member name primaryNames)
+                , Just (path, lm) <- [Map.lookup name prevByName]
+                ]
+    in  Map.union primary carryover
 
 
 -- | Keep only diagnostics whose file is under one of the watched directories.

--- a/tricorder/src/Tricorder/Effects/GhciSession/GhciParser.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession/GhciParser.hs
@@ -9,6 +9,7 @@ module Tricorder.Effects.GhciSession.GhciParser
     , collectResultCustom
     , parseReload
     , parseShowModules
+    , parseShowTargets
     , stripAnsi
     , extractTitle
     , toAbsolute
@@ -95,7 +96,13 @@ data LoadResult = LoadResult
     -- Used by the session layer to decide which files' previous diagnostics to replace vs. retain.
     , loadedModules :: Map FilePath LoadedModule
     -- ^ Map from canonical absolute path to module metadata, derived from @:show modules@ output.
-    -- Acts as the source of truth for what GHCi currently knows.
+    -- Lists only modules that compiled successfully this cycle — GHCi drops
+    -- failed-compile modules from @:show modules@.
+    , targetNames :: [Text]
+    -- ^ Raw entries from @:show targets@ — typically dotted module names in
+    -- @cabal repl --enable-multi-repl@. Unlike 'loadedModules', this list
+    -- survives failed compiles, so the Builder uses it (joined with carried-over
+    -- name↔path knowledge) as the source of truth for which files GHCi tracks.
     , diagnostics :: [Diagnostic]
     }
     deriving stock (Eq, Show)
@@ -372,6 +379,24 @@ showModuleLineP = do
 
 
 -- ---------------------------------------------------------------------------
+-- parseShowTargets
+-- ---------------------------------------------------------------------------
+
+-- | Parse the output of @:show targets@.
+--
+-- Each line names one target. In @cabal repl --enable-multi-repl@ these are
+-- dotted module names (e.g. @"Foo.Bar"@); in plain @ghci@ sessions they can
+-- also be file paths. A leading @*@ marks the active interactive target and
+-- is stripped. Blank lines are skipped.
+parseShowTargets :: [Text] -> [Text]
+parseShowTargets = mapMaybe parseLine
+  where
+    parseLine raw =
+        let cleaned = T.strip (T.dropWhile (== '*') (T.strip (stripAnsi raw)))
+        in  if T.null cleaned then Nothing else Just cleaned
+
+
+-- ---------------------------------------------------------------------------
 -- Pure utilities (unchanged)
 -- ---------------------------------------------------------------------------
 
@@ -405,10 +430,10 @@ stripAnsi t = case T.uncons t of
     Just (c, rest) -> T.cons c (stripAnsi rest)
 
 
--- | Assemble a 'LoadResult' from a project root, parsed reload items, and
--- the @:show modules@ output.
-collectResultCustom :: FilePath -> [GhciLoad] -> [(Text, FilePath)] -> LoadResult
-collectResultCustom projectRoot loads modules =
+-- | Assemble a 'LoadResult' from a project root, parsed reload items, the
+-- @:show modules@ output, and the @:show targets@ output.
+collectResultCustom :: FilePath -> [GhciLoad] -> [(Text, FilePath)] -> [Text] -> LoadResult
+collectResultCustom projectRoot loads modules targets =
     let rel = toRelative projectRoot
         abs' = toAbsolute projectRoot
         compiledFiles = case [l.sourceFile | GLoading l <- loads] of
@@ -422,6 +447,7 @@ collectResultCustom projectRoot loads modules =
             { moduleCount = length modules
             , compiledFiles
             , loadedModules = Map.fromList (map mkEntry modules)
+            , targetNames = targets
             , diagnostics = toDiagnostics rel loads
             }
 

--- a/tricorder/src/Tricorder/Effects/GhciSession/GhciProcess.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession/GhciProcess.hs
@@ -52,6 +52,7 @@ import Tricorder.Effects.GhciSession.GhciParser
     , collectResultCustom
     , parseReload
     , parseShowModules
+    , parseShowTargets
     , stripAnsi
     )
 
@@ -341,7 +342,13 @@ collectGhciResult process lines' projectRoot onProgress = do
     let loads = parseReload lines'
     for_ [l | GLoading l <- loads] onProgress
     moduleLines <- execGhci process ":show modules"
-    pure $ collectResultCustom projectRoot loads (parseShowModules moduleLines)
+    targetLines <- execGhci process ":show targets"
+    pure
+        $ collectResultCustom
+            projectRoot
+            loads
+            (parseShowModules moduleLines)
+            (parseShowTargets targetLines)
 
 
 -- | Execute @:reload@ and return the assembled 'LoadResult', emitting a

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -40,6 +40,7 @@ import Tricorder.Builder
     , onRestart
     , reloadOnSourceChange
     , requestTestRunsForNewBuildResults
+    , resolveKnownTargets
     , setNewPhase
     )
 import Tricorder.Effects.GhciSession (Controls (..), LoadResult (..), LoadedModule (..), extractTitle)
@@ -62,6 +63,7 @@ spec_Builder = do
     describe "setNewPhase" testSetNewPhase
     describe "restartOnCabalChange" testRestartOnCabalChange
     describe "reloadOnSourceChange" testReloadOnSourceChange
+    describe "resolveKnownTargets" testResolveKnownTargets
 
 
 testRestartOnCabalChange :: Spec
@@ -96,24 +98,16 @@ testReloadOnSourceChange = do
                 results `shouldMatchList` [NewLoadResult epoch epoch reloadLr]
 
         describe "when the file is not loaded in GHCi" do
-            -- Regression for stale-results bug: GHCi drops failed-compile
-            -- modules from `:show modules`, so a fixed file looks "unknown" to
-            -- the dispatcher. Dispatching `:add` in that state was a no-op and
-            -- left stale diagnostics in place. `Modified` must always reload.
-            it "calls controls.reload (recovers files that failed to compile last cycle)" do
+            it "calls controls.add (the editor just wrote a new file)" do
                 (results, _) <- runTest Map.empty distinctCtrls (SourceChangeDetected "/abs/path/New.hs" Modified)
-                results `shouldMatchList` [NewLoadResult epoch epoch reloadLr]
+                results `shouldMatchList` [NewLoadResult epoch epoch addLr]
 
     describe "Added" do
-        -- Atomic-save editors (vim, neovim, etc.) write via tmpfile+rename,
-        -- which fsnotify reports as Added even for an existing file. So this
-        -- branch needs the same failed-compile-recovery semantics as Modified:
-        -- always reload, never trust the module map for `unknown` lookups.
-        describe "when the file is not loaded" $ it "calls controls.reload" do
+        describe "when the file is not loaded" $ it "calls controls.add" do
             (results, _) <- runTest Map.empty distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Added)
-            results `shouldMatchList` [NewLoadResult epoch epoch reloadLr]
+            results `shouldMatchList` [NewLoadResult epoch epoch addLr]
 
-        describe "when the file is already loaded" $ it "calls controls.reload" do
+        describe "when the file is already loaded" $ it "calls controls.reload (re-add is a reload)" do
             (results, _) <- runTest knownFoo distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Added)
             results `shouldMatchList` [NewLoadResult epoch epoch reloadLr]
 
@@ -165,6 +159,7 @@ testReloadOnSourceChange = do
             { moduleCount = n
             , compiledFiles = Set.singleton errMsg.file
             , loadedModules = Map.empty
+            , targetNames = []
             , diagnostics = []
             }
     reloadLr = mkLr 10
@@ -208,6 +203,7 @@ testCompileLoadResultsIntoBuildResults = do
                                 { moduleCount = 2
                                 , compiledFiles = Set.singleton errMsg.file
                                 , loadedModules = Map.empty
+                                , targetNames = []
                                 , diagnostics = []
                                 }
                         }
@@ -223,6 +219,7 @@ testCompileLoadResultsIntoBuildResults = do
                                 { moduleCount = 2
                                 , compiledFiles = Set.singleton warnMsg.file
                                 , loadedModules = Map.empty
+                                , targetNames = []
                                 , diagnostics = [warnMsg]
                                 }
                         }
@@ -243,6 +240,7 @@ testCompileLoadResultsIntoBuildResults = do
                                 { moduleCount = 2
                                 , compiledFiles = Set.singleton warnMsg.file
                                 , loadedModules = Map.empty
+                                , targetNames = []
                                 , diagnostics = [warnMsg]
                                 }
                         }
@@ -342,6 +340,81 @@ testRequestTestRunsForNewBuildResults = do
 
 
 --------------------------------------------------------------------------------
+-- resolveKnownTargets tests
+--------------------------------------------------------------------------------
+
+testResolveKnownTargets :: Spec
+testResolveKnownTargets = do
+    it "uses :show modules as the primary source for path↔name mapping" do
+        let result =
+                emptyLr
+                    { loadedModules =
+                        Map.fromList
+                            [
+                                ( "/abs/src/Foo.hs"
+                                , LoadedModule {relPath = "./src/Foo.hs", moduleName = "Foo"}
+                                )
+                            ]
+                    , targetNames = ["Foo"]
+                    }
+        resolveKnownTargets Map.empty result
+            `shouldBe` Map.fromList
+                [
+                    ( "/abs/src/Foo.hs"
+                    , LoadedModule {relPath = "./src/Foo.hs", moduleName = "Foo"}
+                    )
+                ]
+
+    -- Regression test for the stale-results bug. After a failed compile, the
+    -- module disappears from :show modules but stays in :show targets. The
+    -- prior state's entry must be carried over so the dispatcher continues to
+    -- see the file as "known" and issues :reload (not :add) when the user
+    -- fixes the error.
+    it "carries over prior state for targets that are no longer in :show modules" do
+        let prev =
+                Map.fromList
+                    [
+                        ( "/abs/src/Foo.hs"
+                        , LoadedModule {relPath = "./src/Foo.hs", moduleName = "Foo"}
+                        )
+                    ]
+            result =
+                emptyLr
+                    { loadedModules = Map.empty -- Foo failed to compile
+                    , targetNames = ["Foo"] -- but is still a target
+                    }
+        resolveKnownTargets prev result `shouldBe` prev
+
+    it "drops targets that are no longer in :show targets" do
+        let prev =
+                Map.fromList
+                    [
+                        ( "/abs/src/Foo.hs"
+                        , LoadedModule {relPath = "./src/Foo.hs", moduleName = "Foo"}
+                        )
+                    ]
+            result = emptyLr {loadedModules = Map.empty, targetNames = []}
+        resolveKnownTargets prev result `shouldBe` Map.empty
+
+    -- A genuinely-new target that has never compiled successfully has no
+    -- entry in :show modules and no carryover in prior state. We skip it
+    -- silently; the dispatcher will treat the next event for that file as
+    -- "unknown" and issue :add, which is the correct behavior.
+    it "drops targets that have neither a current :show modules entry nor prior state" do
+        let result = emptyLr {loadedModules = Map.empty, targetNames = ["BrandNew"]}
+        resolveKnownTargets Map.empty result `shouldBe` Map.empty
+  where
+    emptyLr =
+        LoadResult
+            { moduleCount = 0
+            , compiledFiles = Set.empty
+            , loadedModules = Map.empty
+            , targetNames = []
+            , diagnostics = []
+            }
+
+
+--------------------------------------------------------------------------------
 -- mergeDiagnostics tests
 --------------------------------------------------------------------------------
 
@@ -357,6 +430,7 @@ testMergeDiagnostics = do
                     { moduleCount = 2
                     , compiledFiles = Set.singleton errMsg.file
                     , loadedModules = Map.empty
+                    , targetNames = []
                     , diagnostics = []
                     }
         let merged = mergeDiagnostics prev result
@@ -369,6 +443,7 @@ testMergeDiagnostics = do
                     { moduleCount = 1
                     , compiledFiles = Set.singleton errMsg.file
                     , loadedModules = Map.empty
+                    , targetNames = []
                     , diagnostics = []
                     }
         let merged = mergeDiagnostics prev result
@@ -382,6 +457,7 @@ testMergeDiagnostics = do
                     { moduleCount = 1
                     , compiledFiles = Set.singleton errMsg.file
                     , loadedModules = Map.empty
+                    , targetNames = []
                     , diagnostics = [newErr]
                     }
         let merged = mergeDiagnostics prev result
@@ -393,6 +469,7 @@ testMergeDiagnostics = do
                     { moduleCount = 1
                     , compiledFiles = Set.singleton warnMsg.file
                     , loadedModules = Map.empty
+                    , targetNames = []
                     , diagnostics = [warnMsg]
                     }
         let merged = mergeDiagnostics Map.empty result

--- a/tricorder/test/Unit/Tricorder/Effects/GhciSession/GhciParserSpec.hs
+++ b/tricorder/test/Unit/Tricorder/Effects/GhciSession/GhciParserSpec.hs
@@ -10,6 +10,7 @@ import Tricorder.Effects.GhciSession.GhciParser
     , Position (..)
     , parseReload
     , parseShowModules
+    , parseShowTargets
     )
 
 
@@ -25,6 +26,8 @@ spec_GhciParser = do
     describe "parseShowModules" do
         describe "typical output" testShowModules
         describe "empty / blank input" testShowModulesEmpty
+
+    describe "parseShowTargets" testShowTargets
 
 
 --------------------------------------------------------------------------------
@@ -277,3 +280,34 @@ testShowModulesEmpty = do
 
     it "skips lines without '( '" do
         parseShowModules ["just some random text"] `shouldBe` []
+
+
+--------------------------------------------------------------------------------
+-- parseShowTargets
+--------------------------------------------------------------------------------
+
+testShowTargets :: Spec
+testShowTargets = do
+    it "parses module names emitted by cabal repl --enable-multi-repl" do
+        parseShowTargets
+            [ "Atelier.Effects.Cache"
+            , "Atelier.Effects.Chan"
+            , "Paths_tricorder"
+            ]
+            `shouldBe` ["Atelier.Effects.Cache", "Atelier.Effects.Chan", "Paths_tricorder"]
+
+    it "parses file-path targets emitted by plain ghci" do
+        parseShowTargets ["src/Foo.hs", "test/Bar.hs"]
+            `shouldBe` ["src/Foo.hs", "test/Bar.hs"]
+
+    it "strips the leading '*' marker for the active interactive target" do
+        parseShowTargets ["*Main", "Foo.Bar"] `shouldBe` ["Main", "Foo.Bar"]
+
+    it "strips ANSI escape sequences" do
+        parseShowTargets ["\ESC[1mFoo.Bar\ESC[0m"] `shouldBe` ["Foo.Bar"]
+
+    it "skips blank and whitespace-only lines" do
+        parseShowTargets ["", "   ", "\t", "Real.Target"] `shouldBe` ["Real.Target"]
+
+    it "returns empty list for empty input" do
+        parseShowTargets [] `shouldBe` []

--- a/tricorder/test/Unit/Tricorder/Effects/GhciSessionSpec.hs
+++ b/tricorder/test/Unit/Tricorder/Effects/GhciSessionSpec.hs
@@ -115,7 +115,7 @@ warnMsg =
 
 -- | Convenience constructor: a scripted result with no compiled-file info.
 simpleResult :: [Diagnostic] -> Either SomeException LoadResult
-simpleResult msgs = Right LoadResult {moduleCount = 0, compiledFiles = Set.empty, loadedModules = Map.empty, diagnostics = msgs}
+simpleResult msgs = Right LoadResult {moduleCount = 0, compiledFiles = Set.empty, loadedModules = Map.empty, targetNames = [], diagnostics = msgs}
 
 
 runScripted :: [Either SomeException LoadResult] -> Eff '[GhciSession, IOE] a -> IO a


### PR DESCRIPTION
The previous commit fixed the stale-results bug by always `:reload`-ing on Added/Modified events, which sidestepped the issue but lost the `:add` optimization for genuinely-new files. Replace that workaround with a proper fix to the underlying invariant.

GHCi has two views: `:show modules` lists only successfully-compiled modules, while `:show targets` lists the configured target set (populated by `cabal repl`) and survives failed compiles. The dispatcher must key on the latter to correctly identify "file GHCi knows but couldn't load this cycle" — the case that caused the regression.

- `LoadResult` gains `targetNames :: [Text]` from `:show targets`.
- `collectGhciResult` queries `:show targets` after `:show modules`.
- `Builder.resolveKnownTargets` joins this cycle's `:show modules` (definitive path↔name mapping) with prior state's carryover for any target that's missing from `:show modules`. Targets that have never compiled are dropped — the dispatcher's `unknown → :add` branch handles them.
- The original dispatch matrix is restored: `:add` is back for genuinely-new files, `:reload` for known files, `:unadd` for removed.
- Tests: `parseShowTargets` parser tests and `resolveKnownTargets` unit tests, including an explicit regression test for the failed-compile carryover.