### PR TITLE
fix: rebuild on every cabal change

### DIFF
--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -148,7 +148,12 @@ withBuilderSession
     -> (SessionStore.Reloader es -> BuilderSession -> Eff es ())
     -> Eff es Void
 withBuilderSession =
-    SessionStore.withSubSession mkBuilderSession
+    -- 'withReloadingSubSession' (not 'withSubSession') so cabal-file edits
+    -- always restart GHCi, even when the projected fields (command, targets,
+    -- testTargets, watchDirs) didn't change. Most cabal edits change ghc-
+    -- options or deps, which are invisible to the projection but still
+    -- require a fresh GHCi.
+    SessionStore.withReloadingSubSession mkBuilderSession
   where
     mkBuilderSession session =
         BuilderSession

--- a/tricorder/src/Tricorder/Effects/SessionStore.hs
+++ b/tricorder/src/Tricorder/Effects/SessionStore.hs
@@ -4,6 +4,7 @@ module Tricorder.Effects.SessionStore
     , get
     , withSession
     , withSubSession
+    , withReloadingSubSession
     , ActiveSession (..)
     , Reloader (..)
     , runSessionStore
@@ -85,6 +86,34 @@ withSubSession mkSubSession initialSession action =
                 Iter.changes
                     initialSubSession
                     (fmap (\(SessionStoreReloaded s) -> mkSubSession s) iter)
+        in  Conc.restartableForkLoop
+                initialSubSession
+                (Iter.next subIter)
+                \cfg -> action (Reloader rawReload) cfg
+
+
+-- | Like 'withSubSession', but restarts the action on every reload regardless
+-- of whether the projected sub-session changed.
+--
+-- Use this when the publisher can't tell from the projection whether a
+-- restart is needed. The motivating case is a cabal-file edit: it may alter
+-- ghc-options, dependencies, or extensions without affecting the resolved
+-- command/targets/watch-dirs that the projection captures.
+withReloadingSubSession
+    :: forall subSession es a
+     . ( Chan :> es
+       , Conc :> es
+       , SessionStore :> es
+       , Sub SessionStoreReloaded :> es
+       )
+    => (Session -> subSession)
+    -> Session
+    -> (Reloader es -> subSession -> Eff es a)
+    -> Eff es Void
+withReloadingSubSession mkSubSession initialSession action =
+    Iter.fromEvents @SessionStoreReloaded \iter ->
+        let initialSubSession = mkSubSession initialSession
+            subIter = fmap (\(SessionStoreReloaded s) -> mkSubSession s) iter
         in  Conc.restartableForkLoop
                 initialSubSession
                 (Iter.next subIter)

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -1,23 +1,30 @@
 module Unit.Tricorder.BuilderSpec (spec_Builder) where
 
 import Data.Default (def)
+import Data.IORef (IORef)
 import Data.Time (UTCTime (..), addUTCTime, fromGregorian)
-import Effectful (runEff, runPureEff)
-import Effectful.Concurrent (runConcurrent)
+import Effectful (IOE, runEff, runPureEff)
+import Effectful.Concurrent (Concurrent, runConcurrent)
+import Effectful.Dispatch.Dynamic (interpret_)
+import Effectful.Error.Static (Error, runErrorNoCallStack, throwError)
 import Effectful.Reader.Static (runReader)
 import Effectful.State.Static.Shared (evalState, execState, runState)
 import Effectful.Writer.Static.Shared (execWriter, runWriter)
 import Test.Hspec (Spec, describe, it, shouldBe, shouldMatchList)
 
+import Data.IORef qualified as IORef
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 
-import Atelier.Effects.Clock (runClockConst)
-import Atelier.Effects.Delay (runDelay)
+import Atelier.Effects.Chan (Chan, runChan)
+import Atelier.Effects.Clock (Clock, runClockConst)
+import Atelier.Effects.Conc (Conc, runConc)
+import Atelier.Effects.Delay (runDelay, settle)
 import Atelier.Effects.FileWatcher (FileEvent (..))
 import Atelier.Effects.Input (runInputConst)
 import Atelier.Effects.Log (runLogNoOp)
