### PR TITLE
refactor: cancel pending debounce forks via generation check

### DIFF
--- a/atelier/src/Atelier/Effects/Debounce.hs
+++ b/atelier/src/Atelier/Effects/Debounce.hs
@@ -42,12 +42,11 @@ import Effectful.Concurrent.STM qualified as STM
 import StmContainers.Map qualified as Map
 
 import Atelier.Effects.Conc (Conc)
-import Atelier.Effects.Timeout (Timeout, timeout)
+import Atelier.Effects.Delay (Delay)
 import Atelier.Time (Millisecond)
-import Atelier.Types.Semaphore.STM (Semaphore)
 
 import Atelier.Effects.Conc qualified as Conc
-import Atelier.Types.Semaphore.STM qualified as Sem
+import Atelier.Effects.Delay qualified as Delay
 
 
 data Debounce key :: Effect where
@@ -77,7 +76,6 @@ debounced settleMs key action = debouncedWith settleMs (\_ _ -> ()) key () (\_ -
 data Entry = Entry
     { arg :: Maybe Dynamic
     , generation :: Int
-    , cancelled :: Semaphore
     }
 
 
@@ -89,8 +87,8 @@ runDebounce
     :: forall key es a
      . ( Conc :> es
        , Concurrent :> es
+       , Delay :> es
        , Hashable key
-       , Timeout :> es
        )
     => Eff (Debounce key : es) a
     -> Eff es a
@@ -102,31 +100,38 @@ runDebounce eff = do
             localUnlift env (ConcUnlift Persistent (Limited 1)) \unlift ->
                 void
                     $ Conc.fork
-                    $ ensureCallback settleMs entry \arg' -> do
-                        STM.atomically $ Map.delete key state
-                        unlift $ callback arg'
+                    $ ensureCallback settleMs state key entry.generation
+                    $ unlift . callback
 
 
+-- | Sleep for @settleMs@, then atomically check whether this fork's
+-- @generation@ is still the latest in the map for @key@. If yes, take the
+-- (possibly merged) argument, remove the entry, and fire the callback. If a
+-- newer call has bumped the generation in the meantime, exit silently.
 ensureCallback
-    :: forall arg es a
+    :: forall key arg es a
      . ( Concurrent :> es
-       , Timeout :> es
+       , Delay :> es
+       , Hashable key
        , Typeable arg
        )
     => Millisecond
-    -> Entry
+    -> Map.Map key Entry
+    -> key
+    -> Int
     -> (arg -> Eff es a)
     -> Eff es ()
-ensureCallback settleMs entry callback = do
-    res <- timeout settleMs do
-        STM.atomically $ Sem.wait entry.cancelled
-
-    -- If res /= Nothing, then it was cancelled
-    when (res == Nothing) do
-        case fromDynamic =<< entry.arg of
-            Nothing -> pure ()
-            Just arg -> do
-                void $ callback arg
+ensureCallback settleMs state key myGeneration callback = do
+    Delay.wait settleMs
+    fire <- STM.atomically do
+        Map.lookup key state >>= \case
+            Just e | e.generation == myGeneration -> do
+                Map.delete key state
+                pure $ fromDynamic =<< e.arg
+            _ -> pure Nothing
+    case fire of
+        Just arg -> void $ callback arg
+        Nothing -> pure ()
 
 
 ensureEntry
@@ -138,28 +143,17 @@ ensureEntry
     -> STM Entry
 ensureEntry key value state merge = do
     current <- Map.lookup key state
-    entry <- case current of
-        Nothing -> do
-            cancelled <- Sem.new
-            pure
-                $ Entry
-                    { arg = Nothing
-                    , generation = 0
-                    , cancelled
-                    }
-        Just e -> do
-            void $ Sem.set e.cancelled
-            cancelled <- Sem.new
-            pure
-                $ e
-                    { generation = e.generation + 1
-                    , cancelled
-                    }
-    let prior = current >>= (.arg) >>= fromDynamic
+    let (gen, prior) = case current of
+            Nothing -> (0, Nothing)
+            Just e -> (e.generation + 1, e.arg >>= fromDynamic)
     let merged = case prior of
             Just p -> merge p value
             Nothing -> value
-    let updatedEntry = entry {arg = Just (toDyn merged)}
+    let updatedEntry =
+            Entry
+                { arg = Just (toDyn merged)
+                , generation = gen
+                }
     Map.insert updatedEntry key state
     pure updatedEntry
 

--- a/atelier/test/Unit/Atelier/Effects/DebounceSpec.hs
+++ b/atelier/test/Unit/Atelier/Effects/DebounceSpec.hs
@@ -4,7 +4,6 @@ import Control.Concurrent.MVar (modifyMVar_, newMVar, readMVar)
 import Data.Dynamic (fromDynamic, toDyn)
 import Effectful (runEff)
 import Effectful.Concurrent (runConcurrent)
-import Effectful.Concurrent.STM (atomically)
 import Test.Hspec
 
 import Data.IORef qualified as IORef
@@ -21,13 +20,11 @@ import Atelier.Effects.Debounce
     , runDebounce
     )
 import Atelier.Effects.Delay (runDelay)
