### PR TITLE
fix: dispatch :reload for cold-start failed targets

### DIFF
--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -6,9 +6,11 @@ module Tricorder.Builder
     , mergeDiagnostics
     , NewLoadResult (..)
     , DiagnosticMap
+    , KnownTargetNames (..)
     , compileLoadResultsIntoBuildResults
     , requestTestRunsForNewBuildResults
     , buildWithGhciOnChange
+    , fileMatchesAnyTarget
     , handleInitialBuild
     , onRestart
     , reloadOnSourceChange
@@ -23,10 +25,11 @@ import Effectful.Exception (bracket_, trySync)
 import Effectful.Reader.Static (Reader, ask)
 import Effectful.State.Static.Shared (State, get, modify, put, state)
 import Relude.Extra.Tuple (dup)
-import System.FilePath (isAbsolute, normalise, (</>))
+import System.FilePath (dropExtension, isAbsolute, normalise, splitDirectories, (</>))
 
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
+import Data.Text qualified as T
 
 import Atelier.Component (Component (..), defaultComponent)
 import Atelier.Effects.Chan (Chan)
@@ -92,6 +95,7 @@ component
        , State (Map FilePath LoadedModule) :> es
        , State BuildId :> es
        , State DiagnosticMap :> es
+       , State KnownTargetNames :> es
        , Sub BuildResult :> es
        , Sub CabalChangeDetected :> es
        , Sub EnteringNewPhase :> es
@@ -171,6 +175,7 @@ restartableListeners
        , State (Map FilePath LoadedModule) :> es
        , State BuildId :> es
        , State DiagnosticMap :> es
+       , State KnownTargetNames :> es
        , Sub BuildResult :> es
        , Sub CabalChangeDetected :> es
        , Sub EnteringNewPhase :> es
@@ -228,6 +233,7 @@ buildWithGhciOnChange
        , State (Map FilePath LoadedModule) :> es
        , State BuildId :> es
        , State DiagnosticMap :> es
+       , State KnownTargetNames :> es
        , Sub CabalChangeDetected :> es
        , Sub SourceChangeDetected :> es
        , TestRunner :> es
@@ -238,6 +244,7 @@ buildWithGhciOnChange
 buildWithGhciOnChange reloader config = forever do
     put @DiagnosticMap Map.empty
     put @(Map FilePath LoadedModule) Map.empty
+    put @KnownTargetNames (KnownTargetNames Set.empty)
     projectRoot <- ask
     BuildId n <- get
     Log.info $ "Starting GHCi session #" <> show n <> ": " <> config.command
@@ -247,6 +254,7 @@ buildWithGhciOnChange reloader config = forever do
         initialEndTime <- Clock.currentTime
         handleInitialBuild config initialStartTime initialEndTime initialLoad
         put @(Map FilePath LoadedModule) (resolveKnownTargets Map.empty initialLoad)
+        put @KnownTargetNames (KnownTargetNames (Set.fromList initialLoad.targetNames))
         rebuildOnChange reloader controls
 
 
@@ -293,6 +301,7 @@ rebuildOnChange
        , Pub NewLoadResult :> es
        , State (Map FilePath LoadedModule) :> es
        , State BuildId :> es
+       , State KnownTargetNames :> es
        , Sub CabalChangeDetected :> es
        , Sub SourceChangeDetected :> es
        , TestRunner :> es
@@ -321,6 +330,7 @@ handleSourceChanges
        , Pub NewLoadResult :> es
        , State (Map FilePath LoadedModule) :> es
        , State BuildId :> es
+       , State KnownTargetNames :> es
        , Sub SourceChangeDetected :> es
        , TestRunner :> es
        )
@@ -361,13 +371,15 @@ reloadOnSourceChange
        , Pub NewLoadResult :> es
        , State (Map FilePath LoadedModule) :> es
        , State BuildId :> es
+       , State KnownTargetNames :> es
        )
     => Semaphore -> GhciSession.Controls (Eff es) -> SourceChangeDetected -> Eff es ()
 reloadOnSourceChange readyToBuildSem controls (SourceChangeDetected fp event) = do
     Log.debug $ "Builder: source change detected " <> show event <> " " <> toText fp
     moduleMap <- get @(Map FilePath LoadedModule)
+    knownTargets <- get @KnownTargetNames
     let known = Map.lookup (normalise fp) moduleMap
-    case dispatch known of
+    case dispatch knownTargets known of
         Nothing ->
             Log.debug
                 $ "Builder: no-op for "
@@ -390,23 +402,27 @@ reloadOnSourceChange readyToBuildSem controls (SourceChangeDetected fp event) = 
                     Log.err $ show now <> " Reload errored: " <> show e
                 Right (startTime, endTime, loadResult) -> do
                     modify @(Map FilePath LoadedModule) (\prev -> resolveKnownTargets prev loadResult)
