### PR TITLE
Builder simplification

### DIFF
--- a/tricorder.cabal
+++ b/tricorder.cabal
@@ -18,6 +18,7 @@ library
       Tricorder
       Tricorder.Arguments
       Tricorder.Builder
+      Tricorder.Builder.Dispatch
       Tricorder.BuildState
       Tricorder.CLI
       Tricorder.CLI.Main

--- a/tricorder/src/Tricorder/BuildState.hs
+++ b/tricorder/src/Tricorder/BuildState.hs
@@ -1,3 +1,10 @@
+-- | Shared wire-protocol vocabulary for the build system.
+--
+-- Every type here is serialised (most via 'FromJSON' / 'ToJSON') and crosses
+-- module boundaries between the daemon, the socket layer, the CLI, the UI,
+-- and external clients. Components' /internal/ caches and bookkeeping (e.g.
+-- the Builder's per-cycle module map and diagnostic accumulator) do not
+-- belong here — they live next to the component that owns them.
 module Tricorder.BuildState
     ( BuildId (..)
     , BuildState (..)

--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -17,8 +17,7 @@ import Data.Time (diffUTCTime)
 import Effectful.Concurrent (Concurrent)
 import Effectful.Exception (bracket_, trySync)
 import Effectful.Reader.Static (Reader, ask)
-import Effectful.State.Static.Shared (State, get, modify, put, state)
-import Relude.Extra.Tuple (dup)
+import Effectful.State.Static.Shared (State, get, modify, state)
 import System.FilePath (normalise)
 
 import Data.Map.Strict qualified as Map
@@ -47,15 +46,16 @@ import Tricorder.BuildState
     , TestRun (..)
     )
 import Tricorder.Builder.Dispatch
-    ( DiagnosticMap
+    ( BuilderState (..)
     , KnownTargetNames (..)
+    , emptyBuilderState
     , fileMatchesAnyTarget
     , filterToWatchDirs
     , mergeDiagnostics
     , resolveKnownTargets
     )
 import Tricorder.Effects.BuildStore (BuildStore)
-import Tricorder.Effects.GhciSession (GhciSession, LoadResult (..), LoadedModule (..))
+import Tricorder.Effects.GhciSession (GhciSession, LoadResult (..))
 import Tricorder.Effects.SessionStore (SessionStore, SessionStoreReloaded)
 import Tricorder.Effects.TestRunner (TestRunner)
 import Tricorder.Runtime (ProjectRoot (..))
@@ -90,10 +90,8 @@ component
        , Pub NewLoadResult :> es
        , Reader ProjectRoot :> es
        , SessionStore :> es
-       , State (Map FilePath LoadedModule) :> es
        , State BuildId :> es
-       , State DiagnosticMap :> es
-       , State KnownTargetNames :> es
+       , State BuilderState :> es
        , Sub BuildResult :> es
        , Sub CabalChangeDetected :> es
        , Sub EnteringNewPhase :> es
@@ -175,10 +173,8 @@ restartableListeners
        , Pub EnteringNewPhase :> es
        , Pub NewLoadResult :> es
        , Reader ProjectRoot :> es
-       , State (Map FilePath LoadedModule) :> es
        , State BuildId :> es
-       , State DiagnosticMap :> es
-       , State KnownTargetNames :> es
+       , State BuilderState :> es
        , Sub BuildResult :> es
        , Sub CabalChangeDetected :> es
        , Sub EnteringNewPhase :> es
@@ -233,10 +229,8 @@ buildWithGhciOnChange
        , Pub EnteringNewPhase :> es
        , Pub NewLoadResult :> es
        , Reader ProjectRoot :> es
-       , State (Map FilePath LoadedModule) :> es
        , State BuildId :> es
-       , State DiagnosticMap :> es
-       , State KnownTargetNames :> es
+       , State BuilderState :> es
        , Sub CabalChangeDetected :> es
        , Sub SourceChangeDetected :> es
        , TestRunner :> es
@@ -245,9 +239,7 @@ buildWithGhciOnChange
     -> BuilderSession
     -> Eff es Void
 buildWithGhciOnChange reloader config = forever do
-    put @DiagnosticMap Map.empty
-    put @(Map FilePath LoadedModule) Map.empty
-    put @KnownTargetNames (KnownTargetNames Set.empty)
+    modify @BuilderState (const emptyBuilderState)
     projectRoot <- ask
     BuildId n <- get
     Log.info $ "Starting GHCi session #" <> show n <> ": " <> config.command
@@ -256,8 +248,11 @@ buildWithGhciOnChange reloader config = forever do
     GhciSession.withGhci config.command projectRoot \initialLoad controls -> do
         initialEndTime <- Clock.currentTime
         handleInitialBuild config initialStartTime initialEndTime initialLoad
-        put @(Map FilePath LoadedModule) (resolveKnownTargets Map.empty initialLoad)
-        put @KnownTargetNames (KnownTargetNames (Set.fromList initialLoad.targetNames))
+        modify @BuilderState \s ->
+            s
+                { loadedModules = resolveKnownTargets Map.empty initialLoad
+                , knownTargets = KnownTargetNames (Set.fromList initialLoad.targetNames)
+                }
         rebuildOnChange reloader controls
 
 
@@ -302,9 +297,8 @@ rebuildOnChange
        , Log :> es
        , Pub EnteringNewPhase :> es
        , Pub NewLoadResult :> es
-       , State (Map FilePath LoadedModule) :> es
        , State BuildId :> es
-       , State KnownTargetNames :> es
+       , State BuilderState :> es
        , Sub CabalChangeDetected :> es
        , Sub SourceChangeDetected :> es
        , TestRunner :> es
@@ -331,9 +325,8 @@ handleSourceChanges
        , Log :> es
        , Pub EnteringNewPhase :> es
        , Pub NewLoadResult :> es
-       , State (Map FilePath LoadedModule) :> es
        , State BuildId :> es
-       , State KnownTargetNames :> es
+       , State BuilderState :> es
        , Sub SourceChangeDetected :> es
        , TestRunner :> es
        )
@@ -372,17 +365,15 @@ reloadOnSourceChange
        , Log :> es
        , Pub EnteringNewPhase :> es
        , Pub NewLoadResult :> es
