### PR TITLE
feat: abort in-flight tests on change with no waiters

### DIFF
--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -21,7 +21,7 @@ import Data.Time (diffUTCTime)
 import Effectful.Concurrent (Concurrent)
 import Effectful.Exception (bracket_, trySync)
 import Effectful.Reader.Static (Reader, ask)
-import Effectful.State.Static.Shared (State, execState, get, modify, put, state)
+import Effectful.State.Static.Shared (State, get, modify, put, state)
 import Relude.Extra.Tuple (dup)
 import System.FilePath (isAbsolute, normalise, (</>))
 
@@ -230,6 +230,7 @@ buildWithGhciOnChange
        , State DiagnosticMap :> es
        , Sub CabalChangeDetected :> es
        , Sub SourceChangeDetected :> es
+       , TestRunner :> es
        )
     => SessionStore.Reloader es
     -> BuilderSession
@@ -294,6 +295,7 @@ rebuildOnChange
        , State BuildId :> es
        , Sub CabalChangeDetected :> es
        , Sub SourceChangeDetected :> es
+       , TestRunner :> es
        )
     => SessionStore.Reloader es
     -> GhciSession.Controls (Eff es)
@@ -320,32 +322,35 @@ handleSourceChanges
        , State (Map FilePath LoadedModule) :> es
        , State BuildId :> es
        , Sub SourceChangeDetected :> es
+       , TestRunner :> es
        )
     => GhciSession.Controls (Eff es) -> Eff es Void
 handleSourceChanges controls = forever $ Conc.scoped do
     readyToBuildSem <- Sem.newSet
     Conc.fork_ $ Sub.listen_ \ev ->
         debounced 200 "source_change_reloader" $ reloadOnSourceChange readyToBuildSem controls ev
-    Conc.fork_ $ Sub.listen_ \_ -> interruptCurrentReload readyToBuildSem controls
+    Conc.fork_ $ Sub.listen_ \_ -> interruptCurrent readyToBuildSem controls
     Conc.awaitAll
 
 
-interruptCurrentReload
+interruptCurrent
     :: ( BuildStore :> es
        , Concurrent :> es
        , Log :> es
+       , TestRunner :> es
        )
     => Semaphore -> GhciSession.Controls (Eff es) -> Eff es ()
-interruptCurrentReload readyToBuildSem controls = do
-    isIdle <- Sem.peek readyToBuildSem
+interruptCurrent readyToBuildSem controls = do
     hasWaiters <- BuildStore.hasWaiters
-    unless (isIdle || hasWaiters)
-        $ bracket_
-            (Sem.unset readyToBuildSem)
-            (Sem.set readyToBuildSem)
-            do
-                Log.info "Change detected. Interrupting current GHCi build."
+    unless hasWaiters do
+        Log.info "Change detected with no waiters. Interrupting current build/tests."
+        isIdle <- Sem.peek readyToBuildSem
+        unless isIdle
+            $ bracket_
+                (Sem.unset readyToBuildSem)
+                (Sem.set readyToBuildSem)
                 controls.interrupt
+        TestRunner.interruptCurrent
 
 
 reloadOnSourceChange
@@ -454,12 +459,18 @@ requestTestRunsForNewBuildResults
     -> Eff es ()
 requestTestRunsForNewBuildResults config partialResult = do
     buildId <- get
-    testRuns <- runTestsIfClean config buildId partialResult
-    publish $ EnteringNewPhase buildId $ Done partialResult {testRuns}
+    runTestsIfClean config buildId partialResult >>= \case
+        Nothing -> Log.info "Test run aborted by source change; skipping Done publish."
+        Just testRuns ->
+            publish $ EnteringNewPhase buildId $ Done partialResult {testRuns}
 
 
 -- Run all configured test suites if the build has no errors.
 -- Transitions to 'Testing' phase while suites are running.
