### PR TITLE
refactor: use Conc instead of Async

### DIFF
--- a/atelier/src/Atelier/Effects/Delay.hs
+++ b/atelier/src/Atelier/Effects/Delay.hs
@@ -19,7 +19,6 @@ module Atelier.Effects.Delay
 import Data.Time.Units (TimeUnit, convertUnit, toMicroseconds)
 import Effectful (Effect, IOE)
 import Effectful.Concurrent (Concurrent, threadDelay)
-import Effectful.Concurrent.Async (race)
 import Effectful.Concurrent.MVar (newEmptyMVar, takeMVar)
 import Effectful.Dispatch.Dynamic (interpret_)
 import Effectful.State.Static.Shared (State, modifyM)
@@ -27,7 +26,10 @@ import Effectful.TH (makeEffect)
 
 import Control.Concurrent.MVar qualified as IO
 
+import Atelier.Effects.Conc (Conc)
 import Atelier.Time (Microsecond)
+
+import Atelier.Effects.Conc qualified as Conc
 
 
 data Delay :: Effect where
@@ -50,11 +52,11 @@ every delay action = forever do
 -- | Race an action against a deadline. Returns 'Right' if the action
 -- completes first, 'Left' if the timeout fires first.
 withTimeout
-    :: (Concurrent :> es, Delay :> es, TimeUnit t)
+    :: (Conc :> es, Delay :> es, TimeUnit t)
     => t
     -> Eff es a
     -> Eff es (Either () a)
-withTimeout duration = race (wait duration)
+withTimeout duration = Conc.race (wait duration)
 
 
 runDelay :: (Concurrent :> es) => Eff (Delay : es) a -> Eff es a

--- a/atelier/test/Unit/Atelier/Effects/Cache/SingleflightSpec.hs
+++ b/atelier/test/Unit/Atelier/Effects/Cache/SingleflightSpec.hs
@@ -1,18 +1,20 @@
 module Unit.Atelier.Effects.Cache.SingleflightSpec (spec_Singleflight) where
 
-import Control.Concurrent (threadDelay)
-import Effectful (IOE, Limit (..), Persistence (..), UnliftStrategy (..), runEff, withEffToIO)
+import Effectful (IOE, runEff)
 import Effectful.Concurrent (Concurrent, runConcurrent)
 import Effectful.Exception (catch, throwIO)
 import Effectful.State.Static.Shared (State, modify, runState)
 import Test.Hspec (Spec, describe, it, shouldBe, shouldThrow)
 
-import Control.Concurrent.Async qualified as Async
-
 import Atelier.Effects.Cache.Singleflight (Singleflight, runSingleflight, updateCache, withCache)
+import Atelier.Effects.Conc (Conc, runConc)
+import Atelier.Effects.Delay (Delay, runDelay)
 import Atelier.Effects.Monitoring.Tracing (Tracing, runTracingNoOp)
+import Atelier.Time (Millisecond)
 import Atelier.Types.Semaphore (Semaphore)
 
+import Atelier.Effects.Conc qualified as Conc
+import Atelier.Effects.Delay qualified as Delay
 import Atelier.Types.Semaphore qualified as Sem
 
 
@@ -24,19 +26,17 @@ data TestException = TestException Text
 
 -- | Run a Singleflight test with execution counter
 runSingleflightTest
-    :: Eff [Singleflight Int Int, State Int, Tracing, Concurrent, IOE] a
+    :: Eff [Singleflight Int Int, State Int, Delay, Tracing, Conc, Concurrent, IOE] a
     -> IO (a, Int)
 runSingleflightTest action =
     runEff
         . runConcurrent
+        . runConc
         . runTracingNoOp
+        . runDelay
         . runState @Int 0
         . runSingleflight @Int @Int
         $ action
-
-
-runSem :: Eff '[Concurrent, IOE] a -> IO a
-runSem = runEff . runConcurrent
 
 
 -- | A computation that increments the execution counter and returns a value