-       , State (Map FilePath LoadedModule) :> es
        , State BuildId :> es
-       , State KnownTargetNames :> es
+       , State BuilderState :> es
        )
     => Semaphore -> GhciSession.Controls (Eff es) -> SourceChangeDetected -> Eff es ()
 reloadOnSourceChange readyToBuildSem controls (SourceChangeDetected fp event) = do
     Log.debug $ "Builder: source change detected " <> show event <> " " <> toText fp
-    moduleMap <- get @(Map FilePath LoadedModule)
-    knownTargets <- get @KnownTargetNames
-    let known = Map.lookup (normalise fp) moduleMap
-    case dispatch knownTargets known of
+    builderState <- get @BuilderState
+    let known = Map.lookup (normalise fp) builderState.loadedModules
+    case dispatch builderState.knownTargets known of
         Nothing ->
             Log.debug
                 $ "Builder: no-op for "
@@ -404,8 +395,11 @@ reloadOnSourceChange readyToBuildSem controls (SourceChangeDetected fp event) = 
                     now <- Clock.currentTime
                     Log.err $ show now <> " Reload errored: " <> show e
                 Right (startTime, endTime, loadResult) -> do
-                    modify @(Map FilePath LoadedModule) (\prev -> resolveKnownTargets prev loadResult)
-                    put @KnownTargetNames (KnownTargetNames (Set.fromList loadResult.targetNames))
+                    modify @BuilderState \s ->
+                        s
+                            { loadedModules = resolveKnownTargets s.loadedModules loadResult
+                            , knownTargets = KnownTargetNames (Set.fromList loadResult.targetNames)
+                            }
                     publish $ NewLoadResult {startTime, endTime, loadResult}
   where
     -- The path-keyed module map misses targets that failed on first load,
@@ -439,7 +433,7 @@ data NewLoadResult = NewLoadResult
 compileLoadResultsIntoBuildResults
     :: ( Pub BuildResult :> es
        , Reader ProjectRoot :> es
-       , State DiagnosticMap :> es
+       , State BuilderState :> es
        )
     => BuilderSession
     -> NewLoadResult
@@ -452,7 +446,9 @@ compileLoadResultsIntoBuildResults session newLoadResult = do
                     filterToWatchDirs projectRoot watchDirs loadResult.diagnostics
                 }
 
-    newAccumulated <- state $ dup . flip mergeDiagnostics filteredResult
+    newAccumulated <- state \s ->
+        let merged = mergeDiagnostics s.diagnosticMap filteredResult
+        in  (merged, s {diagnosticMap = merged})
 
     publish
         BuildResult

--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -2,19 +2,13 @@ module Tricorder.Builder
     ( component
     , withBuilderSession
     , BuilderSession (..)
-    , filterToWatchDirs
-    , mergeDiagnostics
     , NewLoadResult (..)
-    , DiagnosticMap
-    , KnownTargetNames (..)
     , compileLoadResultsIntoBuildResults
     , requestTestRunsForNewBuildResults
     , buildWithGhciOnChange
-    , fileMatchesAnyTarget
     , handleInitialBuild
     , onRestart
     , reloadOnSourceChange
-    , resolveKnownTargets
     , setNewPhase
     ) where
 
@@ -25,11 +19,10 @@ import Effectful.Exception (bracket_, trySync)
 import Effectful.Reader.Static (Reader, ask)
 import Effectful.State.Static.Shared (State, get, modify, put, state)
 import Relude.Extra.Tuple (dup)
-import System.FilePath (dropExtension, isAbsolute, normalise, splitDirectories, (</>))
+import System.FilePath (normalise)
 
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
-import Data.Text qualified as T
 
 import Atelier.Component (Component (..), defaultComponent)
 import Atelier.Effects.Chan (Chan)
@@ -53,6 +46,14 @@ import Tricorder.BuildState
     , SourceChangeDetected (..)
     , TestRun (..)
     )
+import Tricorder.Builder.Dispatch
+    ( DiagnosticMap
+    , KnownTargetNames (..)
+    , fileMatchesAnyTarget
+    , filterToWatchDirs
+    , mergeDiagnostics
+    , resolveKnownTargets
+    )
 import Tricorder.Effects.BuildStore (BuildStore)
 import Tricorder.Effects.GhciSession (GhciSession, LoadResult (..), LoadedModule (..))
 import Tricorder.Effects.SessionStore (SessionStore, SessionStoreReloaded)
@@ -69,9 +70,6 @@ import Tricorder.Effects.BuildStore qualified as BuildStore
 import Tricorder.Effects.GhciSession qualified as GhciSession
 import Tricorder.Effects.SessionStore qualified as SessionStore
 import Tricorder.Effects.TestRunner qualified as TestRunner
-
-
-type DiagnosticMap = Map FilePath [Diagnostic]
 
 
 -- | Builder component.
@@ -532,95 +530,3 @@ runTestsIfClean (BuilderSession {testTargets}) bid partialResult
     insert k v ((k', v') : xs)
         | k == k' = (k, v) : xs
         | otherwise = (k', v') : insert k v xs
