### PR TITLE
feat: add STM-based semaphores

### DIFF
--- a/atelier/src/Atelier/Types/Semaphore.hs
+++ b/atelier/src/Atelier/Types/Semaphore.hs
@@ -1,3 +1,5 @@
+-- | If you need a semaphore that works in 'STM', use
+-- 'Atelier.Types.Semaphore.STM'.
 module Atelier.Types.Semaphore
     ( Semaphore
     , new
@@ -10,75 +12,48 @@ module Atelier.Types.Semaphore
     , withSemaphore
     ) where
 
-import Effectful.Concurrent.MVar
-    ( Concurrent
-    , MVar
-    , isEmptyMVar
-    , newEmptyMVar
-    , newMVar
-    , putMVar
-    , takeMVar
-    , tryPutMVar
-    , tryTakeMVar
-    )
-import Effectful.Exception (bracket)
+import Effectful.Concurrent.STM (Concurrent, atomically)
 
+import Atelier.Types.Semaphore.STM (Semaphore, withSemaphore)
 
--- | A flag for threads to either wait to be set, or signal to other processes
--- to continue. A synchronization primitive.
---
--- Using 'wait' on an unset semaphore blocks.
--- Using 'signal' on a set semaphore blocks.
--- All other operations do not block.
---
--- Using 'wait' on a semaphore makes it unset once the wait resolves.
--- Using 'signal' on a semaphore makes it set once the signal resolves.
-newtype Semaphore = Semaphore (MVar ())
+import Atelier.Types.Semaphore.STM qualified as STM
 
 
 -- | Creates a new, unset semaphore. Waiting on this semaphore immediately will
 -- block.
 new :: (Concurrent :> es) => Eff es Semaphore
-new = Semaphore <$> newEmptyMVar
+new = atomically STM.new
 
 
 -- | Creates a new, set semaphore. Signalling on this semaphore immediately
 -- will block.
 newSet :: (Concurrent :> es) => Eff es Semaphore
-newSet = Semaphore <$> newMVar ()
+newSet = atomically STM.newSet
 
 
 -- | Wait for a semaphore to be set. Blocks and waits for the semaphore to be
 -- set if it is not already set.
 wait :: (Concurrent :> es) => Semaphore -> Eff es ()
-wait (Semaphore ref) = takeMVar ref
+wait = atomically . STM.wait
 
 
 -- | Ensures a semaphore is unset. Returns @True@ if the semaphore was set.
 unset :: (Concurrent :> es) => Semaphore -> Eff es Bool
-unset (Semaphore ref) = isJust <$> tryTakeMVar ref
+unset = atomically . STM.unset
 
 
 -- | Set a semaphore. Blocks and waits if the semaphore is already set.
 signal :: (Concurrent :> es) => Semaphore -> Eff es ()
-signal (Semaphore ref) = putMVar ref ()
+signal = atomically . STM.signal
 
 
 -- | Ensures a semaphore is set. Returns @True@ if the semaphore was not
 -- already set.
 set :: (Concurrent :> es) => Semaphore -> Eff es Bool
-set (Semaphore ref) = tryPutMVar ref ()
+set = atomically . STM.set
 
 
 -- | Check if a semaphore is set, without changing its state. Returns @True@ if
 -- the semaphore is set, @False@ otherwise.
 peek :: (Concurrent :> es) => Semaphore -> Eff es Bool
-peek (Semaphore ref) = not <$> isEmptyMVar ref
-
-
--- | Waits for exclusive access to the semaphore before running a computation,
--- ensuring it is set before starting, and that it is signalled afterwards.
--- If another thread signals or sets the semaphore in the meantime, the caller
--- will _not_ be blocked when attempting to signal the semaphore afterwards.
-withSemaphore :: (Concurrent :> es) => Semaphore -> Eff es a -> Eff es a
-withSemaphore ref = bracket (wait ref) (const $ set ref) . const
+peek = atomically . STM.peek