-import Atelier.Effects.Publishing (runPubWriter)
+import Atelier.Effects.Monitoring.Tracing (Tracing, runTracingNoOp)
+import Atelier.Effects.Publishing (Pub, Sub, publish, runPubSub, runPubWriter)
 import Tricorder.BuildState
     ( BuildId (..)
     , BuildPhase (..)
@@ -47,13 +54,19 @@ import Tricorder.Builder
     , setNewPhase
     )
 import Tricorder.Effects.GhciSession (Controls (..), LoadResult (..), LoadedModule (..), extractTitle)
+import Tricorder.Effects.SessionStore
+    ( SessionStore (..)
+    , SessionStoreReloaded (..)
+    )
 import Tricorder.Effects.TestRunner (runTestRunnerScripted)
 import Tricorder.Runtime (ProjectRoot (..))
+import Tricorder.Session (Session (..))
 
 import Atelier.Types.Semaphore qualified as Sem
 import Tricorder.BuildState qualified as BuildState
 import Tricorder.Builder qualified as Builder
 import Tricorder.Effects.BuildStore qualified as BuildStore
+import Tricorder.Effects.SessionStore qualified as SessionStore
 
 
 spec_Builder :: Spec
@@ -65,6 +78,7 @@ spec_Builder = do
     describe "requestTestRunsForNewBuildResults" testRequestTestRunsForNewBuildResults
     describe "setNewPhase" testSetNewPhase
     describe "restartOnCabalChange" testRestartOnCabalChange
+    describe "rebuildOnChange (cabal reload)" testRebuildOnCabalReload
     describe "reloadOnSourceChange" testReloadOnSourceChange
     describe "resolveKnownTargets" testResolveKnownTargets
     describe "fileMatchesAnyTarget" testFileMatchesAnyTarget
@@ -87,6 +101,103 @@ testRestartOnCabalChange = do
             $ onRestart
 
     run = runEff . runConcurrent . runLogNoOp
+
+
+-- | Reproduces the hpack/cabal-reload bug: when a cabal file change leaves
+-- 'BuilderSession's projected fields (command, targets, testTargets, watchDirs)
+-- unchanged, 'reloader.reload' silently no-ops and the builder action is never
+-- restarted. In the live daemon this manifests as the UI staying on the
+-- previous build's "Done" with no rebuild kicked off after hpack rewrites
+-- @tricorder.cabal@.
+testRebuildOnCabalReload :: Spec
+testRebuildOnCabalReload = do
+    it "restarts the builder action when a cabal reload arrives" do
+        runsRef <- IORef.newIORef (0 :: Int)
+        -- Two sessions with identical BuilderSession projections, differing
+        -- only in a field that the projection ignores (outputFile). Mirrors
+        -- the real scenario where hpack rewrites the cabal file without
+        -- changing GHCi targets.
+        let baseSession = mkSession Nothing
+            sameProjection = mkSession (Just "/other")
+        sessionRef <- IORef.newIORef baseSession
+
+        _ <- runMutable sessionRef do
+            Builder.withBuilderSession baseSession \reloader _cfg -> do
+                n <- liftIO $ IORef.atomicModifyIORef' runsRef (\x -> (x + 1, x + 1))
+                if n == 1 then do
+                    -- Let the inner Iter.fromEvents iterator subscribe.
+                    settle
+                    liftIO $ IORef.writeIORef sessionRef sameProjection
+                    reloader.reload
+                    -- Give the restart a chance to fire (it won't, with the bug).
+                    settle
+                    throwError StopSignal
+                else
+                    throwError StopSignal
+
+        runs <- IORef.readIORef runsRef
+        runs `shouldBe` 2
+  where
+    -- Constructor syntax avoids the -Wambiguous-fields warning that record
+    -- update would trigger (Session and Config in Tricorder.Session share
+    -- field names).
+    mkSession outputFile =
+        Session
+            { command = "cmd"
+            , targets = []
+            , testTargets = []
+            , watchDirs = []
+            , outputFile
+            , replBuildDir = "/tmp"
+            , testTimeout = 10
+            }
+
+
+--------------------------------------------------------------------------------
+-- Effect stack for integration tests
+--------------------------------------------------------------------------------
+
+data StopSignal = StopSignal
+    deriving stock (Show)
+
+
+type IntegrationEs =
+    '[ Conc
+     , Error StopSignal
+     , SessionStore
+     , Pub SessionStoreReloaded
+     , Sub SessionStoreReloaded
+     , Chan
+     , Clock
+     , Tracing
+     , Concurrent
+     , IOE
+     ]
+
+
+runMutable :: IORef Session -> Eff IntegrationEs a -> IO (Either StopSignal a)
+runMutable ref =
+    runEff
+        . runConcurrent
+        . runTracingNoOp
+        . runClockConst epoch
+        . runChan
+        . runPubSub @SessionStoreReloaded
+        . runSessionStoreMutable ref
+        . runErrorNoCallStack @StopSignal
+        . runConc
+
+
+runSessionStoreMutable
+    :: (IOE :> es, Pub SessionStoreReloaded :> es)
+    => IORef Session
+    -> Eff (SessionStore : es) a
+    -> Eff es a
+runSessionStoreMutable ref = interpret_ \case
+    Get -> liftIO $ IORef.readIORef ref
+    RawReload -> do
+        session <- liftIO $ IORef.readIORef ref
+        publish (SessionStoreReloaded session)
 
 
 testReloadOnSourceChange :: Spec