-
-
--- | Merge a new 'LoadResult' into the accumulated per-file diagnostic map.
---
--- Files in 'compiledFiles' have their previous diagnostics cleared and replaced
--- by any new diagnostics produced for them in this cycle. Files absent from
--- 'compiledFiles' were skipped by incremental compilation and retain their
--- previous diagnostics unchanged.
-mergeDiagnostics :: DiagnosticMap -> LoadResult -> DiagnosticMap
-mergeDiagnostics prev LoadResult {compiledFiles, diagnostics} =
-    let cleared = foldr Map.delete prev compiledFiles
-        newByFile = Map.fromListWith (++) [(d.file, [d]) | d <- diagnostics]
-    in  Map.union newByFile cleared
-
-
--- | Path↔module-name map for the next cycle: this round's @:show modules@
--- plus carryover from @prev@ for targets that failed mid-session and so
--- dropped out. Never-compiled targets are absent here (no path↔name
--- mapping); the dispatcher recognises those via 'KnownTargetNames'.
-resolveKnownTargets
-    :: Map FilePath LoadedModule
-    -- ^ Previous known-targets map (carryover source).
-    -> LoadResult
-    -> Map FilePath LoadedModule
-resolveKnownTargets prev lr =
-    let primary = lr.loadedModules
-        primaryNames = Set.fromList [lm.moduleName | lm <- Map.elems primary]
-        prevByName = Map.fromList [(lm.moduleName, (path, lm)) | (path, lm) <- Map.toList prev]
-        carryover =
-            Map.fromList
-                [ (path, lm)
-                | name <- lr.targetNames
-                , not (Set.member name primaryNames)
-                , Just (path, lm) <- [Map.lookup name prevByName]
-                ]
-    in  Map.union primary carryover
-
-
--- | GHCi's current target set, as raw entries from @:show targets@
--- (typically dotted module names under @cabal repl --enable-multi-repl@).
--- Survives every compile failure mode, so the dispatcher can recognise a
--- target even when it's absent from the path-keyed module map.
-newtype KnownTargetNames = KnownTargetNames {unKnownTargetNames :: Set Text}
-    deriving stock (Eq, Show)
-
-
--- | Whether a file path corresponds to one of GHCi's targets.
---
--- We can't convert dotted target names to paths without cabal's
--- source-dirs, so we check the other direction: any uppercase-segment
--- suffix of the path (with @/@ → @.@, extension dropped) that equals a
--- target name is a match. E.g. @./tricorder/src/Tricorder/Version.hs@
--- yields candidates @"Tricorder.Version"@ and @"Version"@.
-fileMatchesAnyTarget :: KnownTargetNames -> FilePath -> Bool
-fileMatchesAnyTarget (KnownTargetNames targets) fp =
-    any (`Set.member` targets) (pathSuffixesAsModuleName fp)
-
-
-pathSuffixesAsModuleName :: FilePath -> [Text]
-pathSuffixesAsModuleName fp =
-    let segments = filter (not . null) (splitDirectories (dropExtension (normalise fp)))
-        upperSegments = dropWhile (not . startsUpper) segments
-        suffixes = takeWhile (not . null) (iterate (drop 1) upperSegments)
-    in  [T.intercalate "." (map toText s) | s <- suffixes]
-  where
-    startsUpper (c : _) = c >= 'A' && c <= 'Z'
-    startsUpper _ = False
-
-
--- | Keep only diagnostics whose file is under one of the watched directories.
---
--- Diagnostics from outside the project (e.g. @.h@ files in the Nix store) and
--- those with mangled filenames produced by the C preprocessor (e.g.
--- @"In file included from ..."@) are dropped here, before they can enter the
--- accumulation map where they would be impossible to evict.
-filterToWatchDirs :: FilePath -> [FilePath] -> [Diagnostic] -> [Diagnostic]
-filterToWatchDirs _ [] diags = diags
-filterToWatchDirs projectRoot watchDirs diags =
-    filter (isUnderAnyWatchDir . (.file)) diags
-  where
-    absWatchDirs = map toAbsWd watchDirs
-    toAbsWd wd
-        | wd == "." = projectRoot
-        | isAbsolute wd = wd
-        | otherwise = projectRoot </> wd
-    isUnderAnyWatchDir file
-        | not (isAbsolute file) && not ("./" `isPrefixOf` file) = False
-        | isAbsolute file =
-            any (\wd -> (wd ++ "/") `isPrefixOf` file || wd == file) absWatchDirs
-        | otherwise =
-            let absFile = projectRoot </> drop 2 file
-            in  any (\wd -> (wd ++ "/") `isPrefixOf` absFile || wd == absFile) absWatchDirs

--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -17,7 +17,7 @@ import Data.Time (diffUTCTime)
 import Effectful.Concurrent (Concurrent)
 import Effectful.Exception (bracket_, trySync)
 import Effectful.Reader.Static (Reader, ask)
-import Effectful.State.Static.Shared (State, get, modify, state)
+import Effectful.State.Static.Shared (State, get, modify, put, state)
 import System.FilePath (normalise)
 
 import Data.Map.Strict qualified as Map
@@ -28,7 +28,6 @@ import Atelier.Effects.Chan (Chan)
 import Atelier.Effects.Clock (Clock, UTCTime)
 import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.Debounce (Debounce, debounced)
-import Atelier.Effects.FileWatcher (FileEvent (..))
 import Atelier.Effects.Log (Log)
 import Atelier.Effects.Publishing (Pub, Sub, publish)
 import Atelier.Time (Millisecond, nominalDiffTime)
@@ -47,15 +46,16 @@ import Tricorder.BuildState
     )
 import Tricorder.Builder.Dispatch
     ( BuilderState (..)
+    , DispatchAction (..)
     , KnownTargetNames (..)
+    , dispatch
     , emptyBuilderState
-    , fileMatchesAnyTarget
     , filterToWatchDirs
     , mergeDiagnostics
-    , resolveKnownTargets
     )
 import Tricorder.Effects.BuildStore (BuildStore)
 import Tricorder.Effects.GhciSession (GhciSession, LoadResult (..))
+import Tricorder.Effects.GhciSession.GhciParser (resolveKnownTargets)
 import Tricorder.Effects.SessionStore (SessionStore, SessionStoreReloaded)
 import Tricorder.Effects.TestRunner (TestRunner)
 import Tricorder.Runtime (ProjectRoot (..))
@@ -239,7 +239,7 @@ buildWithGhciOnChange
     -> BuilderSession
     -> Eff es Void
 buildWithGhciOnChange reloader config = forever do
-    modify @BuilderState (const emptyBuilderState)
+    put emptyBuilderState
     projectRoot <- ask
     BuildId n <- get
     Log.info $ "Starting GHCi session #" <> show n <> ": " <> config.command
@@ -248,7 +248,7 @@ buildWithGhciOnChange reloader config = forever do
     GhciSession.withGhci config.command projectRoot \initialLoad controls -> do
         initialEndTime <- Clock.currentTime
         handleInitialBuild config initialStartTime initialEndTime initialLoad