-import Atelier.Effects.Timeout (runTimeout)
 import Atelier.Time (Millisecond)
 
 import Atelier.Effects.Conc qualified as Conc
 import Atelier.Effects.Console qualified as Console
 import Atelier.Effects.Delay qualified as Delay
-import Atelier.Types.Semaphore.STM qualified as Sem
 
 
 spec_Debounce :: Spec
@@ -50,12 +47,6 @@ testEnsureEntry = do
             entry <- runSTM $ mkEntry 1 42 state (+)
             (entry.arg >>= fromDynamic) `shouldBe` Just @Int 42
 
-        it "starts with empty waiting TMVar" do
-            state <- runSTM Map.new
-            entry <- runSTM $ mkEntry 1 42 state (+)
-            result <- runSTM $ Sem.peek entry.cancelled
-            result `shouldBe` False
-
     describe "existing key" do
         it "increments generation" do
             state <- runSTM Map.new
@@ -68,20 +59,6 @@ testEnsureEntry = do
             _ <- runSTM $ mkEntry 1 5 state (+)
             entry <- runSTM $ mkEntry 1 10 state (+)
             (entry.arg >>= fromDynamic) `shouldBe` Just @Int 15
-
-        it "signals old waiting TMVar" do
-            state <- runSTM Map.new
-            entry1 <- runSTM $ mkEntry 1 42 state (+)
-            _ <- runSTM $ mkEntry 1 99 state (+)
-            result <- runSTM $ Sem.peek entry1.cancelled
-            result `shouldBe` True
-
-        it "new waiting TMVar is empty" do
-            state <- runSTM Map.new
-            _ <- runSTM $ mkEntry 1 42 state (+)
-            entry2 <- runSTM $ mkEntry 1 99 state (+)
-            result <- runSTM $ Sem.peek entry2.cancelled
-            result `shouldBe` False
 
     describe "multiple updates" do
         it "accumulates generation" do
@@ -114,21 +91,31 @@ testEnsureEntry = do
 
 testEnsureCallback :: Spec
 testEnsureCallback = do
-    it "fires callback after settle delay" do
+    it "fires callback when entry's generation still matches" do
         actual <- runCallbackTest do
-            cancelled <- atomically Sem.new
+            state <- STM.atomically Map.new
+            STM.atomically $ Map.insert (entry 0) (1 :: Int) state
             ref <- liftIO $ IORef.newIORef @Int 0
-            t <- Conc.fork $ ensureCallback 1 (entry cancelled) $ liftIO . IORef.writeIORef ref
-            Delay.wait @Millisecond 5
+            t <-
+                Conc.fork
+                    $ ensureCallback @Int @Int 1 state 1 0
+                    $ liftIO . IORef.writeIORef ref
             Conc.await t
             liftIO $ IORef.readIORef ref
         actual `shouldBe` 10
-    it "can be cancelled" do
+    it "skips callback when generation has been bumped" do
         runCallbackTest do
-            cancelled <- atomically Sem.newSet
-            ensureCallback @Int 100 (entry cancelled) \_ ->
+            state <- STM.atomically Map.new
+            -- A newer event has already bumped generation to 1
+            STM.atomically $ Map.insert (entry 1) (1 :: Int) state
+            -- This fork was scheduled for generation 0; it should skip
+            ensureCallback @Int @Int 1 state 1 0 \_ ->
                 liftIO $ False `shouldBe` True
-            Delay.wait @Millisecond 150
+    it "skips callback when entry has been removed" do
+        runCallbackTest do
+            state <- STM.atomically Map.new
+            ensureCallback @Int @Int 1 state 1 0 \_ ->
+                liftIO $ False `shouldBe` True
   where
     runCallbackTest =
         runEff
@@ -136,11 +123,9 @@ testEnsureCallback = do
             . Console.runConsole
             . Delay.runDelay
             . runConc
-            . runTimeout
-    entry cancelled =
+    entry generation =
         Entry
-            { generation = 0
-            , cancelled
+            { generation
             , arg = Just $ toDyn @Int 10
             }
 
@@ -240,5 +225,4 @@ testRunDebounce = do
             . runConcurrent
             . runConc
             . runDelay
-            . runTimeout
             . runDebounce


### PR DESCRIPTION
Replace the per-entry `Semaphore` cancel signal with pure generation comparison. Each fork records its `myGeneration` at scheduling time; after `Delay.wait settleMs` it atomically looks up the map entry and only fires if the generation still matches. A newer event bumps the generation in `ensureEntry`, and the older fork wakes up, sees the mismatch, and exits silently.

- Drops the `Timeout` constraint from `runDebounce` and adds `Delay`.
- Removes the `cancelled` field from `Entry`.
- Removes the `timeout + atomically takeTMVar` pairing in `ensureCallback`, which was the source of flakiness in the `fires callback with the provided arg` spec.