@@ -85,32 +85,30 @@ spec_Singleflight = do
         describe "Concurrent requests are deduplicated" $ do
             it "executes computation once for concurrent requests" $ do
                 (results, execCount) <- runSingleflightTest $ do
-                    withEffToIO (ConcUnlift Persistent Unlimited) $ \unlift -> do
-                        -- Launch 10 concurrent requests for the same key
-                        asyncs <- replicateM 10 do
-                            sem <- runSem Sem.newSet
-                            async <- Async.async $ unlift $ withCache 1 (slowCompute sem 42)
-                            pure (sem, async)
-                        traverse_ (runSem . Sem.unset) $ fst <$> asyncs
-                        traverse Async.wait $ snd <$> asyncs
+                    -- Launch 10 concurrent requests for the same key
+                    asyncs <- replicateM 10 do
+                        sem <- Sem.newSet
+                        async <- Conc.fork $ withCache 1 (slowCompute sem 42)
+                        pure (sem, async)
+                    traverse_ Sem.unset $ fst <$> asyncs
+                    traverse Conc.await $ snd <$> asyncs
                 all (== 42) results `shouldBe` True
                 length results `shouldBe` 10
                 execCount `shouldBe` 1
 
             it "all concurrent waiters receive the same result" $ do
                 (results, execCount) <- runSingleflightTest $ do
-                    withEffToIO (ConcUnlift Persistent Unlimited) $ \unlift -> do
-                        sem <- runSem Sem.new
-                        -- Launch concurrent requests with different delays
-                        a1 <- Async.async $ unlift $ withCache 1 (slowCompute sem 99)
-                        threadDelay 1000 -- Ensure first request starts
-                        a2 <- Async.async $ unlift $ withCache 1 (compute 99)
-                        a3 <- Async.async $ unlift $ withCache 1 (compute 99)
-                        runSem $ Sem.signal sem -- Let first request continue
-                        r1 <- liftIO $ Async.wait a1
-                        r2 <- liftIO $ Async.wait a2
-                        r3 <- liftIO $ Async.wait a3
-                        pure [r1, r2, r3]
+                    sem <- Sem.new
+                    -- Launch concurrent requests with different delays
+                    a1 <- Conc.fork $ withCache 1 (slowCompute sem 99)
+                    Delay.wait (1 :: Millisecond) -- Ensure first request starts
+                    a2 <- Conc.fork $ withCache 1 (compute 99)
+                    a3 <- Conc.fork $ withCache 1 (compute 99)
+                    Sem.signal sem -- Let first request continue
+                    r1 <- Conc.await a1
+                    r2 <- Conc.await a2
+                    r3 <- Conc.await a3
+                    pure [r1, r2, r3]
                 results `shouldBe` [99, 99, 99]
                 execCount `shouldBe` 1
 
@@ -126,16 +124,15 @@ spec_Singleflight = do
 
             it "different keys can run concurrently" $ do
                 (results, execCount) <- runSingleflightTest $ do
-                    withEffToIO (ConcUnlift Persistent Unlimited) $ \unlift -> do
-                        sem <- runSem Sem.newSet
-                        a1 <- Async.async $ unlift $ withCache 1 (slowCompute sem 10)
-                        a2 <- Async.async $ unlift $ withCache 2 (slowCompute sem 20)
-                        a3 <- Async.async $ unlift $ withCache 3 (slowCompute sem 30)
-                        runSem $ replicateM_ 3 $ Sem.signal sem
-                        r1 <- liftIO $ Async.wait a1
-                        r2 <- liftIO $ Async.wait a2
-                        r3 <- liftIO $ Async.wait a3
-                        pure [r1, r2, r3]
+                    sem <- Sem.newSet
+                    a1 <- Conc.fork $ withCache 1 (slowCompute sem 10)
+                    a2 <- Conc.fork $ withCache 2 (slowCompute sem 20)
+                    a3 <- Conc.fork $ withCache 3 (slowCompute sem 30)
+                    replicateM_ 3 $ Sem.signal sem
+                    r1 <- Conc.await a1
+                    r2 <- Conc.await a2
+                    r3 <- Conc.await a3
+                    pure [r1, r2, r3]
                 all (\r -> r `elem` [10, 20, 30]) results `shouldBe` True
                 execCount `shouldBe` 3
 