-        modify @BuilderState \s ->
+        modify \s ->
             s
                 { loadedModules = resolveKnownTargets Map.empty initialLoad
                 , knownTargets = KnownTargetNames (Set.fromList initialLoad.targetNames)
@@ -373,7 +373,7 @@ reloadOnSourceChange readyToBuildSem controls (SourceChangeDetected fp event) = 
     Log.debug $ "Builder: source change detected " <> show event <> " " <> toText fp
     builderState <- get @BuilderState
     let known = Map.lookup (normalise fp) builderState.loadedModules
-    case dispatch builderState.knownTargets known of
+    case dispatch builderState.knownTargets known fp event of
         Nothing ->
             Log.debug
                 $ "Builder: no-op for "
@@ -386,7 +386,7 @@ reloadOnSourceChange readyToBuildSem controls (SourceChangeDetected fp event) = 
 
             res <- trySync $ Sem.withSemaphore readyToBuildSem do
                 startTime <- Clock.currentTime
-                res <- action
+                res <- runAction controls action
                 endTime <- Clock.currentTime
                 pure (startTime, endTime, res)
 
@@ -395,31 +395,19 @@ reloadOnSourceChange readyToBuildSem controls (SourceChangeDetected fp event) = 
                     now <- Clock.currentTime
                     Log.err $ show now <> " Reload errored: " <> show e
                 Right (startTime, endTime, loadResult) -> do
-                    modify @BuilderState \s ->
+                    modify \s ->
                         s
                             { loadedModules = resolveKnownTargets s.loadedModules loadResult
                             , knownTargets = KnownTargetNames (Set.fromList loadResult.targetNames)
                             }
                     publish $ NewLoadResult {startTime, endTime, loadResult}
-  where
-    -- The path-keyed module map misses targets that failed on first load,
-    -- so we fall back to 'KnownTargetNames' for those — otherwise the
-    -- dispatcher would issue @:add@ (a no-op for an already-tracked cabal
-    -- target), leaving stale diagnostics in place.
-    dispatch knownTargets = \case
-        Just lm -> Just $ case event of
-            Added -> controls.reload
-            Modified -> controls.reload
-            Removed -> controls.unadd lm.moduleName
-        Nothing
-            | fileMatchesAnyTarget knownTargets fp -> case event of
-                Added -> Just controls.reload
-                Modified -> Just controls.reload
-                Removed -> Nothing
-            | otherwise -> case event of
-                Added -> Just (controls.add fp)
-                Modified -> Just (controls.add fp)
-                Removed -> Nothing
+
+
+runAction :: GhciSession.Controls (Eff es) -> DispatchAction -> Eff es LoadResult
+runAction controls = \case
+    Reload -> controls.reload
+    Add fp -> controls.add fp
+    Unadd mn -> controls.unadd mn
 
 
 data NewLoadResult = NewLoadResult

--- a/tricorder/src/Tricorder/Builder/Dispatch.hs
+++ b/tricorder/src/Tricorder/Builder/Dispatch.hs
@@ -1,0 +1,112 @@
+module Tricorder.Builder.Dispatch
+    ( DiagnosticMap
+    , KnownTargetNames (..)
+    , fileMatchesAnyTarget
+    , filterToWatchDirs
+    , mergeDiagnostics
+    , resolveKnownTargets
+    ) where
+
+import System.FilePath (dropExtension, isAbsolute, normalise, splitDirectories, (</>))
+
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
+import Data.Text qualified as T
+
+import Tricorder.BuildState (Diagnostic (..))
+import Tricorder.Effects.GhciSession (LoadResult (..), LoadedModule (..))
+
+
+type DiagnosticMap = Map FilePath [Diagnostic]
+
+
+-- | Merge a new 'LoadResult' into the accumulated per-file diagnostic map.
+--
+-- Files in 'compiledFiles' have their previous diagnostics cleared and replaced
+-- by any new diagnostics produced for them in this cycle. Files absent from
+-- 'compiledFiles' were skipped by incremental compilation and retain their
+-- previous diagnostics unchanged.
+mergeDiagnostics :: DiagnosticMap -> LoadResult -> DiagnosticMap
+mergeDiagnostics prev LoadResult {compiledFiles, diagnostics} =
+    let cleared = foldr Map.delete prev compiledFiles
+        newByFile = Map.fromListWith (++) [(d.file, [d]) | d <- diagnostics]
+    in  Map.union newByFile cleared
+
+
+-- | Path↔module-name map for the next cycle: this round's @:show modules@
+-- plus carryover from @prev@ for targets that failed mid-session and so
+-- dropped out. Never-compiled targets are absent here (no path↔name
+-- mapping); the dispatcher recognises those via 'KnownTargetNames'.
+resolveKnownTargets
+    :: Map FilePath LoadedModule
+    -- ^ Previous known-targets map (carryover source).
+    -> LoadResult
+    -> Map FilePath LoadedModule
+resolveKnownTargets prev lr =
+    let primary = lr.loadedModules
+        primaryNames = Set.fromList [lm.moduleName | lm <- Map.elems primary]
+        prevByName = Map.fromList [(lm.moduleName, (path, lm)) | (path, lm) <- Map.toList prev]
+        carryover =
+            Map.fromList
+                [ (path, lm)
+                | name <- lr.targetNames
+                , not (Set.member name primaryNames)
+                , Just (path, lm) <- [Map.lookup name prevByName]
+                ]
+    in  Map.union primary carryover
+
+
+-- | GHCi's current target set, as raw entries from @:show targets@
+-- (typically dotted module names under @cabal repl --enable-multi-repl@).
+-- Survives every compile failure mode, so the dispatcher can recognise a
+-- target even when it's absent from the path-keyed module map.
+newtype KnownTargetNames = KnownTargetNames {unKnownTargetNames :: Set Text}
+    deriving stock (Eq, Show)
+
+
+-- | Whether a file path corresponds to one of GHCi's targets.
+--
+-- We can't convert dotted target names to paths without cabal's
+-- source-dirs, so we check the other direction: any uppercase-segment
+-- suffix of the path (with @/@ → @.@, extension dropped) that equals a
+-- target name is a match. E.g. @./tricorder/src/Tricorder/Version.hs@
+-- yields candidates @"Tricorder.Version"@ and @"Version"@.
+fileMatchesAnyTarget :: KnownTargetNames -> FilePath -> Bool
+fileMatchesAnyTarget (KnownTargetNames targets) fp =
+    any (`Set.member` targets) (pathSuffixesAsModuleName fp)
+
+
+pathSuffixesAsModuleName :: FilePath -> [Text]
+pathSuffixesAsModuleName fp =
+    let segments = filter (not . null) (splitDirectories (dropExtension (normalise fp)))
+        upperSegments = dropWhile (not . startsUpper) segments
+        suffixes = takeWhile (not . null) (iterate (drop 1) upperSegments)
+    in  [T.intercalate "." (map toText s) | s <- suffixes]
+  where
+    startsUpper (c : _) = c >= 'A' && c <= 'Z'
+    startsUpper _ = False
+
+
+-- | Keep only diagnostics whose file is under one of the watched directories.
+--
+-- Diagnostics from outside the project (e.g. @.h@ files in the Nix store) and
+-- those with mangled filenames produced by the C preprocessor (e.g.
+-- @"In file included from ..."@) are dropped here, before they can enter the
+-- accumulation map where they would be impossible to evict.
+filterToWatchDirs :: FilePath -> [FilePath] -> [Diagnostic] -> [Diagnostic]
+filterToWatchDirs _ [] diags = diags
+filterToWatchDirs projectRoot watchDirs diags =
+    filter (isUnderAnyWatchDir . (.file)) diags
+  where
+    absWatchDirs = map toAbsWd watchDirs
+    toAbsWd wd
+        | wd == "." = projectRoot
+        | isAbsolute wd = wd
+        | otherwise = projectRoot </> wd
+    isUnderAnyWatchDir file
+        | not (isAbsolute file) && not ("./" `isPrefixOf` file) = False
+        | isAbsolute file =
+            any (\wd -> (wd ++ "/") `isPrefixOf` file || wd == file) absWatchDirs
+        | otherwise =
+            let absFile = projectRoot </> drop 2 file
+            in  any (\wd -> (wd ++ "/") `isPrefixOf` absFile || wd == absFile) absWatchDirs

--- a/tricorder/src/Tricorder/Builder/Dispatch.hs
+++ b/tricorder/src/Tricorder/Builder/Dispatch.hs
@@ -1,12 +1,13 @@
 module Tricorder.Builder.Dispatch
     ( BuilderState (..)
     , DiagnosticMap
+    , DispatchAction (..)
     , KnownTargetNames (..)
+    , dispatch
     , emptyBuilderState
     , fileMatchesAnyTarget
     , filterToWatchDirs
     , mergeDiagnostics
-    , resolveKnownTargets
     ) where
 
 import Data.Default (Default (..))
@@ -15,6 +16,7 @@ import System.FilePath (isAbsolute, (</>))
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 
+import Atelier.Effects.FileWatcher (FileEvent (..))
 import Tricorder.BuildState (Diagnostic (..))
 import Tricorder.Effects.GhciSession (LoadResult (..), LoadedModule (..))
 import Tricorder.Effects.GhciSession.GhciParser (pathSuffixesAsModuleName)
@@ -28,8 +30,6 @@ data BuilderState = BuilderState
     { loadedModules :: Map FilePath LoadedModule
     , knownTargets :: KnownTargetNames
     , diagnosticMap :: DiagnosticMap
-    -- ^ Named 'diagnosticMap' (not 'diagnostics') to avoid 'DuplicateRecordFields'
-    -- collisions with 'LoadResult' and 'BuildResult'.
     }
     deriving stock (Eq, Show)
 
@@ -63,29 +63,6 @@ mergeDiagnostics prev LoadResult {compiledFiles, diagnostics} =
     in  Map.union newByFile cleared
 
 
--- | Path↔module-name map for the next cycle: this round's @:show modules@
--- plus carryover from @prev@ for targets that failed mid-session and so
--- dropped out. Never-compiled targets are absent here (no path↔name
--- mapping); the dispatcher recognises those via 'KnownTargetNames'.
-resolveKnownTargets
-    :: Map FilePath LoadedModule
-    -- ^ Previous known-targets map (carryover source).
-    -> LoadResult
-    -> Map FilePath LoadedModule
-resolveKnownTargets prev lr =
-    let primary = lr.loadedModules
-        primaryNames = Set.fromList [lm.moduleName | lm <- Map.elems primary]
-        prevByName = Map.fromList [(lm.moduleName, (path, lm)) | (path, lm) <- Map.toList prev]
-        carryover =
-            Map.fromList
-                [ (path, lm)
-                | name <- lr.targetNames
-                , not (Set.member name primaryNames)
-                , Just (path, lm) <- [Map.lookup name prevByName]
-                ]
-    in  Map.union primary carryover
-
-
 -- | GHCi's current target set, as raw entries from @:show targets@
 -- (typically dotted module names under @cabal repl --enable-multi-repl@).
 -- Survives every compile failure mode, so the dispatcher can recognise a
@@ -98,6 +75,42 @@ newtype KnownTargetNames = KnownTargetNames {unKnownTargetNames :: Set Text}
 fileMatchesAnyTarget :: KnownTargetNames -> FilePath -> Bool
 fileMatchesAnyTarget (KnownTargetNames targets) fp =
     any (`Set.member` targets) (pathSuffixesAsModuleName fp)
+
+
+-- | A GHCi command to issue in response to a source file change.
+data DispatchAction
+    = Reload
+    | Add FilePath
+    | Unadd Text
+    deriving stock (Eq, Show)
+
+
+-- | Decide what GHCi action a source-file change requires.
+--
+-- The path-keyed module map misses targets that failed on first load,
+-- so we fall back to 'KnownTargetNames' for those — otherwise we would
+-- issue @:add@ (a no-op for an already-tracked cabal target), leaving
+-- stale diagnostics in place.
+dispatch
+    :: KnownTargetNames
+    -> Maybe LoadedModule
+    -> FilePath
+    -> FileEvent
+    -> Maybe DispatchAction
+dispatch knownTargets known fp event = case known of
+    Just lm -> Just $ case event of
+        Added -> Reload
+        Modified -> Reload
+        Removed -> Unadd lm.moduleName
+    Nothing
+        | fileMatchesAnyTarget knownTargets fp -> case event of
+            Added -> Just Reload
+            Modified -> Just Reload
+            Removed -> Nothing
+        | otherwise -> case event of
+            Added -> Just (Add fp)
+            Modified -> Just (Add fp)
+            Removed -> Nothing
 
 
 -- | Keep only diagnostics whose file is under one of the watched directories.

--- a/tricorder/src/Tricorder/Builder/Dispatch.hs
+++ b/tricorder/src/Tricorder/Builder/Dispatch.hs
@@ -7,14 +7,14 @@ module Tricorder.Builder.Dispatch
     , resolveKnownTargets
     ) where
 
