### PR TITLE
fix: stream GHCi build progress live to the UI

### DIFF
--- a/tricorder/src/Tricorder/BuildState.hs
+++ b/tricorder/src/Tricorder/BuildState.hs
@@ -135,7 +135,7 @@ data TestRunCompletion = TestRunCompletion
 
 
 data TestRun
-    = TestRunning Text
+    = TestRunning Text (Maybe BuildProgress)
     | TestRunErrored TestRunError
     | TestRunCompleted TestRunCompletion
     deriving stock (Eq, Generic, Show)

--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -489,11 +489,11 @@ runTestsIfClean (BuilderSession {testTargets}) bid partialResult
         TestRunner.resetAbort
         publish
             $ EnteringNewPhase bid
-            $ Testing partialResult {testRuns = map TestRunning testTargets}
+            $ Testing partialResult {testRuns = map (`TestRunning` Nothing) testTargets}
 
         Log.info $ "Running " <> show (length testTargets) <> " test suite(s)"
 
-        let initial = (\t -> (t, TestRunning t)) <$> testTargets
+        let initial = (\t -> (t, TestRunning t Nothing)) <$> testTargets
         runLoop initial testTargets
   where
     runLoop acc [] = pure (Just (snd <$> acc))

--- a/tricorder/src/Tricorder/CLI.hs
+++ b/tricorder/src/Tricorder/CLI.hs
@@ -29,6 +29,7 @@ import Tricorder.Arguments
     )
 import Tricorder.BuildState
     ( BuildPhase (..)
+    , BuildProgress (..)
     , BuildResult (..)
     , BuildState (..)
     , Diagnostic (..)
@@ -122,7 +123,8 @@ showStatus opts = do
 
     printTestRun verbosity tr = do
         Console.putTextLn $ case tr of
-            TestRunning t -> t <> "  running..."
+            TestRunning t Nothing -> t <> "  running..."
+            TestRunning t (Just p) -> t <> "  running... (" <> show p.compiled <> "/" <> show p.total <> ")"
             TestRunErrored e -> e.target <> "  error: " <> e.message
             TestRunCompleted c -> c.target <> "  " <> completionSummary c
         when (verbosity == Verbose) $ case tr of
@@ -135,7 +137,7 @@ showStatus opts = do
       where
         isFailedRun (TestRunCompleted c) = not c.passed
         isFailedRun (TestRunErrored _) = True
-        isFailedRun (TestRunning _) = False
+        isFailedRun (TestRunning _ _) = False
 
     buildSummary tz r =
         let errs = length $ filter ((== SError) . (.severity)) r.diagnostics
@@ -219,15 +221,17 @@ showTests opts = do
 
     isFailed (TestRunCompleted c) = not c.passed
     isFailed (TestRunErrored _) = True
-    isFailed (TestRunning _) = False
+    isFailed (TestRunning _ _) = False
 
-    testRunTarget (TestRunning t) = t
+    testRunTarget (TestRunning t _) = t
     testRunTarget (TestRunErrored e) = e.target
     testRunTarget (TestRunCompleted c) = c.target
 
     printTestOutput tr = case tr of
-        TestRunning t ->
+        TestRunning t Nothing ->
             Console.putTextLn $ t <> "  running..."
+        TestRunning t (Just p) ->
+            Console.putTextLn $ t <> "  running... (" <> show p.compiled <> "/" <> show p.total <> ")"
         TestRunErrored e ->
             Console.putTextLn $ e.target <> "  error: " <> e.message
         TestRunCompleted c -> do

--- a/tricorder/src/Tricorder/Daemon/Main.hs
+++ b/tricorder/src/Tricorder/Daemon/Main.hs
@@ -84,10 +84,10 @@ main =
         . runPubSub @BuildState.EnteringNewPhase
         . runDaemonInfo
         . runLogging
-        . runTestRunnerIO
         . runCacheTtl @GhcPkg.ModuleName @GhcPkg.PackageId
         . runCacheTtl @(GhcPkg.PackageId, GhcPkg.SourceQuery) @(Text, [SourceLookup.ReExport])
         . runBuildStore
+        . runTestRunnerIO
         . runGhcPkgIO
         . runUnixSocketIO
         . runGhciSession

--- a/tricorder/src/Tricorder/Effects/GhciSession.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession.hs
@@ -110,18 +110,18 @@ runGhciSession
        )
     => Eff (GhciSession : es) a -> Eff es a
 runGhciSession = interpret $ \env -> \case