@@ -170,14 +167,13 @@ spec_Singleflight = do
         describe "All concurrent waiters receive the result" $ do
             it "broadcasts result to all waiting requests" $ do
                 (results, execCount) <- runSingleflightTest $ do
-                    withEffToIO (ConcUnlift Persistent Unlimited) $ \unlift -> do
-                        -- Start one slow computation and many fast waiters
-                        asyncs <- replicateM 20 do
-                            sem <- runSem Sem.new
-                            async <- Async.async $ unlift $ withCache 1 (slowCompute sem 777)
-                            pure (sem, async)
-                        traverse_ (runSem . Sem.signal) $ fst <$> asyncs
-                        traverse Async.wait $ snd <$> asyncs
+                    -- Start one slow computation and many fast waiters
+                    asyncs <- replicateM 20 do
+                        sem <- Sem.new
+                        async <- Conc.fork $ withCache 1 (slowCompute sem 777)
+                        pure (sem, async)
+                    traverse_ Sem.signal $ fst <$> asyncs
+                    traverse Conc.await $ snd <$> asyncs
                 all (== 777) results `shouldBe` True
                 length results `shouldBe` 20
                 execCount `shouldBe` 1
@@ -202,46 +198,43 @@ spec_Singleflight = do
 
             it "propagates exception to all concurrent waiters" $ do
                 let action = runSingleflightTest $ do
-                        withEffToIO (ConcUnlift Persistent Unlimited) $ \unlift -> do
-                            sem <- runSem Sem.new
-                            a1 <- Async.async $ unlift $ withCache @Int @Int 1 (slowCompute sem 42 >> throwIO (TestException "concurrent-boom"))
-                            threadDelay 1000
-                            a2 <- Async.async $ unlift $ withCache @Int @Int 1 (compute 99)
-                            runSem $ Sem.signal sem
-                            _ <- Async.wait a1
-                            Async.wait a2
+                        sem <- Sem.new
+                        a1 <- Conc.fork $ withCache @Int @Int 1 (slowCompute sem 42 >> throwIO (TestException "concurrent-boom"))
+                        Delay.wait (1 :: Millisecond)
+                        a2 <- Conc.fork $ withCache @Int @Int 1 (compute 99)
+                        Sem.signal sem
+                        _ <- Conc.await a1
+                        Conc.await a2
                 action `shouldThrow` (\(TestException msg) -> msg == "concurrent-boom")
 
         describe "UpdateCache on in-flight computation" $ do
             it "overrides result of in-flight computation" $ do
                 (result, execCount) <- runSingleflightTest $ do
-                    withEffToIO (ConcUnlift Persistent Unlimited) $ \unlift -> do
-                        sem <- runSem Sem.new
-                        -- Start slow computation
-                        a1 <- Async.async $ unlift $ withCache 1 (slowCompute sem 42)
-                        threadDelay 1000 -- Let it start
-                        -- Update cache while computation is running
-                        unlift $ updateCache [(1, 999)]
-                        -- Both should get the updated value
-                        runSem $ Sem.signal sem
-                        Async.wait a1
+                    sem <- Sem.new
+                    -- Start slow computation
+                    a1 <- Conc.fork $ withCache 1 (slowCompute sem 42)
+                    Delay.wait (1 :: Millisecond) -- Let it start
+                    -- Update cache while computation is running
+                    updateCache [(1, 999)]
+                    -- Both should get the updated value
+                    Sem.signal sem
+                    Conc.await a1
                 result `shouldBe` 999
                 execCount `shouldBe` 1
 
             it "waiting requests receive updated value" $ do
                 (results, execCount) <- runSingleflightTest $ do