-import System.FilePath (dropExtension, isAbsolute, normalise, splitDirectories, (</>))
+import System.FilePath (isAbsolute, (</>))
 
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
-import Data.Text qualified as T
 
 import Tricorder.BuildState (Diagnostic (..))
 import Tricorder.Effects.GhciSession (LoadResult (..), LoadedModule (..))
+import Tricorder.Effects.GhciSession.GhciParser (pathSuffixesAsModuleName)
 
 
 type DiagnosticMap = Map FilePath [Diagnostic]
@@ -65,26 +65,9 @@ newtype KnownTargetNames = KnownTargetNames {unKnownTargetNames :: Set Text}
 
 
 -- | Whether a file path corresponds to one of GHCi's targets.
---
--- We can't convert dotted target names to paths without cabal's
--- source-dirs, so we check the other direction: any uppercase-segment
--- suffix of the path (with @/@ → @.@, extension dropped) that equals a
--- target name is a match. E.g. @./tricorder/src/Tricorder/Version.hs@
--- yields candidates @"Tricorder.Version"@ and @"Version"@.
 fileMatchesAnyTarget :: KnownTargetNames -> FilePath -> Bool
 fileMatchesAnyTarget (KnownTargetNames targets) fp =
     any (`Set.member` targets) (pathSuffixesAsModuleName fp)