+                    put @KnownTargetNames (KnownTargetNames (Set.fromList loadResult.targetNames))
                     publish $ NewLoadResult {startTime, endTime, loadResult}
   where
-    -- Dispatch on (is the file currently loaded in GHCi?, FileEvent).
-    --
-    -- The module map is the source of truth for "is this file a tracked
-    -- target?" and it must be built from `:show targets` (which survives
-    -- failed compiles), not `:show modules` (which drops them). See
-    -- 'resolveKnownTargets' for how the map is maintained.
-    dispatch = \case
+    -- The path-keyed module map misses targets that failed on first load,
+    -- so we fall back to 'KnownTargetNames' for those — otherwise the
+    -- dispatcher would issue @:add@ (a no-op for an already-tracked cabal
+    -- target), leaving stale diagnostics in place.
+    dispatch knownTargets = \case
         Just lm -> Just $ case event of
-            Added -> controls.reload -- re-adding a known file is just a reload
+            Added -> controls.reload
             Modified -> controls.reload
             Removed -> controls.unadd lm.moduleName
-        Nothing -> case event of
-            Added -> Just (controls.add fp)
-            Modified -> Just (controls.add fp) -- editor wrote a not-yet-loaded file
-            Removed -> Nothing -- nothing to remove
+        Nothing
+            | fileMatchesAnyTarget knownTargets fp -> case event of
+                Added -> Just controls.reload
+                Modified -> Just controls.reload
+                Removed -> Nothing
+            | otherwise -> case event of
+                Added -> Just (controls.add fp)
+                Modified -> Just (controls.add fp)
+                Removed -> Nothing
 
 
 data NewLoadResult = NewLoadResult
@@ -526,16 +542,10 @@ mergeDiagnostics prev LoadResult {compiledFiles, diagnostics} =
     in  Map.union newByFile cleared
 
 
--- | Compute the next "known targets" map by joining this cycle's
--- @:show modules@ (definitive path↔name mapping for successful loads) with
--- the prior map (carryover for targets that failed to compile and are
--- therefore absent from @:show modules@).
---
--- Targets that have never compiled successfully — so we have no entry for
--- them in either source — are dropped here: with neither @:show modules@ nor
--- prior knowledge we can't resolve their dotted name to a file path, and the
--- dispatcher keys on file paths. They'll be picked up next cycle via the
--- @unknown → :add@ branch.
+-- | Path↔module-name map for the next cycle: this round's @:show modules@
+-- plus carryover from @prev@ for targets that failed mid-session and so
+-- dropped out. Never-compiled targets are absent here (no path↔name
+-- mapping); the dispatcher recognises those via 'KnownTargetNames'.
 resolveKnownTargets
     :: Map FilePath LoadedModule
     -- ^ Previous known-targets map (carryover source).
@@ -553,6 +563,37 @@ resolveKnownTargets prev lr =
                 , Just (path, lm) <- [Map.lookup name prevByName]
                 ]
     in  Map.union primary carryover
+
+
+-- | GHCi's current target set, as raw entries from @:show targets@
+-- (typically dotted module names under @cabal repl --enable-multi-repl@).
+-- Survives every compile failure mode, so the dispatcher can recognise a
+-- target even when it's absent from the path-keyed module map.
+newtype KnownTargetNames = KnownTargetNames {unKnownTargetNames :: Set Text}
+    deriving stock (Eq, Show)
+
+
+-- | Whether a file path corresponds to one of GHCi's targets.
+--
+-- We can't convert dotted target names to paths without cabal's
+-- source-dirs, so we check the other direction: any uppercase-segment
+-- suffix of the path (with @/@ → @.@, extension dropped) that equals a
+-- target name is a match. E.g. @./tricorder/src/Tricorder/Version.hs@
+-- yields candidates @"Tricorder.Version"@ and @"Version"@.
+fileMatchesAnyTarget :: KnownTargetNames -> FilePath -> Bool
+fileMatchesAnyTarget (KnownTargetNames targets) fp =
+    any (`Set.member` targets) (pathSuffixesAsModuleName fp)
+
+
+pathSuffixesAsModuleName :: FilePath -> [Text]
+pathSuffixesAsModuleName fp =
+    let segments = filter (not . null) (splitDirectories (dropExtension (normalise fp)))
+        upperSegments = dropWhile (not . startsUpper) segments
+        suffixes = takeWhile (not . null) (iterate (drop 1) upperSegments)
+    in  [T.intercalate "." (map toText s) | s <- suffixes]
+  where
+    startsUpper (c : _) = c >= 'A' && c <= 'Z'
+    startsUpper _ = False
 
 
 -- | Keep only diagnostics whose file is under one of the watched directories.