-                    withEffToIO (ConcUnlift Persistent Unlimited) $ \unlift -> do
-                        sem <- runSem Sem.new
-                        -- Start slow computation and waiters
-                        a1 <- Async.async $ unlift $ withCache 1 (slowCompute sem 42)
-                        threadDelay 1000
-                        a2 <- Async.async $ unlift $ withCache 1 (compute 42)
-                        threadDelay 1000
-                        -- Update while they're all waiting/running
-                        unlift $ updateCache [(1, 888)]
-                        runSem $ Sem.signal sem
-                        r1 <- Async.wait a1
-                        r2 <- Async.wait a2
-                        pure [r1, r2]
+                    sem <- Sem.new
+                    -- Start slow computation and waiters
+                    a1 <- Conc.fork $ withCache 1 (slowCompute sem 42)
+                    Delay.wait (1 :: Millisecond)
+                    a2 <- Conc.fork $ withCache 1 (compute 42)
+                    Delay.wait (1 :: Millisecond)
+                    -- Update while they're all waiting/running
+                    updateCache [(1, 888)]
+                    Sem.signal sem
+                    r1 <- Conc.await a1
+                    r2 <- Conc.await a2
+                    pure [r1, r2]
                 all (== 888) results `shouldBe` True
                 execCount `shouldBe` 1

--- a/atelier/test/Unit/Atelier/Effects/CacheSpec.hs
+++ b/atelier/test/Unit/Atelier/Effects/CacheSpec.hs
@@ -3,7 +3,6 @@ module Unit.Atelier.Effects.CacheSpec (spec_Cache) where
 import Data.Time (UTCTime, addUTCTime, getCurrentTime)
 import Effectful (IOE, runEff)
 import Effectful.Concurrent (Concurrent, runConcurrent)
-import Effectful.Concurrent.Async (mapConcurrently)
 import Effectful.Reader.Static (Reader, runReader)
 import Effectful.State.Static.Shared (State, evalState, put)
 import Hedgehog (forAll, (===))
@@ -147,15 +146,15 @@ spec_Cache = do
         it "concurrent inserts to different keys don't interfere" $ hedgehog do
             n <- forAll $ Gen.int (Range.linear 1 20)
             results <- liftIO $ runCacheTest $ do
-                _ <- mapConcurrently (\i -> cacheInsert @Int @Int i i) [1 .. n]
-                traverse (\i -> cacheLookup @Int @Int i) [1 .. n]
+                for_ [1 .. n] \i -> cacheInsert i i
+                traverse (\i -> cacheLookup i) [1 .. n]
             results === map (Just . id) [1 .. n]
 
         it "modify is atomic under concurrency" $ hedgehog do
             n <- forAll $ Gen.int (Range.linear 1 50)
             finalVal <- liftIO $ runCacheTest $ do
-                _ <- mapConcurrently (const $ cacheModify @Int @Int 1 (maybe 1 (+ 1))) [1 .. n]
-                cacheLookup @Int @Int 1
+                for_ [1 .. n] \_ -> cacheModify 1 (maybe 1 (+ 1))
+                cacheLookup 1
             finalVal === Just n
 
 

--- a/atelier/test/Unit/Atelier/Effects/DelaySpec.hs
+++ b/atelier/test/Unit/Atelier/Effects/DelaySpec.hs
@@ -7,7 +7,6 @@ import Effectful.Prim.IORef (atomicModifyIORef, newIORef, readIORef)
 import Effectful.State.Static.Shared (evalState, execState, gets)
 import Test.Hspec
 
-import Effectful.Concurrent.Async qualified as Async
 import Effectful.Prim.IORef qualified as IORef
 
 import Atelier.Effects.Delay (mkTimers, runDelayWithControls)
@@ -219,16 +218,16 @@ testWithTimeout = do
 
     it "action finishes before deadline returns Right" do
         result <- runTest do
-            a <- Async.async $ Delay.withTimeout (100 :: Microsecond) (Delay.wait (10 :: Microsecond))
+            a <- Conc.fork $ Delay.withTimeout (100 :: Microsecond) (Delay.wait (10 :: Microsecond))
             Delay.tickNext