-
-
-pathSuffixesAsModuleName :: FilePath -> [Text]
-pathSuffixesAsModuleName fp =
-    let segments = filter (not . null) (splitDirectories (dropExtension (normalise fp)))
-        upperSegments = dropWhile (not . startsUpper) segments
-        suffixes = takeWhile (not . null) (iterate (drop 1) upperSegments)
-    in  [T.intercalate "." (map toText s) | s <- suffixes]
-  where
-    startsUpper (c : _) = c >= 'A' && c <= 'Z'
-    startsUpper _ = False
 
 
 -- | Keep only diagnostics whose file is under one of the watched directories.

--- a/tricorder/src/Tricorder/Builder/Dispatch.hs
+++ b/tricorder/src/Tricorder/Builder/Dispatch.hs
@@ -1,12 +1,15 @@
 module Tricorder.Builder.Dispatch
-    ( DiagnosticMap
+    ( BuilderState (..)
+    , DiagnosticMap
     , KnownTargetNames (..)
+    , emptyBuilderState
     , fileMatchesAnyTarget
     , filterToWatchDirs
     , mergeDiagnostics
     , resolveKnownTargets
     ) where
 
+import Data.Default (Default (..))
 import System.FilePath (isAbsolute, (</>))
 
 import Data.Map.Strict qualified as Map
@@ -15,6 +18,33 @@ import Data.Set qualified as Set
 import Tricorder.BuildState (Diagnostic (..))
 import Tricorder.Effects.GhciSession (LoadResult (..), LoadedModule (..))
 import Tricorder.Effects.GhciSession.GhciParser (pathSuffixesAsModuleName)
+
+
+-- | The Builder's per-GHCi-session cache: what it last saw from GHCi plus its
+-- accumulated diagnostics. Reset on every GHCi restart in
+-- @buildWithGhciOnChange@; 'BuildId' is intentionally /not/ here because it
+-- counts across restarts.
+data BuilderState = BuilderState
+    { loadedModules :: Map FilePath LoadedModule
+    , knownTargets :: KnownTargetNames
+    , diagnosticMap :: DiagnosticMap
+    -- ^ Named 'diagnosticMap' (not 'diagnostics') to avoid 'DuplicateRecordFields'
+    -- collisions with 'LoadResult' and 'BuildResult'.
+    }
+    deriving stock (Eq, Show)
+
+
+instance Default BuilderState where
+    def = emptyBuilderState
+
+
+emptyBuilderState :: BuilderState
+emptyBuilderState =
+    BuilderState
+        { loadedModules = mempty
+        , knownTargets = KnownTargetNames mempty
+        , diagnosticMap = mempty
+        }
 
 
 type DiagnosticMap = Map FilePath [Diagnostic]

--- a/tricorder/src/Tricorder/Daemon/Main.hs
+++ b/tricorder/src/Tricorder/Daemon/Main.hs
@@ -36,6 +36,7 @@ import Atelier.Effects.Cache.Config qualified as CacheConfig
 import Atelier.Effects.Log qualified as Log
 import Tricorder.BuildState qualified as BuildState
 import Tricorder.Builder qualified as Builder
+import Tricorder.Builder.Dispatch qualified as Builder
 import Tricorder.Effects.SessionStore qualified as SessionStore
 import Tricorder.GhcPkg.Types qualified as GhcPkg
 import Tricorder.Observability qualified as Observability

--- a/tricorder/src/Tricorder/Daemon/Main.hs
+++ b/tricorder/src/Tricorder/Daemon/Main.hs
@@ -25,7 +25,7 @@ import Tricorder.BuildState (BuildId (..), runDaemonInfo)
 import Tricorder.Config (restartOnConfigChange, runLoadedConfig)
 import Tricorder.Effects.BuildStore (runBuildStore)
 import Tricorder.Effects.GhcPkg (runGhcPkgIO)
-import Tricorder.Effects.GhciSession (LoadedModule, runGhciSession)
+import Tricorder.Effects.GhciSession (runGhciSession)
 import Tricorder.Effects.Logging (runLogging)
 import Tricorder.Effects.SessionStore (runSessionStore)
 import Tricorder.Effects.TestRunner (runTestRunnerIO)
@@ -36,7 +36,7 @@ import Atelier.Effects.Cache.Config qualified as CacheConfig
 import Atelier.Effects.Log qualified as Log
 import Tricorder.BuildState qualified as BuildState
 import Tricorder.Builder qualified as Builder
-import Tricorder.Builder.Dispatch qualified as Builder
+import Tricorder.Builder.Dispatch qualified as Dispatch
 import Tricorder.Effects.SessionStore qualified as SessionStore
 import Tricorder.GhcPkg.Types qualified as GhcPkg
 import Tricorder.Observability qualified as Observability
@@ -92,9 +92,7 @@ main =
         . runUnixSocketIO
         . runGhciSession
         . evalState (BuildId 1)
-        . evalState @Builder.DiagnosticMap mempty
-        . evalState @(Map FilePath LoadedModule) mempty
-        . evalState @Builder.KnownTargetNames (Builder.KnownTargetNames mempty)
+        . evalState @Dispatch.BuilderState Dispatch.emptyBuilderState
         $ do
             Log.info $ "Starting tricorder " <> Version.gitHash
             runSystem

--- a/tricorder/src/Tricorder/Effects/GhciSession.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession.hs
@@ -11,9 +11,6 @@ module Tricorder.Effects.GhciSession
       -- * Interpreters
     , runGhciSession
     , runGhciSessionScripted
-
-      -- * Parsing utilities
-    , extractTitle
     ) where
 
 import Data.Default (def)