+--
+-- Returns 'Nothing' if the run was aborted mid-flight by a source change
+-- (the caller should not publish a Done phase in that case). Returns
+-- 'Just' with the collected results otherwise.
 runTestsIfClean
     :: ( Log :> es
        , Pub EnteringNewPhase :> es
@@ -468,26 +479,34 @@ runTestsIfClean
     => BuilderSession
     -> BuildId
     -> BuildResult
-    -> Eff es [TestRun]
+    -> Eff es (Maybe [TestRun])
 runTestsIfClean (BuilderSession {testTargets}) bid partialResult
-    | null testTargets || any (\d -> d.severity == SError) partialResult.diagnostics = pure []
+    | null testTargets || any (\d -> d.severity == SError) partialResult.diagnostics = pure (Just [])
     | otherwise = do
+        TestRunner.resetAbort
         publish
             $ EnteringNewPhase bid
             $ Testing partialResult {testRuns = map TestRunning testTargets}
 
         Log.info $ "Running " <> show (length testTargets) <> " test suite(s)"
 
-        fmap (fmap snd)
-            $ execState ((\t -> (t, TestRunning t)) <$> testTargets)
-            $ for_ testTargets \target -> do
-                Log.info $ "Running tests: " <> target
-                result <- TestRunner.runTestSuite target
-                runs <- state $ dup . insert target result
-                publish
-                    $ EnteringNewPhase bid
-                    $ Testing partialResult {testRuns = snd <$> runs}
+        let initial = (\t -> (t, TestRunning t)) <$> testTargets
+        runLoop initial testTargets
   where
+    runLoop acc [] = pure (Just (snd <$> acc))
+    runLoop acc (target : rest) = do
+        Log.info $ "Running tests: " <> target
+        result <- TestRunner.runTestSuite target
+        aborted <- TestRunner.isAborted
+        if aborted then
+            pure Nothing
+        else do
+            let acc' = insert target result acc
+            publish
+                $ EnteringNewPhase bid
+                $ Testing partialResult {testRuns = snd <$> acc'}
+            runLoop acc' rest
+
     insert _ _ [] = []
     insert k v ((k', v') : xs)
         | k == k' = (k, v) : xs

--- a/tricorder/src/Tricorder/Effects/TestRunner.hs
+++ b/tricorder/src/Tricorder/Effects/TestRunner.hs
@@ -2,6 +2,9 @@ module Tricorder.Effects.TestRunner
     ( -- * Effect
       TestRunner
     , runTestSuite
+    , interruptCurrent
+    , resetAbort
+    , isAborted
 
       -- * Interpreters
     , runTestRunnerIO
@@ -12,13 +15,15 @@ module Tricorder.Effects.TestRunner
     , detectOutcome
     ) where
 
+import Control.Concurrent.STM (readTVar, writeTVar)
 import Control.Exception (throwIO)
 import Data.Default (def)
 import Data.Time.Units (Second)
 import Effectful (Effect, IOE)
 import Effectful.Concurrent (Concurrent)
+import Effectful.Concurrent.STM (atomically, newTVarIO)
 import Effectful.Dispatch.Dynamic (interpretWith_, reinterpret)
-import Effectful.Exception (trySync)
+import Effectful.Exception (bracket_, trySync)
 import Effectful.Reader.Static (Reader, ask)
 import Effectful.State.Static.Shared (State, evalState, get, put)
 import Effectful.TH (makeEffect)
@@ -30,7 +35,7 @@ import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.Delay (Delay, withTimeout)
 import Atelier.Effects.File (File)
 import Tricorder.BuildState (TestRun (..), TestRunCompletion (..), TestRunError (..))
-import Tricorder.Effects.GhciSession.GhciProcess (execGhci, withGhciProcess)
+import Tricorder.Effects.GhciSession.GhciProcess (GhciProcess, execGhci, interruptGhci, withGhciProcess)
 import Tricorder.Effects.SessionStore (SessionStore)
 import Tricorder.Runtime (ProjectRoot (..))
 import Tricorder.Session (Session (..))
@@ -43,6 +48,14 @@ data TestRunner :: Effect where
     -- | Run a single test suite in a short-lived @cabal repl@ process and
     -- return the captured output and detected outcome.
     RunTestSuite :: Text -> TestRunner m TestRun
+    -- | Interrupt the test currently in flight (if any) and latch an abort
+    -- flag so that subsequent 'RunTestSuite' calls short-circuit until
+    -- 'ResetAbort' is called.
+    InterruptCurrent :: TestRunner m ()
+    -- | Clear the abort flag. Call this at the start of a new test run.
+    ResetAbort :: TestRunner m ()
+    -- | Read the abort flag without clearing it.
+    IsAborted :: TestRunner m Bool
 
 
 makeEffect ''TestRunner
@@ -63,35 +76,51 @@ runTestRunnerIO
     => Eff (TestRunner : es) a -> Eff es a
 runTestRunnerIO act = do
     ProjectRoot projectRoot <- ask
+    currentProcRef <- newTVarIO (Nothing :: Maybe GhciProcess)
+    abortedRef <- newTVarIO False
     interpretWith_ act \case
+        InterruptCurrent -> do
+            mProc <- atomically do
+                writeTVar abortedRef True
+                readTVar currentProcRef
+            for_ mProc interruptGhci
+        ResetAbort -> atomically (writeTVar abortedRef False)
+        IsAborted -> atomically (readTVar abortedRef)
         RunTestSuite target -> do
-            Session {testTimeout} <- SessionStore.get
-            result <- trySync $ withGhciProcess def ("cabal repl " <> target) projectRoot \ghci _ -> do
-                case testTimeout of
-                    secs | secs <= 0 -> Right <$> execGhci ghci ":main"
-                    secs ->
-                        withTimeout (fromIntegral secs :: Second) (execGhci ghci ":main") >>= \case
-                            Left () -> pure (Left secs)
-                            Right ls -> pure (Right ls)
-            pure $ case result of
-                Left ex ->
-                    TestRunErrored $ TestRunError {target, message = show ex}
-                Right (Left secs) ->
-                    TestRunErrored $ TestRunError {target, message = "Test suite timed out after " <> show secs <> "s"}
-                Right (Right mainLines) ->
-                    let output = T.unlines mainLines
-                    in  case detectOutcome output of
-                            GhciCrashed msg ->
-                                TestRunErrored $ TestRunError {target, message = msg}
-                            outcome ->
-                                TestRunCompleted
-                                    $ TestRunCompletion
-                                        { target
-                                        , passed = outcome == GhciPassed
-                                        , output
-                                        , testCases = parseHspecOutput output
-                                        , duration = parseHspecDuration output
-                                        }
+            alreadyAborted <- atomically (readTVar abortedRef)
+            if alreadyAborted then
+                pure $ TestRunErrored $ TestRunError {target, message = "Test run aborted"}
+            else do
+                Session {testTimeout} <- SessionStore.get
+                result <- trySync $ withGhciProcess def ("cabal repl " <> target) projectRoot \ghci _ ->
+                    bracket_
+                        (atomically (writeTVar currentProcRef (Just ghci)))
+                        (atomically (writeTVar currentProcRef Nothing))
+                        $ case testTimeout of
+                            secs | secs <= 0 -> Right <$> execGhci ghci ":main"
+                            secs ->
+                                withTimeout (fromIntegral secs :: Second) (execGhci ghci ":main") >>= \case
+                                    Left () -> pure (Left secs)
+                                    Right ls -> pure (Right ls)
+                pure $ case result of
+                    Left ex ->
+                        TestRunErrored $ TestRunError {target, message = show ex}
+                    Right (Left secs) ->
+                        TestRunErrored $ TestRunError {target, message = "Test suite timed out after " <> show secs <> "s"}
+                    Right (Right mainLines) ->
+                        let output = T.unlines mainLines
+                        in  case detectOutcome output of
+                                GhciCrashed msg ->
+                                    TestRunErrored $ TestRunError {target, message = msg}
+                                outcome ->
+                                    TestRunCompleted
+                                        $ TestRunCompletion
+                                            { target
+                                            , passed = outcome == GhciPassed
+                                            , output
+                                            , testCases = parseHspecOutput output
+                                            , duration = parseHspecDuration output
+                                            }
 
 
 -- | Scripted interpreter for testing.
@@ -113,6 +142,9 @@ runTestRunnerScripted results = reinterpret (evalState results) $ \_ ->
                 Right r : rest -> put rest >> pure r
     in  \case
             RunTestSuite _ -> popResult
+            InterruptCurrent -> pure ()
+            ResetAbort -> pure ()
+            IsAborted -> pure False
 
 
 data GhciOutcome


### PR DESCRIPTION
When a source change arrives mid-build with no clients blocked in `waitUntilDone`, interrupt both the GHCi reload (existing behaviour) **and** the currently running test suite, then start a fresh cycle on the latest code instead of finishing the now-stale run.

- `TestRunner` gains `InterruptCurrent`, `ResetAbort`, `IsAborted`. The IO interpreter tracks the in-flight `GhciProcess` in a `TVar` and reuses the existing `interruptGhci` (process-group SIGINT) primitive.
- `Builder.interruptCurrent` (renamed from `interruptCurrentReload`) gates on `hasWaiters` and always fires `TestRunner.interruptCurrent` alongside `controls.interrupt`.
- `runTestsIfClean` returns `Maybe [TestRun]` — `Nothing` on abort. Caller skips the `Done` publish so no stale result reaches clients; the next change triggers a fresh `Building -> Testing -> Done` cycle.