-            Async.wait a
+            Conc.await a
         result `shouldBe` Right ()
 
     it "deadline fires before action returns Left" do
         result <- runTest do
-            a <- Async.async $ Delay.withTimeout (10 :: Microsecond) (Delay.wait (100 :: Microsecond))
+            a <- Conc.fork $ Delay.withTimeout (10 :: Microsecond) (Delay.wait (100 :: Microsecond))
             Delay.tickNext
-            Async.wait a
+            Conc.await a
         result `shouldBe` Left ()
   where
     runTest = runEff . runPrim . runConcurrent . Conc.runConc . evalState mkTimers . runDelayWithControls

--- a/atelier/test/Unit/Atelier/Effects/TallySpec.hs
+++ b/atelier/test/Unit/Atelier/Effects/TallySpec.hs
@@ -2,7 +2,6 @@ module Unit.Atelier.Effects.TallySpec (spec_Tally) where
 
 import Effectful (IOE, runEff)
 import Effectful.Concurrent (Concurrent, runConcurrent)
-import Effectful.Concurrent.Async (mapConcurrently)
 import Effectful.Reader.Static (Reader, runReader)
 import Hedgehog (forAll, (===))
 import Test.Hspec (Spec, describe, it, shouldBe)
@@ -66,7 +65,7 @@ spec_Tally = do
         it "no lost updates under concurrency" $ hedgehog $ do
             n <- forAll $ Gen.int (Range.linear 1 50)
             finalCount <- liftIO $ runTallyTest $ do
-                _ <- mapConcurrently (const checkCount) [1 .. n]
+                replicateM_ n checkCount
                 checkCount
             finalCount === n + 1
 

--- a/tricorder/src/Tricorder/Effects/GhciSession/GhciProcess.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession/GhciProcess.hs
@@ -16,7 +16,6 @@ import Data.Default (Default (..))
 import Data.Time.Units (Second)
 import Effectful (IOE)
 import Effectful.Concurrent (Concurrent)
-import Effectful.Concurrent.Async (concurrently)
 import Effectful.Concurrent.STM (atomically, newTVarIO)
 import Effectful.Exception (bracket, finally, throwIO, try, trySync)
 import System.Process (interruptProcessGroupOf)
@@ -109,7 +108,14 @@ instance Exception GhciProcessError
 -- Waits up to 'startupTimeout' seconds for GHCi to print its version banner,
 -- then performs initial setup (setting prompts and synchronising) and sends
 -- any 'extraSetupCommands' from the config.
-startGhciProcess :: (Conc :> es, Concurrent :> es, Delay :> es, File :> es, IOE :> es) => Config -> Text -> FilePath -> Eff es (GhciProcess, [Text])
+startGhciProcess
+    :: ( Conc :> es
+       , Concurrent :> es
+       , Delay :> es
+       , File :> es
+       , IOE :> es
+       )
+    => Config -> Text -> FilePath -> Eff es (GhciProcess, [Text])
 startGhciProcess config cmd dir = do
     p <-
         liftIO
@@ -194,7 +200,13 @@ withGhciProcess config cmd dir action =
 
 
 -- | Execute a command in GHCi and return the combined stdout+stderr output lines.
-execGhci :: (Concurrent :> es, File :> es, IOE :> es) => GhciProcess -> Text -> Eff es [Text]
+execGhci
+    :: ( Conc :> es
+       , Concurrent :> es
+       , File :> es
+       , IOE :> es
+       )
+    => GhciProcess -> Text -> Eff es [Text]
 execGhci ghciProcess command = do
     n <- atomically do
         readTVar ghciProcess.stateVar >>= \case
@@ -207,10 +219,10 @@ execGhci ghciProcess command = do
         liftIO $ TIO.hPutStrLn ghciProcess.stdin command
         File.hFlush ghciProcess.stdin
         sendSyncCommand ghciProcess.stdin marker