@@ -46,7 +43,6 @@ import Tricorder.Effects.GhciSession.GhciParser
     ( GhciLoading (..)
     , LoadResult (..)
     , LoadedModule (..)
-    , extractTitle
     )
 import Tricorder.Effects.GhciSession.GhciProcess (addGhci, collectGhciResult, interruptGhci, reloadGhci, unaddGhci, withGhciProcess)
 import Tricorder.Runtime (ProjectRoot (..))

--- a/tricorder/src/Tricorder/Effects/GhciSession/GhciParser.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession/GhciParser.hs
@@ -11,6 +11,7 @@ module Tricorder.Effects.GhciSession.GhciParser
     , parseShowModules
     , parseShowTargets
     , pathSuffixesAsModuleName
+    , resolveKnownTargets
     , stripAnsi
     , extractTitle
     , toAbsolute
@@ -469,6 +470,29 @@ collectResultCustom projectRoot loads modules targets =
             , targetNames = targets
             , diagnostics = toDiagnostics rel loads
             }
+
+
+-- | Path↔module-name map for the next cycle: this round's @:show modules@
+-- plus carryover from @prev@ for targets that failed mid-session and so
+-- dropped out. Never-compiled targets are absent here (no path↔name
+-- mapping); the dispatcher recognises those via 'KnownTargetNames'.
+resolveKnownTargets
+    :: Map FilePath LoadedModule
+    -- ^ Previous known-targets map (carryover source).
+    -> LoadResult
+    -> Map FilePath LoadedModule
+resolveKnownTargets prev lr =
+    let primary = lr.loadedModules
+        primaryNames = Set.fromList [lm.moduleName | lm <- Map.elems primary]
+        prevByName = Map.fromList [(lm.moduleName, (path, lm)) | (path, lm) <- Map.toList prev]
+        carryover =
+            Map.fromList
+                [ (path, lm)
+                | name <- lr.targetNames
+                , not (Set.member name primaryNames)
+                , Just (path, lm) <- [Map.lookup name prevByName]
+                ]
+    in  Map.union primary carryover
 
 
 toDiagnostics :: (FilePath -> FilePath) -> [GhciLoad] -> [BuildState.Diagnostic]

--- a/tricorder/src/Tricorder/Effects/GhciSession/GhciParser.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession/GhciParser.hs
@@ -10,6 +10,7 @@ module Tricorder.Effects.GhciSession.GhciParser
     , parseReload
     , parseShowModules
     , parseShowTargets
+    , pathSuffixesAsModuleName
     , stripAnsi
     , extractTitle
     , toAbsolute
@@ -17,7 +18,7 @@ module Tricorder.Effects.GhciSession.GhciParser
     ) where
 
 import Data.Char (isAlpha, isDigit, isSpace, toLower)
-import System.FilePath (isAbsolute, makeRelative, normalise, splitDirectories, (</>))
+import System.FilePath (dropExtension, isAbsolute, makeRelative, normalise, splitDirectories, (</>))
 import Text.Megaparsec
 import Text.Megaparsec.Char (char, string)
 
@@ -416,6 +417,24 @@ toAbsolute :: FilePath -> FilePath -> FilePath
 toAbsolute base path
     | isAbsolute path = path
     | otherwise = base </> path
+
+
+-- | Candidate dotted module names for a file path.
+--
+-- We can't convert dotted target names to paths without cabal's
+-- source-dirs, so callers check the other direction: any uppercase-segment
+-- suffix of the path (with @/@ → @.@, extension dropped) is a candidate.
+-- E.g. @./tricorder/src/Tricorder/Version.hs@ yields candidates
+-- @"Tricorder.Version"@ and @"Version"@.
+pathSuffixesAsModuleName :: FilePath -> [Text]
+pathSuffixesAsModuleName fp =
+    let segments = filter (not . null) (splitDirectories (dropExtension (normalise fp)))
+        upperSegments = dropWhile (not . startsUpper) segments
+        suffixes = takeWhile (not . null) (iterate (drop 1) upperSegments)
+    in  [T.intercalate "." (map toText s) | s <- suffixes]
+  where
+    startsUpper (c : _) = c >= 'A' && c <= 'Z'
+    startsUpper _ = False
 
 
 -- | Strip ANSI escape sequences of the form @ESC [ \<params\> \<letter\>@.

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -49,7 +49,9 @@ import Tricorder.Builder
     , setNewPhase
     )
 import Tricorder.Builder.Dispatch