@@ -333,7 +444,8 @@ testRequestTestRunsForNewBuildResults = do
             . execWriter
             . runPubWriter
             . runTestRunnerScripted script
-            . requestTestRunsForNewBuildResults (def {testTargets})
+            . requestTestRunsForNewBuildResults
+                BuilderSession {command = "", targets = [], testTargets, watchDirs = []}
 
     mkPhase = EnteringNewPhase (BuildId 1)
     mkTesting = mkPhase . Testing

--- a/tricorder/test/Unit/Tricorder/Effects/SessionStoreSpec.hs
+++ b/tricorder/test/Unit/Tricorder/Effects/SessionStoreSpec.hs
@@ -22,6 +22,7 @@ import Tricorder.Effects.SessionStore
     , SessionStore (..)
     , SessionStoreReloaded (..)
     , runSessionStoreConst
+    , withReloadingSubSession
     , withSession
     )
 import Tricorder.Session (Session (..))
@@ -32,6 +33,7 @@ import Tricorder.Effects.SessionStore qualified as SessionStore
 spec_SessionStore :: Spec
 spec_SessionStore = do
     describe "withSession" testWithSession
+    describe "withReloadingSubSession" testWithReloadingSubSession
 
 
 testWithSession :: Spec
@@ -71,6 +73,30 @@ testWithSession = do
                     throwError StopSignal
         sessions <- reverse <$> IORef.readIORef sessionsRef
         sessions `shouldBe` [session1.command, session2.command]
+
+
+testWithReloadingSubSession :: Spec
+testWithReloadingSubSession = do
+    -- The key difference vs 'withSubSession': re-publishing a session whose
+    -- projection is unchanged still restarts the action.
+    it "restarts the action on every reload, even when the projection is unchanged" do
+        runsRef <- IORef.newIORef (0 :: Int)
+        sessionRef <- IORef.newIORef session1
+        _ <- runMutable sessionRef do
+            withReloadingSubSession project session1 \_reloader _cfg -> do
+                n <- liftIO $ IORef.atomicModifyIORef' runsRef (\x -> (x + 1, x + 1))
+                if n == 1 then do
+                    liftIO $ threadDelay 1_000
+                    -- Same session, same projection — 'withSubSession' would
+                    -- filter this out via 'Iter.changes'; the reloading
+                    -- variant must not.
+                    publish (SessionStoreReloaded session1)
+                else
+                    throwError StopSignal
+        runs <- IORef.readIORef runsRef
+        runs `shouldBe` 2
+  where
+    project s = s.command
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
`withSubSession` filters via the projected sub-session's `Eq`, so cabal-file edits that only change unprojected fields (ghc-options, build-depends) were silently dropped after hpack regenerated the cabal file.

Add `withReloadingSubSession` as a non-filtering sibling and have `withBuilderSession` use it instead.