-    WithGhci cmd (ProjectRoot dir) handler ->
-        withGhciProcess def cmd dir \process startupLines ->
+    WithGhci cmd (ProjectRoot dir) handler -> do
+        let onProgress loading = do
+                buildState <- getState
+                setPhase buildState.buildId
+                    $ Building
+                    $ Just
+                    $ BuildProgress {compiled = loading.index, total = loading.total}
+        withGhciProcess def cmd dir onProgress \process startupLines ->
             localLift env (ConcUnlift Persistent Unlimited) \liftEff ->
                 localUnlift env (ConcUnlift Persistent Unlimited) \unlift -> do
-                    let onProgress loading = do
-                            buildState <- getState
-                            setPhase buildState.buildId
-                                $ Building
-                                $ Just
-                                $ BuildProgress {compiled = loading.index, total = loading.total}
-                        doReload = liftEff $ reloadGhci process dir onProgress
-                    initialResult <- unlift $ liftEff $ collectGhciResult process startupLines dir onProgress
+                    let doReload = liftEff $ reloadGhci process dir onProgress
+                    initialResult <- unlift $ liftEff $ collectGhciResult process startupLines dir
                     unlift
                         $ handler
                             initialResult

--- a/tricorder/src/Tricorder/Effects/GhciSession/GhciParser.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession/GhciParser.hs
@@ -7,6 +7,7 @@ module Tricorder.Effects.GhciSession.GhciParser
     , LoadedModule (..)
     , Position (..)
     , collectResultCustom
+    , parseProgressLine
     , parseReload
     , parseShowModules
     , parseShowTargets
@@ -313,6 +314,21 @@ reloadItem =
         , -- Fallback: skip any other line
           fmap (const Nothing) anySingle
         ]
+
+
+-- | Parse a single line as a "[N of M] Compiling …" progress event.
+--
+-- Returns 'Nothing' for any line that is not a loading line. Used to stream
+-- progress updates as GHCi emits them, rather than parsing the whole reload
+-- output after the fact.
+parseProgressLine :: Text -> Maybe GhciLoading
+parseProgressLine line =
+    let stripped = stripAnsi line
+    in  if "[" `T.isPrefixOf` stripped then case runTP loadingLineP stripped of
+            Just (GLoading l) -> Just l
+            _ -> Nothing
+        else
+            Nothing
 
 
 -- | Parse a "[N of M] Compiling Mod ( file, ... )" loading line.

--- a/tricorder/src/Tricorder/Effects/GhciSession/GhciProcess.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession/GhciProcess.hs
@@ -45,10 +45,10 @@ import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.File (File)
 import Atelier.Effects.Timeout (Timeout, timeout)
 import Tricorder.Effects.GhciSession.GhciParser
