### PR TITLE
fix: enable mouse wheel scrolling in TUI

### DIFF
--- a/tricorder/src/Tricorder/Effects/Brick.hs
+++ b/tricorder/src/Tricorder/Effects/Brick.hs
@@ -9,6 +9,7 @@ import Brick.Main (App, customMain)
 import Effectful (Effect, IOE)
 import Effectful.Dispatch.Dynamic (interpret_)
 import Effectful.TH (makeEffect)
+import Graphics.Vty (Mode (Mouse), outputIface, setMode)
 import Graphics.Vty.Config (userConfig)
 import Graphics.Vty.CrossPlatform (mkVty)
 
@@ -35,7 +36,9 @@ runBrick = interpret_ \case
     RunBrickApp chan app initialState -> liftIO do
         let buildVty = do
                 cfg <- userConfig
-                mkVty cfg
+                vty <- mkVty cfg
+                setMode (outputIface vty) Mouse True
+                pure vty
         initialVty <- liftIO buildVty
         customMain
             initialVty

--- a/tricorder/src/Tricorder/UI/Event.hs
+++ b/tricorder/src/Tricorder/UI/Event.hs
@@ -3,7 +3,7 @@ module Tricorder.UI.Event
     , handleEvent
     ) where
 
-import Brick (BrickEvent (..), EventM)
+import Brick (BrickEvent (..), EventM, vScrollBy, viewportScroll)
 import Brick.Keybindings (KeyDispatcher, handleKey)
 import Control.Monad.State (modify)
 
@@ -23,6 +23,8 @@ data Event
 handleEvent :: KeyDispatcher KeyEvent (EventM Viewports State) -> BrickEvent Viewports Event -> EventM Viewports State ()
 handleEvent _ (AppEvent ev) = handleAppEvent ev
 handleEvent d (VtyEvent (Vty.EvKey key modifiers)) = void $ handleKey d key modifiers
+handleEvent _ (MouseDown vp Vty.BScrollUp _ _) = vScrollBy (viewportScroll vp) (-1)
+handleEvent _ (MouseDown vp Vty.BScrollDown _ _) = vScrollBy (viewportScroll vp) 1
 handleEvent _ _ = pure ()
 
 


### PR DESCRIPTION
Enable Vty mouse mode in `buildVty` and dispatch `BScrollUp` / `BScrollDown` `MouseDown` events to `vScrollBy` on the targeted viewport. Without an explicit `setMode Mouse True`, terminals like kitty+tmux never deliver wheel events to the app, so scrolling in the diagnostic and test-output viewports silently did nothing.