-        (stdoutLines, stderrLines) <-
-            concurrently
-                (drainUntil ghciProcess.stdout marker)
-                (drainUntil ghciProcess.stderr marker)
+        (stdoutLines, stderrLines) <- do
+            stdoutThread <- Conc.fork $ drainUntil ghciProcess.stdout marker
+            stderrThread <- Conc.fork $ drainUntil ghciProcess.stderr marker
+            (,) <$> Conc.await stdoutThread <*> Conc.await stderrThread
         pure (stdoutLines ++ stderrLines)
 
 
@@ -232,7 +244,13 @@ interruptGhci ghciProcess = do
 -- | Stop the GHCi process gracefully, falling back to forced termination.
 --
 -- Never throws — all errors are swallowed.
-stopGhciProcess :: (Concurrent :> es, Delay :> es, File :> es, IOE :> es) => Config -> GhciProcess -> Eff es ()
+stopGhciProcess
+    :: ( Conc :> es
+       , Delay :> es
+       , File :> es
+       , IOE :> es
+       )
+    => Config -> GhciProcess -> Eff es ()
 stopGhciProcess config ghciProcess = do
     -- Try to write :quit
     void $ trySync $ do
@@ -305,7 +323,12 @@ drainUntil h command = go []
 -- given handle.
 --
 -- Returns 'True' if the banner was seen, 'False' on timeout.
-waitForBanner :: (Concurrent :> es, Delay :> es, File :> es) => Second -> Handle -> Eff es Bool
+waitForBanner
+    :: ( Conc :> es
+       , Delay :> es
+       , File :> es
+       )
+    => Second -> Handle -> Eff es Bool
 waitForBanner timeout h = do
     result <- withTimeout timeout go
     pure (isRight result)
@@ -332,7 +355,7 @@ waitForBanner timeout h = do
 -- list via @:show modules@. Emits a progress callback for each
 -- @[N of M] Compiling …@ line.
 collectGhciResult
-    :: (Concurrent :> es, File :> es, IOE :> es)
+    :: (Conc :> es, Concurrent :> es, File :> es, IOE :> es)
     => GhciProcess
     -> [Text]
     -> FilePath
@@ -354,7 +377,7 @@ collectGhciResult process lines' projectRoot onProgress = do
 -- | Execute @:reload@ and return the assembled 'LoadResult', emitting a
 -- progress callback for each @[N of M] Compiling …@ line.
 reloadGhci
-    :: (Concurrent :> es, File :> es, IOE :> es)
+    :: (Conc :> es, Concurrent :> es, File :> es, IOE :> es)
     => GhciProcess
     -> FilePath
     -> (GhciLoading -> Eff es ())
@@ -367,7 +390,7 @@ reloadGhci process projectRoot onProgress = do
 -- | Execute @:add@ for the given file and return the assembled 'LoadResult',
 -- emitting a progress callback for each @[N of M] Compiling …@ line.
 addGhci
-    :: (Concurrent :> es, File :> es, IOE :> es)
+    :: (Conc :> es, Concurrent :> es, File :> es, IOE :> es)
     => GhciProcess
     -> FilePath -- the file to :add
     -> FilePath -- projectRoot
@@ -381,7 +404,7 @@ addGhci process filePath projectRoot onProgress = do
 -- | Execute @:unadd@ for the given module and return the assembled 'LoadResult',
 -- emitting a progress callback for each @[N of M] Compiling …@ line.
 unaddGhci
-    :: (Concurrent :> es, File :> es, IOE :> es)
+    :: (Conc :> es, Concurrent :> es, File :> es, IOE :> es)
     => GhciProcess
     -> Text -- the module name to :unadd
     -> FilePath -- projectRoot


### PR DESCRIPTION
Standardize on using our `Conc` effect instead of functions from `Effectful.Concurrent.Async` and `Control.Concurrent.Async`.

This is also an attempt at remedying the flakiness of some of `Singleflight`'s tests.