--- a/tricorder/src/Tricorder/Daemon/Main.hs
+++ b/tricorder/src/Tricorder/Daemon/Main.hs
@@ -93,6 +93,7 @@ main =
         . evalState (BuildId 1)
         . evalState @Builder.DiagnosticMap mempty
         . evalState @(Map FilePath LoadedModule) mempty
+        . evalState @Builder.KnownTargetNames (Builder.KnownTargetNames mempty)
         $ do
             Log.info $ "Starting tricorder " <> Version.gitHash
             runSystem

--- a/tricorder/src/Tricorder/Effects/GhciSession/GhciParser.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession/GhciParser.hs
@@ -99,10 +99,10 @@ data LoadResult = LoadResult
     -- Lists only modules that compiled successfully this cycle — GHCi drops
     -- failed-compile modules from @:show modules@.
     , targetNames :: [Text]
-    -- ^ Raw entries from @:show targets@ — typically dotted module names in
-    -- @cabal repl --enable-multi-repl@. Unlike 'loadedModules', this list
-    -- survives failed compiles, so the Builder uses it (joined with carried-over
-    -- name↔path knowledge) as the source of truth for which files GHCi tracks.
+    -- ^ Raw entries from @:show targets@ — typically dotted module names
+    -- in @cabal repl --enable-multi-repl@. Unlike 'loadedModules' this
+    -- survives failed compiles, so the Builder feeds it into
+    -- @KnownTargetNames@ for the dispatcher's fallback lookup.
     , diagnostics :: [Diagnostic]
     }
     deriving stock (Eq, Show)

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -34,8 +34,10 @@ import Tricorder.BuildState
     )
 import Tricorder.Builder
     ( BuilderSession (..)
+    , KnownTargetNames (..)
     , NewLoadResult (..)
     , compileLoadResultsIntoBuildResults
+    , fileMatchesAnyTarget
     , filterToWatchDirs
     , mergeDiagnostics
     , onRestart
@@ -65,6 +67,7 @@ spec_Builder = do
     describe "restartOnCabalChange" testRestartOnCabalChange
     describe "reloadOnSourceChange" testReloadOnSourceChange
     describe "resolveKnownTargets" testResolveKnownTargets
+    describe "fileMatchesAnyTarget" testFileMatchesAnyTarget
 
 
 testRestartOnCabalChange :: Spec
@@ -91,43 +94,58 @@ testReloadOnSourceChange = do
     describe "Modified" do
         describe "when the file is loaded in GHCi" do
             it "publishes that it is building" do
-                (_, phases) <- runTest knownFoo distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Modified)
+                (_, phases) <- runTest knownFoo noTargets distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Modified)
                 phases `shouldMatchList` [EnteringNewPhase (BuildId 1) $ Building Nothing]
 
             it "calls controls.reload" do
-                (results, _) <- runTest knownFoo distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Modified)
+                (results, _) <- runTest knownFoo noTargets distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Modified)
                 results `shouldMatchList` [NewLoadResult epoch epoch reloadLr]
 
         describe "when the file is not loaded in GHCi" do
             it "calls controls.add (the editor just wrote a new file)" do
-                (results, _) <- runTest Map.empty distinctCtrls (SourceChangeDetected "/abs/path/New.hs" Modified)
+                (results, _) <- runTest Map.empty noTargets distinctCtrls (SourceChangeDetected "/abs/path/New.hs" Modified)
                 results `shouldMatchList` [NewLoadResult epoch epoch addLr]
+
+        -- Regression test for stale-diagnostics bug: cold-start with a
+        -- pre-existing error then fix it. Foo is in :show targets but
+        -- not :show modules, so dispatch must consult KnownTargetNames to
+        -- avoid issuing a no-op :add.
+        describe "when the file is a known target that failed on initial load" do
+            it "calls controls.reload, not controls.add" do
+                (results, _) <-
+                    runTest
+                        Map.empty
+                        (KnownTargetNames (Set.singleton "Foo"))
+                        distinctCtrls
+                        (SourceChangeDetected "/abs/src/Foo.hs" Modified)
+                results `shouldMatchList` [NewLoadResult epoch epoch reloadLr]
 
     describe "Added" do
         describe "when the file is not loaded" $ it "calls controls.add" do
-            (results, _) <- runTest Map.empty distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Added)
+            (results, _) <- runTest Map.empty noTargets distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Added)
             results `shouldMatchList` [NewLoadResult epoch epoch addLr]
 
         describe "when the file is already loaded" $ it "calls controls.reload (re-add is a reload)" do