--- a/atelier/src/Atelier/Types/Semaphore/STM.hs
+++ b/atelier/src/Atelier/Types/Semaphore/STM.hs
@@ -1,0 +1,87 @@
+-- | STM variant of 'Atelier.Types.Semaphore'.
+module Atelier.Types.Semaphore.STM
+    ( Semaphore
+    , new
+    , newSet
+    , wait
+    , signal
+    , unset
+    , set
+    , peek
+    , withSemaphore
+    ) where
+
+import Effectful.Concurrent.STM
+    ( Concurrent
+    , STM
+    , TMVar
+    , atomically
+    , isEmptyTMVar
+    , newEmptyTMVar
+    , newTMVar
+    , putTMVar
+    , takeTMVar
+    , tryPutTMVar
+    , tryTakeTMVar
+    )
+import Effectful.Exception (bracket_)
+
+
+-- | A flag for threads to either wait to be set, or signal to other processes
+-- to continue. A synchronization primitive.
+--
+-- Using 'wait' on an unset semaphore blocks.
+-- Using 'signal' on a set semaphore blocks.
+-- All other operations do not block.
+--
+-- Using 'wait' on a semaphore makes it unset once the wait resolves.
+-- Using 'signal' on a semaphore makes it set once the signal resolves.
+newtype Semaphore = Semaphore (TMVar ())
+
+
+-- | Creates a new, unset semaphore. Waiting on this semaphore immediately will
+-- block.
+new :: STM Semaphore
+new = Semaphore <$> newEmptyTMVar
+
+
+-- | Creates a new, set semaphore. Signalling on this semaphore immediately
+-- will block.
+newSet :: STM Semaphore
+newSet = Semaphore <$> newTMVar ()
+
+
+-- | Wait for a semaphore to be set. Blocks and waits for the semaphore to be
+-- set if it is not already set.
+wait :: Semaphore -> STM ()
+wait (Semaphore ref) = takeTMVar ref
+
+
+-- | Ensures a semaphore is unset. Returns @True@ if the semaphore was set.
+unset :: Semaphore -> STM Bool
+unset (Semaphore ref) = isJust <$> tryTakeTMVar ref
+
+
+-- | Set a semaphore. Blocks and waits if the semaphore is already set.
+signal :: Semaphore -> STM ()
+signal (Semaphore ref) = putTMVar ref ()
+
+
+-- | Ensures a semaphore is set. Returns @True@ if the semaphore was not
+-- already set.
+set :: Semaphore -> STM Bool
+set (Semaphore ref) = tryPutTMVar ref ()
+
+
+-- | Check if a semaphore is set, without changing its state. Returns @True@ if
+-- the semaphore is set, @False@ otherwise.
+peek :: Semaphore -> STM Bool
+peek (Semaphore ref) = not <$> isEmptyTMVar ref
+
+
+-- | Waits for exclusive access to the semaphore before running a computation,
+-- ensuring it is set before starting, and that it is signalled afterwards.
+-- If another thread signals or sets the semaphore in the meantime, the caller
+-- will _not_ be blocked when attempting to signal the semaphore afterwards.
+withSemaphore :: (Concurrent :> es) => Semaphore -> Eff es a -> Eff es a
+withSemaphore ref = bracket_ (atomically $ wait ref) (atomically $ set ref)