-    ( KnownTargetNames (..)
+    ( BuilderState (..)
+    , KnownTargetNames (..)
+    , emptyBuilderState
     , fileMatchesAnyTarget
     , filterToWatchDirs
     , mergeDiagnostics
@@ -257,8 +259,11 @@ testReloadOnSourceChange = do
             . runConcurrent
             . runClockConst epoch
             . evalState (BuildId 1)
-            . evalState @(Map FilePath LoadedModule) initialModuleMap
-            . evalState @KnownTargetNames initialTargets
+            . evalState @BuilderState
+                emptyBuilderState
+                    { loadedModules = initialModuleMap
+                    , knownTargets = initialTargets
+                    }
             . runLogNoOp
             . runWriter
             . runPubWriter @EnteringNewPhase
@@ -388,13 +393,15 @@ testCompileLoadResultsIntoBuildResults = do
                     }
         rs `shouldMatchList` [expected]
   where
-    runTest acc =
-        runPureEff
-            . runWriter
-            . runPubWriter
-            . runReader (ProjectRoot "/")
-            . execState acc
-            . compileLoadResultsIntoBuildResults (def {Builder.watchDirs = ["/src"]})
+    runTest acc nlr =
+        let (st, rs) =
+                runPureEff
+                    . runWriter
+                    . runPubWriter
+                    . runReader (ProjectRoot "/")
+                    . execState (emptyBuilderState {diagnosticMap = acc})
+                    $ compileLoadResultsIntoBuildResults (def {Builder.watchDirs = ["/src"]}) nlr
+        in  (st.diagnosticMap, rs)
 
 
 testRequestTestRunsForNewBuildResults :: Spec

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -55,9 +55,9 @@ import Tricorder.Builder.Dispatch
     , fileMatchesAnyTarget
     , filterToWatchDirs
     , mergeDiagnostics
-    , resolveKnownTargets
     )
-import Tricorder.Effects.GhciSession (Controls (..), LoadResult (..), LoadedModule (..), extractTitle)
+import Tricorder.Effects.GhciSession (Controls (..), LoadResult (..), LoadedModule (..))
+import Tricorder.Effects.GhciSession.GhciParser (extractTitle, resolveKnownTargets)
 import Tricorder.Effects.SessionStore
     ( SessionStore (..)
     , SessionStoreReloaded (..)
@@ -259,7 +259,7 @@ testReloadOnSourceChange = do
             . runConcurrent
             . runClockConst epoch
             . evalState (BuildId 1)
-            . evalState @BuilderState
+            . evalState
                 emptyBuilderState
                     { loadedModules = initialModuleMap
                     , knownTargets = initialTargets
@@ -394,14 +394,13 @@ testCompileLoadResultsIntoBuildResults = do
         rs `shouldMatchList` [expected]
   where
     runTest acc nlr =
-        let (st, rs) =
-                runPureEff
-                    . runWriter
-                    . runPubWriter
-                    . runReader (ProjectRoot "/")
-                    . execState (emptyBuilderState {diagnosticMap = acc})
-                    $ compileLoadResultsIntoBuildResults (def {Builder.watchDirs = ["/src"]}) nlr
-        in  (st.diagnosticMap, rs)
+        first (.diagnosticMap)
+            . runPureEff
+            . runWriter
+            . runPubWriter
+            . runReader (ProjectRoot "/")
+            . execState (emptyBuilderState {diagnosticMap = acc})
+            $ compileLoadResultsIntoBuildResults (def {Builder.watchDirs = ["/src"]}) nlr
 
 
 testRequestTestRunsForNewBuildResults :: Spec

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -41,17 +41,19 @@ import Tricorder.BuildState
     )
 import Tricorder.Builder
     ( BuilderSession (..)
-    , KnownTargetNames (..)
     , NewLoadResult (..)
     , compileLoadResultsIntoBuildResults
-    , fileMatchesAnyTarget
-    , filterToWatchDirs
-    , mergeDiagnostics
     , onRestart
     , reloadOnSourceChange
     , requestTestRunsForNewBuildResults
-    , resolveKnownTargets
     , setNewPhase
+    )
+import Tricorder.Builder.Dispatch
+    ( KnownTargetNames (..)
+    , fileMatchesAnyTarget
+    , filterToWatchDirs
+    , mergeDiagnostics
+    , resolveKnownTargets
     )
 import Tricorder.Effects.GhciSession (Controls (..), LoadResult (..), LoadedModule (..), extractTitle)
 import Tricorder.Effects.SessionStore


### PR DESCRIPTION
A series of small refactors that trim `Tricorder.Builder`. No behaviour changes.

## Commits

### `9e44f71` — `refactor: extract pure helpers into Builder.Dispatch`

Moves `DiagnosticMap`, `mergeDiagnostics`, `KnownTargetNames`, `resolveKnownTargets`, `fileMatchesAnyTarget`, `pathSuffixesAsModuleName`, and `filterToWatchDirs` out of `Tricorder.Builder` into a new `Tricorder.Builder.Dispatch` module. Effectful orchestration is no longer interleaved with pure parsing and diagnostic merging.

### `5ed7cc0` — `refactor: move pathSuffixesAsModuleName into GhciParser`

The path → candidate-module-names helper sits more naturally beside the existing `toRelative` / `toAbsolute` / `parseShowModules` family in `GhciParser` than in `Builder.Dispatch`. `fileMatchesAnyTarget` stays in `Dispatch` (a Builder concept) and now imports the helper directly from the parser module.

### `641a38b` — `docs: clarify BuildState as shared wire vocabulary`

Adds a module-level haddock to `Tricorder.BuildState` explaining that it is the serialised vocabulary shared across the daemon, socket layer, CLI, UI, and external clients — not a home for component-internal caches. Anchors the ownership rule used by the next commit.

### `5d0f25f` — `refactor: bundle Builder's session-scoped state into BuilderState`

The Builder kept three separate `State` effects (`Map FilePath LoadedModule`, `KnownTargetNames`, `DiagnosticMap`) that all share the same lifetime — reset on every GHCi restart. Bundles them into one `BuilderState` record, collapsing three constraints into one across `component`, `restartableListeners`, `buildWithGhciOnChange`, `rebuildOnChange`, `handleSourceChanges`, `reloadOnSourceChange`, and `compileLoadResultsIntoBuildResults`, and turning three `put`s into a single `modify`. `BuildId` stays separate because it counts across restarts.

The `diagnostics` field is renamed to `diagnosticMap` to avoid `DuplicateRecordFields` collisions with `LoadResult.diagnostics` and `BuildResult.diagnostics`.