-            (results, _) <- runTest knownFoo distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Added)
+            (results, _) <- runTest knownFoo noTargets distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Added)
             results `shouldMatchList` [NewLoadResult epoch epoch reloadLr]
 
     describe "Removed" do
         describe "when the file is loaded" $ it "calls controls.unadd" do
-            (results, _) <- runTest knownFoo distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Removed)
+            (results, _) <- runTest knownFoo noTargets distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Removed)
             results `shouldMatchList` [NewLoadResult epoch epoch unaddLr]
 
         describe "when the file is not loaded" $ it "is a no-op" do
-            (results, phases) <- runTest Map.empty distinctCtrls (SourceChangeDetected "/abs/path/Unknown.hs" Removed)
+            (results, phases) <- runTest Map.empty noTargets distinctCtrls (SourceChangeDetected "/abs/path/Unknown.hs" Removed)
             results `shouldMatchList` []
             phases `shouldMatchList` []
   where
-    runTest initialModuleMap ctrls event = do
+    runTest initialModuleMap initialTargets ctrls event = do
         runEff
             . runConcurrent
             . runClockConst epoch
             . evalState (BuildId 1)
             . evalState @(Map FilePath LoadedModule) initialModuleMap
+            . evalState @KnownTargetNames initialTargets
             . runLogNoOp
             . runWriter
             . runPubWriter @EnteringNewPhase
@@ -136,6 +154,8 @@ testReloadOnSourceChange = do
             $ do
                 sem <- Sem.newSet
                 reloadOnSourceChange sem ctrls event
+
+    noTargets = KnownTargetNames Set.empty
 
     distinctCtrls =
         Controls
@@ -397,10 +417,8 @@ testResolveKnownTargets = do
             result = emptyLr {loadedModules = Map.empty, targetNames = []}
         resolveKnownTargets prev result `shouldBe` Map.empty
 
-    -- A genuinely-new target that has never compiled successfully has no
-    -- entry in :show modules and no carryover in prior state. We skip it
-    -- silently; the dispatcher will treat the next event for that file as
-    -- "unknown" and issue :add, which is the correct behavior.
+    -- Dropped from the path-keyed map because we have no path↔name entry;
+    -- the dispatcher still handles them via 'KnownTargetNames'.
     it "drops targets that have neither a current :show modules entry nor prior state" do
         let result = emptyLr {loadedModules = Map.empty, targetNames = ["BrandNew"]}
         resolveKnownTargets Map.empty result `shouldBe` Map.empty
@@ -413,6 +431,43 @@ testResolveKnownTargets = do
             , targetNames = []
             , diagnostics = []
             }
+
+
+--------------------------------------------------------------------------------
+-- fileMatchesAnyTarget tests
+--------------------------------------------------------------------------------
+
+testFileMatchesAnyTarget :: Spec
+testFileMatchesAnyTarget = do
+    it "matches when the path's uppercase-suffix equals a target" do
+        fileMatchesAnyTarget
+            (KnownTargetNames (Set.singleton "Tricorder.Version"))
+            "./tricorder/src/Tricorder/Version.hs"
+            `shouldBe` True
+
+    it "matches a single-segment module" do
+        fileMatchesAnyTarget
+            (KnownTargetNames (Set.singleton "Main"))
+            "./app/Main.hs"
+            `shouldBe` True
+
+    it "does not match when no uppercase-suffix equals a target" do
+        fileMatchesAnyTarget
+            (KnownTargetNames (Set.singleton "Other.Module"))
+            "./tricorder/src/Tricorder/Version.hs"
+            `shouldBe` False
+
+    it "does not match a lowercase-prefix even if textually contained" do
+        fileMatchesAnyTarget
+            (KnownTargetNames (Set.singleton "src.Tricorder.Version"))
+            "./tricorder/src/Tricorder/Version.hs"
+            `shouldBe` False
+
+    it "handles .lhs extension" do
+        fileMatchesAnyTarget
+            (KnownTargetNames (Set.singleton "Foo.Bar"))
+            "./src/Foo/Bar.lhs"
+            `shouldBe` True
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
A file with a pre-existing error at daemon start is in `:show targets` but absent from `:show modules`, and `resolveKnownTargets` has no path↔name carryover for it. The dispatcher's `Map.lookup` then misses, falling through to `:add` — a no-op for an already-tracked cabal target. Result: the diagnostic never clears after the user fixes the file.

Track `:show targets` separately as `KnownTargetNames` and consult it in the dispatcher's `Nothing` branch via path-suffix module-name matching, choosing `:reload` over `:add` when the file is a known target.

- New `KnownTargetNames` state, populated from each cycle's `targetNames`
- New `fileMatchesAnyTarget` helper (uppercase-suffix dotted-name match)
- Regression test on the dispatcher; 5 unit tests for the helper