--- a/atelier/test/Unit/Atelier/Types/Semaphore/STMSpec.hs
+++ b/atelier/test/Unit/Atelier/Types/Semaphore/STMSpec.hs
@@ -1,0 +1,126 @@
+module Unit.Atelier.Types.Semaphore.STMSpec (spec_Semaphore_STM) where
+
+import Effectful (runEff)
+import Effectful.Concurrent (runConcurrent)
+import Effectful.Concurrent.STM (atomically)
+import Effectful.State.Static.Shared (evalState, get, put)
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+import Data.IORef qualified as IORef
+
+import Atelier.Effects.Conc qualified as Conc
+import Atelier.Types.Semaphore.STM qualified as Sem
+
+
+spec_Semaphore_STM :: Spec
+spec_Semaphore_STM = do
+    describe "wait" $ it "should halt the computation" do
+        runEff . runConcurrent . Conc.runConc . evalState @Int 0 $ do
+            sem <- atomically Sem.new
+
+            thread <- Conc.fork do
+                atomically $ Sem.wait sem
+                put 1
+
+            a1 <- get
+            liftIO $ a1 `shouldBe` 0
+
+            atomically $ Sem.signal sem
+
+            Conc.await thread
+
+            a2 <- get
+            liftIO $ a2 `shouldBe` 1
+
+    describe "signal" do
+        it "sets the semaphore" do
+            result <- runEff . runConcurrent . atomically $ do
+                sem <- Sem.new
+                Sem.signal sem
+                Sem.peek sem
+            result `shouldBe` True
+
+    describe "clear" do
+        describe "when the semaphore was set" $ it "returns True" do
+            result <- runEff . runConcurrent . atomically $ do
+                sem <- Sem.newSet
+                Sem.unset sem
+            result `shouldBe` True
+
+        describe "when the semaphore was not set" $ it "returns False" do
+            result <- runEff . runConcurrent . atomically $ do
+                sem <- Sem.new
+                Sem.unset sem
+            result `shouldBe` False
+
+        it "leaves the semaphore clear" do
+            result <- runEff . runConcurrent . atomically $ do
+                sem <- Sem.newSet
+                _ <- Sem.unset sem
+                Sem.peek sem
+            result `shouldBe` False
+
+    describe "reset" do
+        describe "when the semaphore was not set" $ it "returns True" do
+            result <- runEff . runConcurrent . atomically $ do
+                sem <- Sem.new
+                Sem.set sem
+            result `shouldBe` True
+
+        describe "when the semaphore was already set" $ it "returns False" do
+            result <- runEff . runConcurrent . atomically $ do
+                sem <- Sem.newSet
+                Sem.set sem
+            result `shouldBe` False
+
+        it "leaves the semaphore set" do
+            result <- runEff . runConcurrent . atomically $ do
+                sem <- Sem.new
+                _ <- Sem.set sem
+                Sem.peek sem
+            result `shouldBe` True
+
+    describe "peek" do
+        describe "when the semaphore is set" $ it "returns True" do
+            result <- runEff . runConcurrent . atomically $ do
+                sem <- Sem.newSet
+                Sem.peek sem
+            result `shouldBe` True
+
+        describe "when the semaphore is not set" $ it "returns False" do
+            result <- runEff . runConcurrent . atomically $ do
+                sem <- Sem.new
+                Sem.peek sem
+            result `shouldBe` False
+
+        it "does not change the state of the semaphore" do
+            (before, after) <- runEff . runConcurrent . atomically $ do
+                sem <- Sem.newSet
+                before <- Sem.peek sem
+                after <- Sem.peek sem
+                pure (before, after)
+            (before, after) `shouldBe` (True, True)
+
+    describe "withSemaphore" do
+        it "returns the result of the enclosed computation" do
+            result <- runEff . runConcurrent $ do
+                sem <- atomically Sem.newSet
+                Sem.withSemaphore sem $ pure (42 :: Int)
+            result `shouldBe` 42
+
+        it "signals the semaphore after the computation" do
+            result <- runEff . runConcurrent $ do
+                sem <- atomically Sem.newSet
+                Sem.withSemaphore sem $ pure ()
+                atomically $ Sem.peek sem
+            result `shouldBe` True
+
+        it "waits for the semaphore before running" do
+            result <- runEff . runConcurrent . Conc.runConc $ do
+                sem <- atomically Sem.new
+                ref <- liftIO $ IORef.newIORef False
+                _ <- Conc.fork $ do
+                    liftIO $ IORef.writeIORef ref True
+                    atomically $ Sem.signal sem
+                Sem.withSemaphore sem $ liftIO $ IORef.readIORef ref
+            result `shouldBe` True

--- a/tricorder.cabal
+++ b/tricorder.cabal
@@ -161,6 +161,7 @@ library atelier
       Atelier.Types.JsonReadShow
       Atelier.Types.QuietSnake
       Atelier.Types.Semaphore
+      Atelier.Types.Semaphore.STM
       Atelier.Types.WithDefaults
   other-modules:
       Paths_tricorder
@@ -405,6 +406,7 @@ test-suite atelier-test
       Unit.Atelier.Effects.PublishingSpec
       Unit.Atelier.Effects.TallySpec
       Unit.Atelier.Effects.YieldSpec
+      Unit.Atelier.Types.Semaphore.STMSpec
       Unit.Atelier.Types.SemaphoreSpec
       Unit.Atelier.Types.WithDefaultsSpec
       Paths_tricorder


### PR DESCRIPTION
Needed a `Semaphore` that I could create and manipulate in `STM` more easily. Thus, we now use `TMVar ()` for our semaphores, and we just wrap each `STM`-based operation in `atomically` for `Atelier.Types.Semaphore`'s operations.