-    ( GhciLoad (..)
-    , GhciLoading (..)
+    ( GhciLoading (..)
     , LoadResult (..)
     , collectResultCustom
+    , parseProgressLine
     , parseReload
     , parseShowModules
     , parseShowTargets
@@ -115,8 +115,15 @@ startGhciProcess
        , IOE :> es
        , Timeout :> es
        )
-    => Config -> Text -> FilePath -> Eff es (GhciProcess, [Text])
-startGhciProcess config cmd dir = do
+    => Config
+    -> Text
+    -> FilePath
+    -> (GhciLoading -> Eff es ())
+    -- ^ Called as each @[N of M] Compiling …@ line is streamed during the
+    -- initial-build drain, so the UI can update the progress bar live
+    -- instead of replaying everything once compilation finishes.
+    -> Eff es (GhciProcess, [Text])
+startGhciProcess config cmd dir onProgress = do
     p <-
         liftIO
             $ startProcess
@@ -166,12 +173,15 @@ startGhciProcess config cmd dir = do
 
     -- Sync: drain until marker 1 seen, then set counter to 2.
     -- Capture lines from both streams — the stderr output contains the initial
-    -- compilation progress and any startup diagnostics.
+    -- compilation progress and any startup diagnostics. The line hook fires
+    -- 'onProgress' for each "[N of M] Compiling …" line as it arrives, so the
+    -- UI can update the progress bar live during the initial build.
     let marker1 = markerFor 1
+        hook = progressLineHook onProgress
     sendSyncCommand inp marker1
     initialLines <- Conc.scoped do
-        stdoutThread <- Conc.fork $ drainUntil out marker1
-        stderrThread <- Conc.fork $ drainUntil err marker1
+        stdoutThread <- Conc.fork $ drainUntil out marker1 hook
+        stderrThread <- Conc.fork $ drainUntil err marker1 hook
         stdoutLines <- Conc.await stdoutThread
         stderrLines <- Conc.await stderrThread
         pure (stdoutLines ++ stderrLines)
@@ -184,30 +194,36 @@ startGhciProcess config cmd dir = do
 --
 -- The action receives both the process handle and the output lines captured
 -- during the startup sync (stdout ++ stderr). These lines contain the initial
--- compilation progress and any startup diagnostics.
+-- compilation progress and any startup diagnostics. The @onProgress@ callback
+-- fires for each @[N of M] Compiling …@ line as GHCi emits it during the
+-- initial build, so the UI can update its progress bar in real time.
 withGhciProcess
     :: (Conc :> es, Concurrent :> es, File :> es, IOE :> es, Timeout :> es)
     => Config
     -> Text
     -> FilePath
+    -> (GhciLoading -> Eff es ())
     -> (GhciProcess -> [Text] -> Eff es a)
     -> Eff es a
-withGhciProcess config cmd dir action =
+withGhciProcess config cmd dir onProgress action =
     bracket
-        (startGhciProcess config cmd dir)
+        (startGhciProcess config cmd dir onProgress)
         (stopGhciProcess config . fst)
         (uncurry action)
 
 
--- | Execute a command in GHCi and return the combined stdout+stderr output lines.
+-- | Execute a command in GHCi and return the combined stdout+stderr output
+-- lines. The @onProgress@ callback fires for each @[N of M] Compiling …@ line
+-- as it arrives, so reload/add/unadd progress is streamed live to the UI.
+-- Pass @\\_ -> pure ()@ for commands that do not trigger compilation.
 execGhci
     :: ( Conc :> es
        , Concurrent :> es
        , File :> es
        , IOE :> es
        )
-    => GhciProcess -> Text -> Eff es [Text]
-execGhci ghciProcess command = do
+    => GhciProcess -> Text -> (GhciLoading -> Eff es ()) -> Eff es [Text]
+execGhci ghciProcess command onProgress = do
     n <- atomically do
         readTVar ghciProcess.stateVar >>= \case
             Idle n -> writeTVar ghciProcess.stateVar (Busy n) $> n
@@ -216,12 +232,13 @@ execGhci ghciProcess command = do
   where
     doExec n = do
         let marker = markerFor n
+            hook = progressLineHook onProgress
         liftIO $ TIO.hPutStrLn ghciProcess.stdin command
         File.hFlush ghciProcess.stdin
         sendSyncCommand ghciProcess.stdin marker
         (stdoutLines, stderrLines) <- do
-            stdoutThread <- Conc.fork $ drainUntil ghciProcess.stdout marker
-            stderrThread <- Conc.fork $ drainUntil ghciProcess.stderr marker
+            stdoutThread <- Conc.fork $ drainUntil ghciProcess.stdout marker hook
+            stderrThread <- Conc.fork $ drainUntil ghciProcess.stderr marker hook
             (,) <$> Conc.await stdoutThread <*> Conc.await stderrThread
         pure (stdoutLines ++ stderrLines)
 
@@ -297,11 +314,13 @@ sendSyncCommand h marker = do
 -- | Read lines from a handle until any finish marker is seen (or EOF).
 --
 -- Stops on any line containing the marker prefix, so an interrupt that writes
--- a later marker will unblock a drain waiting for an earlier one.
+-- a later marker will unblock a drain waiting for an earlier one. Each
+-- non-marker line is passed to @onLine@ as it arrives, so callers can stream
+-- progress without waiting for the full drain to complete.
 -- Returns accumulated non-marker lines in order. Throws 'UnexpectedExit' on
 -- EOF before a marker is seen.
-drainUntil :: (File :> es) => Handle -> Text -> Eff es [Text]
-drainUntil h command = go []
+drainUntil :: (File :> es) => Handle -> Text -> (Text -> Eff es ()) -> Eff es [Text]
+drainUntil h command onLine = go []
   where
     go acc = do
         result <- try @E.IOException $ File.hGetLine h
@@ -311,8 +330,15 @@ drainUntil h command = go []
             Right line ->
                 if markerPrefix `T.isInfixOf` line then
                     pure (reverse acc)
-                else
+                else do
+                    onLine line
                     go (line : acc)
+
+
+-- | Convert a 'GhciLoading' progress callback into a per-line hook suitable
+-- for 'drainUntil'. Non-progress lines are ignored.
+progressLineHook :: (GhciLoading -> Eff es ()) -> Text -> Eff es ()
+progressLineHook onProgress line = traverse_ onProgress (parseProgressLine line)
 
 
 -- | Wait up to the given number of seconds for a GHCi version banner on the
@@ -346,21 +372,22 @@ waitForBanner delay h = do
                     go
 
 
--- | Parse GHCi output lines into a 'LoadResult', fetching the current module
--- list via @:show modules@. Emits a progress callback for each
--- @[N of M] Compiling …@ line.
+-- | Parse already-drained GHCi output lines into a 'LoadResult', fetching the
+-- current module list via @:show modules@.
+--
+-- Progress is emitted live by 'drainUntil' as lines arrive, so no replay
+-- callback is needed here — this function only assembles the final result.
 collectGhciResult
     :: (Conc :> es, Concurrent :> es, File :> es, IOE :> es)
     => GhciProcess
     -> [Text]
     -> FilePath
-    -> (GhciLoading -> Eff es ())
     -> Eff es LoadResult
-collectGhciResult process lines' projectRoot onProgress = do
+collectGhciResult process lines' projectRoot = do
     let loads = parseReload lines'
-    for_ [l | GLoading l <- loads] onProgress
-    moduleLines <- execGhci process ":show modules"
-    targetLines <- execGhci process ":show targets"
+        noProgress = \_ -> pure ()
+    moduleLines <- execGhci process ":show modules" noProgress
+    targetLines <- execGhci process ":show targets" noProgress
     pure
         $ collectResultCustom
             projectRoot
@@ -369,8 +396,8 @@ collectGhciResult process lines' projectRoot onProgress = do
             (parseShowTargets targetLines)
 
 
--- | Execute @:reload@ and return the assembled 'LoadResult', emitting a
--- progress callback for each @[N of M] Compiling …@ line.
+-- | Execute @:reload@ and return the assembled 'LoadResult'. Progress events
+-- fire live via @onProgress@ as each @[N of M] Compiling …@ line is read.
 reloadGhci
     :: (Conc :> es, Concurrent :> es, File :> es, IOE :> es)
     => GhciProcess
@@ -378,12 +405,12 @@ reloadGhci
     -> (GhciLoading -> Eff es ())
     -> Eff es LoadResult
 reloadGhci process projectRoot onProgress = do
-    reloadLines <- execGhci process ":reload"
-    collectGhciResult process reloadLines projectRoot onProgress
+    reloadLines <- execGhci process ":reload" onProgress
+    collectGhciResult process reloadLines projectRoot
 
 
--- | Execute @:add@ for the given file and return the assembled 'LoadResult',
--- emitting a progress callback for each @[N of M] Compiling …@ line.
+-- | Execute @:add@ for the given file and return the assembled 'LoadResult'.
+-- Progress events fire live via @onProgress@ as compilation proceeds.
 addGhci
     :: (Conc :> es, Concurrent :> es, File :> es, IOE :> es)
     => GhciProcess
@@ -392,12 +419,13 @@ addGhci
     -> (GhciLoading -> Eff es ())
     -> Eff es LoadResult
 addGhci process filePath projectRoot onProgress = do
-    addLines <- execGhci process (":add " <> T.pack filePath)
-    collectGhciResult process addLines projectRoot onProgress
+    addLines <- execGhci process (":add " <> T.pack filePath) onProgress
+    collectGhciResult process addLines projectRoot
 
 
--- | Execute @:unadd@ for the given module and return the assembled 'LoadResult',
--- emitting a progress callback for each @[N of M] Compiling …@ line.
+-- | Execute @:unadd@ for the given module and return the assembled
+-- 'LoadResult'. Progress events fire live via @onProgress@ as compilation
+-- proceeds.
 unaddGhci
     :: (Conc :> es, Concurrent :> es, File :> es, IOE :> es)
     => GhciProcess
@@ -406,5 +434,5 @@ unaddGhci
     -> (GhciLoading -> Eff es ())
     -> Eff es LoadResult
 unaddGhci process moduleName projectRoot onProgress = do
-    unaddLines <- execGhci process (":unadd " <> moduleName)
-    collectGhciResult process unaddLines projectRoot onProgress
+    unaddLines <- execGhci process (":unadd " <> moduleName) onProgress
+    collectGhciResult process unaddLines projectRoot

--- a/tricorder/src/Tricorder/Effects/TestRunner.hs
+++ b/tricorder/src/Tricorder/Effects/TestRunner.hs
@@ -34,7 +34,17 @@ import Data.Text qualified as T
 import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.File (File)
 import Atelier.Effects.Timeout (Timeout, timeout)
-import Tricorder.BuildState (TestRun (..), TestRunCompletion (..), TestRunError (..))
+import Tricorder.BuildState
+    ( BuildPhase (..)
+    , BuildProgress (..)
+    , BuildResult (..)
+    , BuildState (..)
+    , TestRun (..)
+    , TestRunCompletion (..)
+    , TestRunError (..)
+    )
+import Tricorder.Effects.BuildStore (BuildStore, getState, setPhase)
+import Tricorder.Effects.GhciSession.GhciParser (GhciLoading (..))
 import Tricorder.Effects.GhciSession.GhciProcess (GhciProcess, execGhci, interruptGhci, withGhciProcess)
 import Tricorder.Effects.SessionStore (SessionStore)
 import Tricorder.Runtime (ProjectRoot (..))
@@ -65,7 +75,8 @@ makeEffect ''TestRunner
 -- process for each suite, feeds @:main\\n:quit\\n@ to stdin, captures combined
 -- stdout+stderr, and detects the outcome via 'detectOutcome'.
 runTestRunnerIO
-    :: ( Conc :> es
+    :: ( BuildStore :> es
+       , Conc :> es
        , Concurrent :> es
        , File :> es
        , IOE :> es
@@ -92,14 +103,16 @@ runTestRunnerIO act = do
                 pure $ TestRunErrored $ TestRunError {target, message = "Test run aborted"}
             else do
                 Session {testTimeout} <- SessionStore.get
-                result <- trySync $ withGhciProcess def ("cabal repl " <> target) projectRoot \ghci _ ->
+                let onProgress = reportTestProgress target
+                    noProgress = \_ -> pure ()
+                result <- trySync $ withGhciProcess def ("cabal repl " <> target) projectRoot onProgress \ghci _ ->
                     bracket_
                         (atomically (writeTVar currentProcRef (Just ghci)))
                         (atomically (writeTVar currentProcRef Nothing))
                         $ case testTimeout of
-                            secs | secs <= 0 -> Right <$> execGhci ghci ":main"
+                            secs | secs <= 0 -> Right <$> execGhci ghci ":main" noProgress
                             secs ->
-                                timeout (fromIntegral secs :: Second) (execGhci ghci ":main") >>= \case
+                                timeout (fromIntegral secs :: Second) (execGhci ghci ":main" noProgress) >>= \case
                                     Nothing -> pure (Left secs)
                                     Just ls -> pure (Right ls)
                 pure $ case result of
@@ -145,6 +158,31 @@ runTestRunnerScripted results = reinterpret (evalState results) $ \_ ->
             InterruptCurrent -> pure ()
             ResetAbort -> pure ()
             IsAborted -> pure False
+
+
+-- | Patch live compile progress for a test suite into the current 'Testing'
+-- phase of the build state.
+--
+-- A test suite's @cabal repl@ session typically recompiles a slice of the
+-- project before running @:main@. Mirroring the main-build progress bar, we
+-- update the matching 'TestRunning' entry as each @[N of M] Compiling …@
+-- line arrives so the UI shows @running... (N/M)@ live.
+--
+-- The update is best-effort: if the phase has moved on (e.g. a source change
+-- triggered 'Restarting' or 'Building'), the progress event is dropped rather
+-- than reverting the phase.
+reportTestProgress
+    :: (BuildStore :> es) => Text -> GhciLoading -> Eff es ()
+reportTestProgress target loading = do
+    state <- getState
+    case state.phase of
+        Testing partialResult ->
+            let progress = BuildProgress {compiled = loading.index, total = loading.total}
+                updateRun (TestRunning t _) | t == target = TestRunning t (Just progress)
+                updateRun r = r
+                newRuns = map updateRun partialResult.testRuns
+            in  setPhase state.buildId (Testing partialResult {testRuns = newRuns})
+        _ -> pure ()
 
 
 data GhciOutcome

--- a/tricorder/src/Tricorder/UI/View.hs
+++ b/tricorder/src/Tricorder/UI/View.hs
@@ -270,7 +270,9 @@ viewTestRuns runs = vBox $ viewTestRun <$> runs
 
 
 viewTestRun :: TestRun -> Widget n
-viewTestRun (TestRunning t) = hBox [txt t, txt "  ", warn $ txt "running..."]
+viewTestRun (TestRunning t Nothing) = hBox [txt t, txt "  ", warn $ txt "running..."]
+viewTestRun (TestRunning t (Just p)) =
+    hBox [txt t, txt "  ", warn $ txt $ "running... (" <> show p.compiled <> "/" <> show p.total <> ")"]
 viewTestRun (TestRunErrored e) = hBox [txt e.target, txt "  ", err $ txt "error: ", txt e.message]
 viewTestRun (TestRunCompleted c) = hBox [txt c.target, txt "  ", viewCompletionStatus c]
 
@@ -373,7 +375,9 @@ scrollableRuns tv runs =
 
 
 viewTestRunDetail :: TestView -> TestRun -> Widget n
-viewTestRunDetail _ (TestRunning t) = hBox [txt t, txt "  ", warn $ txt "running..."]
+viewTestRunDetail _ (TestRunning t Nothing) = hBox [txt t, txt "  ", warn $ txt "running..."]
+viewTestRunDetail _ (TestRunning t (Just p)) =
+    hBox [txt t, txt "  ", warn $ txt $ "running... (" <> show p.compiled <> "/" <> show p.total <> ")"]
 viewTestRunDetail _ (TestRunErrored e) = hBoxSpaced 1 [txt e.target, err $ txt "error:", txt e.message]
 viewTestRunDetail tv (TestRunCompleted c) =
     vBox
@@ -399,11 +403,11 @@ viewTestOutput TestViewFailOnly c
 isFailedRun :: TestRun -> Bool
 isFailedRun (TestRunCompleted c) = not c.passed
 isFailedRun (TestRunErrored _) = True
-isFailedRun (TestRunning _) = False
+isFailedRun (TestRunning _ _) = False
 
 
 testRunTarget :: TestRun -> Text
-testRunTarget (TestRunning t) = t
+testRunTarget (TestRunning t _) = t
 testRunTarget (TestRunErrored e) = e.target
 testRunTarget (TestRunCompleted c) = c.target
 

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -414,12 +414,12 @@ testRequestTestRunsForNewBuildResults = do
         length phases `shouldBe` 4
         let expectedPhases =
                 [ mkTesting . buildWithTests
-                    $ [ TestRunning "test:foo"
-                      , TestRunning "test:bar"
+                    $ [ TestRunning "test:foo" Nothing
+                      , TestRunning "test:bar" Nothing
                       ]
                 , mkTesting . buildWithTests
                     $ [ mkTestRun "test:foo"
-                      , TestRunning "test:bar"
+                      , TestRunning "test:bar" Nothing
                       ]
                 , mkTesting . buildWithTests
                     $ [ mkTestRun "test:foo"


### PR DESCRIPTION
`drainUntil` buffered output until the sync marker, so `[N of M] Compiling` events were replayed in a tight loop after compilation finished — the progress bar jumped from `Building...` to `87/134` to `All good` instead of ticking up.

- Thread a per-line hook through `drainUntil`, `startGhciProcess`, `withGhciProcess`, and `execGhci`, parsing `[N of M]` lines with the existing `loadingLineP` as they arrive.
- Lift `onProgress` above `withGhciProcess` in the `GhciSession` interpreter so the initial-build drain (previously running before any callback was set up) also streams progress.
- Drop the after-the-fact replay in `collectGhciResult`.
- Apply the same treatment to `TestRunner`: `TestRunning` now carries an optional `BuildProgress`, and the interpreter patches the matching entry in the `Testing` phase as each module compiles, so the UI shows `running... (N/M)` per suite. Guards against a stale write if the phase has moved on (e.g. `Restarting` after a source change mid-test).
- Reorder `runTestRunnerIO` below `runBuildStore` in the daemon stack so `BuildStore` is in scope when `TestRunner` interprets.