### PR TITLE
fix: resolve stuck "Building…" on rapid edits; restructure Builder

### DIFF
--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -1,30 +1,26 @@
 module Tricorder.Builder
     ( component
-    , BuilderSession (..)
+    , BuildConfig (..)
+
+      -- * Internals exposed for testing
     , NewLoadResult (..)
     , EnteringNewPhase (..)
-    , afterLoad
     , compileLoadResultsIntoBuildResults
     , requestTestRunsForNewBuildResults
     , buildWithGhciOnChange
-    , handleSourceChanges
-    , handleInitialBuild
     , interruptCurrent
     , onRestart
     , reloadOnSourceChange
     , setNewPhase
-    , withCabalChangeRestarts
-    , withCycleLock
-    , newCycleLock
-    , CycleLock
+    , restartOnCabalChange
     ) where
 
-import Control.Concurrent.STM (TMVar, check, newTMVar, putTMVar, readTVar, retry, takeTMVar, writeTVar)
+import Control.Concurrent.STM (check, readTVar, retry, writeTVar)
 import Data.Default (Default (..))
 import Data.Time (diffUTCTime)
 import Effectful.Concurrent (Concurrent)
 import Effectful.Concurrent.STM (atomically, newTVar)
-import Effectful.Exception (bracket_, finally, trySync)
+import Effectful.Exception (finally, trySync)
 import Effectful.Reader.Static (Reader, ask)
 import Effectful.State.Static.Shared (State, get, modify, put, state)
 import System.FilePath (normalise)
@@ -100,12 +96,12 @@ component
 component =
     defaultComponent
         { name = "Builder"
-        , listeners = pure [coordinator]
+        , listeners = pure [runBuilder defaultGhciSessionHooks]
         }
 
 
 -- | A subset of 'Session' with just the properties that 'Builder' cares about.
-data BuilderSession = BuilderSession
+data BuildConfig = BuildConfig
     { command :: Text
     , targets :: [Text]
     , testTargets :: [Text]
@@ -114,9 +110,9 @@ data BuilderSession = BuilderSession
     deriving stock (Eq)
 
 
-instance Default BuilderSession where
+instance Default BuildConfig where
     def =
-        BuilderSession
+        BuildConfig
             { command = session.command
             , targets = session.targets
             , testTargets = session.testTargets
@@ -126,64 +122,20 @@ instance Default BuilderSession where
         session = def @Session
 
 
--- | Project the parts of 'Session' the Builder cares about.
-mkBuilderSession :: Session -> BuilderSession
-mkBuilderSession session =
-    BuilderSession
-        { command = session.command
-        , targets = session.targets
-        , testTargets = session.testTargets
-        , watchDirs = session.watchDirs
-        }
+--------------------------------------------------------------------------------
+-- Level 1 — Builder lifecycle: supervise the tricorder session
+--------------------------------------------------------------------------------
 
-
--- | Run @action@ in a loop that restarts whenever a 'CabalChangeDetected'
--- event arrives. At most one iteration of @action@ runs at any moment: cabal
--- events arriving during a restart collapse into a single next iteration.
+-- | Level 1 — supervise the /tricorder session/ (the project config). For the
+-- current config, run successive GHCi sessions; whenever a @.cabal@ file
+-- changes, reload the config and restart everything.
 --
--- A TVar flag funnels the events: the cabal listener writes 'True' to it; a
--- single coordinator drains it via 'restartableForkWith', runs @preRestart@,
--- and exits the inner scope. Scope teardown cancels the current @action@
--- (including the 'cabal repl' subprocess via its bracket) and waits for it to
--- finish before the next iteration starts — so we never have two builders
--- racing for the same dist-newstyle directory.
-withCabalChangeRestarts
-    :: ( Conc :> es
-       , Concurrent :> es
-       , Log :> es
-       , Sub CabalChangeDetected :> es
-       )
-    => Eff es ()
-    -- ^ Pre-restart hook: runs in the coordinator thread after the flag has
-    -- been drained but before the inner scope is torn down. Use this to set
-    -- the UI to 'Restarting' and reload the session.
-    -> Eff es r
-    -- ^ Setup: runs at the start of each iteration, before @action@ is forked.
-    -> (r -> Eff es Void)
-    -- ^ Inner action. Must never return.
-    -> Eff es Void
-withCabalChangeRestarts preRestart setup action = do
-    needsRestart <- atomically (newTVar False)
-    Conc.scoped do
-        Conc.fork_ $ Conc.restartableForkWith (signal needsRestart) setup action
-        Sub.listen_ @CabalChangeDetected $ \_ -> do
-            Log.info "Cabal file changed; queued restart"
-            atomically (writeTVar needsRestart True)
-  where
-    signal needsRestart = do
-        atomically do
-            check =<< readTVar needsRestart
-            writeTVar needsRestart False
-        preRestart
-
-
--- | Owns the Builder's lifecycle.
---
--- Cabal-change events flip a TVar; the coordinator consumes the flag,
--- transitions the UI to 'Restarting', reloads the session, then exits the
--- inner scope which cancels the in-flight builder. The next iteration
--- forks a fresh builder with the reloaded session.
-coordinator
+-- Cabal-change events flip a TVar; 'restartOnCabalChange' consumes the flag,
+-- runs @preRestart@ (transition to 'Restarting', reload the config),
+-- then exits the inner scope which cancels the in-flight GHCi session. The next
+-- iteration reloads the config via 'loadBuildConfig' and forks a fresh
+-- 'runGhciSessions'.
+runBuilder
     :: ( BuildStore :> es
        , Clock :> es
        , Conc :> es
@@ -199,28 +151,43 @@ coordinator
        , Sub SourceChangeDetected :> es
        , TestRunner :> es
        )
-    => Eff es Void
-coordinator = withCabalChangeRestarts preRestart setup action
+    => GhciSessionHooks es
+    -> Eff es Void
+runBuilder hooks =
+    restartOnCabalChange preRestart loadBuildConfig session
   where
+    -- The tricorder session's restart hook: the outer loop reloading *its own*
+    -- config. This is not a GHCi-session concern, so it lives here rather than
+    -- in 'GhciSessionHooks'.
     preRestart = do
         -- Flip the UI to 'Restarting' immediately so the user sees the change
-        -- has been picked up before scope teardown (which kills cabal repl
-        -- and waits for graceful exit).
-        buildId <- get
-        setNewPhase $ EnteringNewPhase buildId Restarting
-        -- Pick up cabal/package.yaml edits before the next iteration starts.
+        -- has been picked up before scope teardown (which kills cabal repl and
+        -- waits for graceful exit).
+        enterPhase Restarting
+        -- Pick up cabal/package.yaml edits before the next iteration.
         SessionStore.rawReload
 
-    setup = do
-        session <- SessionStore.get
-        let config = mkBuilderSession session
-        ProjectRoot projectRoot <- ask
-        Log.info $ "Builder.component: resolved command = " <> config.command
-        Log.info $ "Builder.component: projectRoot = " <> toText projectRoot
-        pure config
+    session config = runGhciSessions hooks config `finally` onRestart
 
-    action config =
-        buildWithGhciOnChange config `finally` onRestart
+
+-- | Read the current tricorder 'Session' and project the parts the Builder
+-- cares about. Runs at the start of each restart iteration.
+loadBuildConfig
+    :: ( Log :> es
+       , SessionStore :> es
+       )
+    => Eff es BuildConfig
+loadBuildConfig = do
+    session <- SessionStore.get
+    let config =
+            BuildConfig
+                { command = session.command
+                , targets = session.targets
+                , testTargets = session.testTargets
+                , watchDirs = session.watchDirs
+                }
+    Log.info $ "Builder.component: resolved command = " <> config.command
+    pure config
 
 
 onRestart
@@ -236,30 +203,104 @@ onRestart = do
     setNewPhase $ EnteringNewPhase buildId $ Building Nothing
 
 
-setNewPhase
-    :: (BuildStore :> es)
-    => EnteringNewPhase -> Eff es ()
-setNewPhase (EnteringNewPhase bid phase) =
-    BuildStore.setPhase bid phase
+--------------------------------------------------------------------------------
+-- Level 2 — GHCi-session lifecycle
+--------------------------------------------------------------------------------
+
+-- | The lifecycle hooks for one /GHCi session/. Each field is one moment in a
+-- GHCi session's life; the coordinators below (@runGhciSessions@ /
+-- @watchSourceChanges@) own the /when/, these own the /what/.
+--
+-- These are deliberately GHCi-session hooks only. Reloading the /tricorder
+-- session/ (the project config) on a @.cabal@ change belongs to the outer loop
+-- and lives inline in 'runBuilder' — keeping it out of here is what stops a
+-- \"child restarting its parent\". Tests supply their own record to observe a
+-- single hook in isolation.
+data GhciSessionHooks es = GhciSessionHooks
+    { onStart :: Eff es ()
+    -- ^ A fresh GHCi session is about to launch: reset accumulated state.
+    , onInitialLoad :: BuildConfig -> NewLoadResult -> Eff es ()
+    -- ^ The initial load finished: run the post-load pipeline.
+    , onSourceChange :: BuildConfig -> GhciSession.Controls (Eff es) -> SourceChangeDetected -> Eff es ()
+    -- ^ A debounced source change arrived: run one build/test cycle.
+    , onStartupFail :: SomeException -> Eff es ()
+    -- ^ GHCi failed to start: surface 'BuildFailed' and wait to retry.
+    }
 
 
--- | Run the post-load pipeline synchronously: compile diagnostics into a
--- 'BuildResult', then (optionally) run tests and transition through the
--- corresponding phases.
-afterLoad
+-- | The default GHCi-session hooks.
+defaultGhciSessionHooks
     :: ( BuildStore :> es
+       , Clock :> es
        , Log :> es
        , Reader ProjectRoot :> es
        , State BuildId :> es
        , State BuilderState :> es
+       , Sub SourceChangeDetected :> es
        , TestRunner :> es
        )
-    => BuilderSession -> NewLoadResult -> Eff es ()
-afterLoad config newLoadResult = do
-    buildResult <- compileLoadResultsIntoBuildResults config newLoadResult
-    requestTestRunsForNewBuildResults config buildResult
+    => GhciSessionHooks es
+defaultGhciSessionHooks =
+    GhciSessionHooks
+        { onStart = put emptyBuilderState
+        , onInitialLoad = afterLoad
+        , onSourceChange = reloadOnSourceChange
+        , onStartupFail = recoverFromStartupFailure
+        }
 
 
+-- | Level 2 — run successive /GHCi sessions/ for one tricorder session, each
+-- retried on startup failure. Reads top-to-bottom as a GHCi session's phases:
+--
+--   1. 'onStart' — reset accumulated state.
+--   2. launch GHCi; on its initial load, 'onInitialLoad' runs the pipeline.
+--   3. 'watchSourceChanges' — the inner loop, until the session is torn down.
+--   4. 'onStartupFail' — if the launch itself threw, recover and retry.
+runGhciSessions
+    :: ( BuildStore :> es
+       , Clock :> es
+       , Conc :> es
+       , Concurrent :> es
+       , Debounce Text :> es
+       , GhciSession :> es
+       , Log :> es
+       , Reader ProjectRoot :> es
+       , State BuildId :> es
+       , State BuilderState :> es
+       , Sub SourceChangeDetected :> es
+       , TestRunner :> es
+       )
+    => GhciSessionHooks es
+    -> BuildConfig
+    -> Eff es Void
+runGhciSessions hooks config = forever do
+    hooks.onStart
+    root@(ProjectRoot rootPath) <- ask
+    BuildId n <- get
+    Log.info $ "Starting GHCi session #" <> show n <> ": " <> config.command
+
+    startTime <- Clock.currentTime
+    result <- trySync $ GhciSession.withGhci config.command root \initialLoad controls -> do
+        endTime <- Clock.currentTime
+        let filteredMsgs = filterToWatchDirs rootPath config.watchDirs initialLoad.diagnostics
+        Log.info
+            $ mconcat
+                ["GHCi started (session #", show n, "): ", show (length filteredMsgs), " diagnostics"]
+        hooks.onInitialLoad config NewLoadResult {startTime, endTime, loadResult = initialLoad}
+        modify \s ->
+            s
+                { loadedModules = resolveKnownTargets Map.empty initialLoad
+                , knownTargets = KnownTargetNames (Set.fromList initialLoad.targetNames)
+                }
+        watchSourceChanges hooks config controls
+    case result of
+        Right _ -> pure ()
+        Left ex -> hooks.onStartupFail ex
+
+
+-- | The GHCi-session loop with the default 'defaultGhciSessionHooks'. Kept as a
+-- named entry point for tests; 'runBuilder' wraps this with the tricorder
+-- session's cabal-restart handling.
 buildWithGhciOnChange
     :: ( BuildStore :> es
        , Clock :> es
@@ -274,152 +315,77 @@ buildWithGhciOnChange
        , Sub SourceChangeDetected :> es
        , TestRunner :> es
        )
-    => BuilderSession
+    => BuildConfig
     -> Eff es Void
-buildWithGhciOnChange config = forever do
-    put emptyBuilderState
-    projectRoot <- ask
-    BuildId n <- get
-    Log.info $ "Starting GHCi session #" <> show n <> ": " <> config.command
-
-    initialStartTime <- Clock.currentTime
-    result <- trySync $ GhciSession.withGhci config.command projectRoot \initialLoad controls -> do
-        initialEndTime <- Clock.currentTime
-        handleInitialBuild config initialStartTime initialEndTime initialLoad
-        modify \s ->
-            s
-                { loadedModules = resolveKnownTargets Map.empty initialLoad
-                , knownTargets = KnownTargetNames (Set.fromList initialLoad.targetNames)
-                }
-        rebuildOnChange config controls
-    case result of
-        Right _ -> pure ()
-        Left ex -> do
-            buildId <- get
-            Log.err $ "GHCi session failed to start: " <> show ex
-            setNewPhase $ EnteringNewPhase buildId $ BuildFailed $ renderStartupError ex
-            -- Wait for a source change, then loop to retry the launch. A cabal
-            -- change is handled out-of-band by the coordinator cancelling this
-            -- scope. Without this, a startup failure was a dead end: the user
-            -- could fix the offending source file and nothing would happen,
-            -- because no 'SourceChangeDetected' listener is active on this path.
-            Log.info "Build command failed; waiting for a source change to retry"
-            void $ Sub.listenOnce_ @SourceChangeDetected
+buildWithGhciOnChange = runGhciSessions defaultGhciSessionHooks
 
 
-renderStartupError :: SomeException -> Text
-renderStartupError ex = case fromException ex of
-    Just (StartupFailed msg) -> msg
-    Just StartupTimeout -> "Build command did not produce a GHCi banner before timing out."
-    Just (UnexpectedExit cmd lastLine) ->
-        "Build command exited unexpectedly: "
-            <> cmd
-            <> maybe "" (\l -> "\n" <> l) lastLine
-    Nothing -> toText (displayException ex)
-
-
-handleInitialBuild
+-- | Default 'onStartupFail': surface 'BuildFailed', then wait for a source
+-- change to retry the launch.
+--
+-- A cabal change is handled out-of-band by 'runBuilder' cancelling this scope.
+-- Without the wait, a startup failure was a dead end: the user could fix the
+-- offending source file and nothing would happen, because no
+-- 'SourceChangeDetected' listener is active on this path.
+recoverFromStartupFailure
     :: ( BuildStore :> es
        , Log :> es
-       , Reader ProjectRoot :> es
        , State BuildId :> es
-       , State BuilderState :> es
-       , TestRunner :> es
+       , Sub SourceChangeDetected :> es
        )
-    => BuilderSession
-    -> UTCTime
-    -> UTCTime
-    -> LoadResult
-    -> Eff es ()
-handleInitialBuild config startTime endTime loadResult = do
-    ProjectRoot projectRoot <- ask
-    BuildId n <- get
-    let filteredMsgs = filterToWatchDirs projectRoot config.watchDirs loadResult.diagnostics
-
-    Log.info
-        $ mconcat
-            [ "GHCi started (session #"
-            , show n
-            , "): "
-            , show $ length filteredMsgs
-            , " diagnostics"
-            ]
-    afterLoad config NewLoadResult {startTime, endTime, loadResult}
+    => SomeException -> Eff es ()
+recoverFromStartupFailure ex = do
+    Log.err $ "GHCi session failed to start: " <> show ex
+    enterPhase $ BuildFailed $ renderStartupError ex
+    Log.info "Build command failed; waiting for a source change to retry"
+    void $ Sub.listenOnce_ @SourceChangeDetected
 
 
-rebuildOnChange
+--------------------------------------------------------------------------------
+-- Level 3 — Source-change loop and build/test cycle
+--------------------------------------------------------------------------------
+
+-- | Level 3 — the inner loop. Wait for source changes and drive one build/test
+-- cycle ('onSourceChange') per change.
+--
+-- Coalesce debounced source-change events through a single-slot register: the
+-- debounced listener writes the latest event into the slot, and a single worker
+-- fork drains it. Events that arrive while the worker is processing the previous
+-- one simply overwrite the slot, so a burst of N touches collapses into exactly
+-- one trailing cycle (carrying the most recent event) rather than queueing N
+-- back-to-back cycles. This matters whenever 'interruptCurrent' can't drop the
+-- in-flight cycle promptly — e.g. when a 'status --wait' caller has registered
+-- as a waiter, gating 'interruptCurrent' to a no-op.
+watchSourceChanges
     :: ( BuildStore :> es
-       , Clock :> es
        , Conc :> es
        , Concurrent :> es
        , Debounce Text :> es
        , Log :> es
-       , Reader ProjectRoot :> es
        , State BuildId :> es
-       , State BuilderState :> es
        , Sub SourceChangeDetected :> es
        , TestRunner :> es
        )
-    => BuilderSession
+    => GhciSessionHooks es
+    -> BuildConfig
     -> GhciSession.Controls (Eff es)
     -> Eff es Void
-rebuildOnChange config controls = Conc.scoped do
+watchSourceChanges hooks config controls = Conc.scoped do
     BuildId n <- get
     Log.debug $ "Builder: waiting for dirty flag (build #" <> show n <> ")"
-    handleSourceChanges config controls
-
-
-handleSourceChanges
-    :: ( BuildStore :> es
-       , Clock :> es
-       , Conc :> es
-       , Concurrent :> es
-       , Debounce Text :> es
-       , Log :> es
-       , Reader ProjectRoot :> es
-       , State BuildId :> es
-       , State BuilderState :> es
-       , Sub SourceChangeDetected :> es
-       , TestRunner :> es
-       )
-    => BuilderSession -> GhciSession.Controls (Eff es) -> Eff es Void
-handleSourceChanges config controls = forever $ Conc.scoped do
-    -- Coalesce debounced source-change events through a single-slot
-    -- register: the debounced listener writes the latest event into the
-    -- slot, and a single worker fork drains it. Events that arrive while
-    -- the worker is processing the previous one simply overwrite the slot,
-    -- so a burst of N touches collapses into exactly one trailing cycle
-    -- (carrying the most recent event) rather than queueing N back-to-back
-    -- cycles. This matters whenever 'interruptCurrent' can't drop the
-    -- in-flight cycle promptly — e.g. when a 'status --wait' caller has
-    -- registered as a waiter, gating 'interruptCurrent' to a no-op.
-    pending <- atomically (newTVar @(Maybe SourceChangeDetected) Nothing)
-    Conc.fork_ $ Sub.listen_ \ev ->
-        debounced 200 "source_change_reloader"
-            $ atomically (writeTVar pending (Just ev))
-    Conc.fork_ $ Sub.listen_ \_ -> interruptCurrent controls
-    Conc.fork_ $ forever do
-        ev <- atomically do
-            readTVar pending >>= \case
-                Nothing -> retry
-                Just e -> writeTVar pending Nothing >> pure e
-        reloadOnSourceChange config controls ev
-    Conc.awaitAll
-
-
--- | A mutex serialising one build/test cycle at a time.
-newtype CycleLock = CycleLock (TMVar ())
-
-
-newCycleLock :: (Concurrent :> es) => Eff es CycleLock
-newCycleLock = CycleLock <$> atomically (newTMVar ())
-
-
--- | Run @action@ under @lock@, blocking if another cycle is already in
--- flight. The lock is released even if @action@ throws.
-withCycleLock :: (Concurrent :> es) => CycleLock -> Eff es a -> Eff es a
-withCycleLock (CycleLock t) =
-    bracket_ (atomically (takeTMVar t)) (atomically (putTMVar t ()))
+    forever $ Conc.scoped do
+        pending <- atomically (newTVar @(Maybe SourceChangeDetected) Nothing)
+        Conc.fork_ $ Sub.listen_ \ev ->
+            debounced 200 "source_change_reloader"
+                $ atomically (writeTVar pending (Just ev))
+        Conc.fork_ $ Sub.listen_ \_ -> interruptCurrent controls
+        Conc.fork_ $ forever do
+            ev <- atomically do
+                readTVar pending >>= \case
+                    Nothing -> retry
+                    Just e -> writeTVar pending Nothing >> pure e
+            hooks.onSourceChange config controls ev
+        Conc.awaitAll
 
 
 -- 'controls.interrupt' is a safe no-op when GHCi is idle, and 'GhciSession'
@@ -447,7 +413,7 @@ reloadOnSourceChange
        , State BuilderState :> es
        , TestRunner :> es
        )
-    => BuilderSession
+    => BuildConfig
     -> GhciSession.Controls (Eff es)
     -> SourceChangeDetected
     -> Eff es ()
@@ -463,8 +429,7 @@ reloadOnSourceChange config controls (SourceChangeDetected fp event) = do
                     <> " of file not loaded in GHCi: "
                     <> toText fp
         Just action -> do
-            buildId <- get
-            setNewPhase $ EnteringNewPhase buildId $ Building Nothing
+            enterPhase $ Building Nothing
 
             res <- trySync do
                 startTime <- Clock.currentTime
@@ -476,6 +441,11 @@ reloadOnSourceChange config controls (SourceChangeDetected fp event) = do
                 Left e -> do
                     now <- Clock.currentTime
                     Log.err $ show now <> " Reload errored: " <> show e
+                    -- Resolve the UI instead of stranding it in 'Building': a
+                    -- reload that errors (rather than producing a result) must
+                    -- not leave the daemon stuck until the next source change
+                    -- happens to arrive and succeed.
+                    enterPhase $ BuildFailed $ "Reload failed: " <> toText (displayException e)
                 Right (startTime, endTime, loadResult) -> do
                     modify \s ->
                         s
@@ -492,24 +462,28 @@ runAction controls = \case
     Unadd mn -> controls.unadd mn
 
 
-data NewLoadResult = NewLoadResult
-    { startTime :: UTCTime
-    , endTime :: UTCTime
-    , loadResult :: LoadResult
-    }
-    deriving stock (Eq, Show)
-
-
--- | A pending phase transition. Carried by 'setNewPhase' into the 'BuildStore'.
-data EnteringNewPhase = EnteringNewPhase BuildId BuildPhase
-    deriving stock (Eq, Show)
+-- | Run the post-load pipeline synchronously: compile diagnostics into a
+-- 'BuildResult', then (optionally) run tests and transition through the
+-- corresponding phases.
+afterLoad
+    :: ( BuildStore :> es
+       , Log :> es
+       , Reader ProjectRoot :> es
+       , State BuildId :> es
+       , State BuilderState :> es
+       , TestRunner :> es
+       )
+    => BuildConfig -> NewLoadResult -> Eff es ()
+afterLoad config newLoadResult = do
+    buildResult <- compileLoadResultsIntoBuildResults config newLoadResult
+    requestTestRunsForNewBuildResults config buildResult
 
 
 compileLoadResultsIntoBuildResults
     :: ( Reader ProjectRoot :> es
        , State BuilderState :> es
        )
-    => BuilderSession
+    => BuildConfig
     -> NewLoadResult
     -> Eff es BuildResult
 compileLoadResultsIntoBuildResults session newLoadResult = do
@@ -533,7 +507,7 @@ compileLoadResultsIntoBuildResults session newLoadResult = do
             , testRuns = []
             }
   where
-    BuilderSession {watchDirs} = session
+    BuildConfig {watchDirs} = session
     NewLoadResult {startTime, endTime, loadResult} = newLoadResult
 
 
@@ -543,7 +517,7 @@ requestTestRunsForNewBuildResults
        , State BuildId :> es
        , TestRunner :> es
        )
-    => BuilderSession
+    => BuildConfig
     -> BuildResult
     -> Eff es ()
 requestTestRunsForNewBuildResults config partialResult = do
@@ -565,11 +539,11 @@ runTestsIfClean
        , Log :> es
        , TestRunner :> es
        )
-    => BuilderSession
+    => BuildConfig
     -> BuildId
     -> BuildResult
     -> Eff es (Maybe [TestRun])
-runTestsIfClean (BuilderSession {testTargets}) bid partialResult
+runTestsIfClean (BuildConfig {testTargets}) bid partialResult
     | null testTargets || any (\d -> d.severity == SError) partialResult.diagnostics = pure (Just [])
     | otherwise = do
         TestRunner.resetAbort
@@ -600,3 +574,97 @@ runTestsIfClean (BuilderSession {testTargets}) bid partialResult
     insert k v ((k', v') : xs)
         | k == k' = (k, v) : xs
         | otherwise = (k', v') : insert k v xs
+
+
+--------------------------------------------------------------------------------
+-- Restart machinery
+--------------------------------------------------------------------------------
+
+-- | Run @action@ in a loop that restarts whenever a 'CabalChangeDetected'
+-- event arrives. At most one iteration of @action@ runs at any moment: cabal
+-- events arriving during a restart collapse into a single next iteration.
+--
+-- A TVar flag funnels the events: the cabal listener writes 'True' to it; a
+-- single coordinator drains it via 'restartableForkWith', runs @preRestart@,
+-- and exits the inner scope. Scope teardown cancels the current @action@
+-- (including the 'cabal repl' subprocess via its bracket) and waits for it to
+-- finish before the next iteration starts — so we never have two builders
+-- racing for the same dist-newstyle directory.
+restartOnCabalChange
+    :: ( Conc :> es
+       , Concurrent :> es
+       , Log :> es
+       , Sub CabalChangeDetected :> es
+       )
+    => Eff es ()
+    -- ^ Pre-restart hook: runs in the coordinator thread after the flag has
+    -- been drained but before the inner scope is torn down. Use this to set
+    -- the UI to 'Restarting' and reload the session.
+    -> Eff es r
+    -- ^ Setup: runs at the start of each iteration, before @action@ is forked.
+    -> (r -> Eff es Void)
+    -- ^ Inner action. Must never return.
+    -> Eff es Void
+restartOnCabalChange preRestart setup action = do
+    needsRestart <- atomically (newTVar False)
+    Conc.scoped do
+        Conc.fork_ $ Conc.restartableForkWith (signal needsRestart) setup action
+        Sub.listen_ @CabalChangeDetected $ \_ -> do
+            Log.info "Cabal file changed; queued restart"
+            atomically (writeTVar needsRestart True)
+  where
+    signal needsRestart = do
+        atomically do
+            check =<< readTVar needsRestart
+            writeTVar needsRestart False
+        preRestart
+
+
+--------------------------------------------------------------------------------
+-- Phase-transition helpers
+--------------------------------------------------------------------------------
+
+setNewPhase
+    :: (BuildStore :> es)
+    => EnteringNewPhase -> Eff es ()
+setNewPhase (EnteringNewPhase bid phase) =
+    BuildStore.setPhase bid phase
+
+
+-- | Transition the /current/ build into @phase@.
+enterPhase
+    :: ( BuildStore :> es
+       , State BuildId :> es
+       )
+    => BuildPhase -> Eff es ()
+enterPhase phase = do
+    buildId <- get
+    setNewPhase $ EnteringNewPhase buildId phase
+
+
+renderStartupError :: SomeException -> Text
+renderStartupError ex = case fromException ex of
+    Just (StartupFailed msg) -> msg
+    Just StartupTimeout -> "Build command did not produce a GHCi banner before timing out."
+    Just (UnexpectedExit cmd lastLine) ->
+        "Build command exited unexpectedly: "
+            <> cmd
+            <> maybe "" (\l -> "\n" <> l) lastLine
+    Nothing -> toText (displayException ex)
+
+
+--------------------------------------------------------------------------------
+-- Supporting types
+--------------------------------------------------------------------------------
+
+data NewLoadResult = NewLoadResult
+    { startTime :: UTCTime
+    , endTime :: UTCTime
+    , loadResult :: LoadResult
+    }
+    deriving stock (Eq, Show)
+
+
+-- | A pending phase transition. Carried by 'setNewPhase' into the 'BuildStore'.
+data EnteringNewPhase = EnteringNewPhase BuildId BuildPhase
+    deriving stock (Eq, Show)

--- a/tricorder/src/Tricorder/Effects/GhciSession/GhciProcess.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession/GhciProcess.hs
@@ -94,8 +94,8 @@ data SessionState = Idle Int | Busy Int
 -- 'NoOpIdle' means the GHCi session is at the prompt — sending SIGINT and a
 -- sync marker would dirty the buffers and desync the next 'execGhci'.
 -- 'SendInterruptFor n' means a command was in flight (state 'Busy n') and
--- the caller should SIGINT the process group and write @markerFor (n + 1)@
--- to unblock the in-progress 'drainUntil'.
+-- the caller should SIGINT the process group and re-write @markerFor n@ (that
+-- command's own marker) to unblock the in-progress 'drainUntil'.
 data InterruptDecision
     = NoOpIdle
     | SendInterruptFor Int
@@ -154,10 +154,10 @@ startGhciProcess
     -- initial-build drain, so the UI can update the progress bar live
     -- instead of replaying everything once compilation finishes.
     -> (GhciProcess -> Eff es ())
-    -- ^ @onReady@. Called once the 'GhciProcess' is constructed but before
-    -- the initial-build drain runs — so callers can register the process
-    -- for interruption while the slow @cabal repl@ recompilation is still
-    -- in progress.
+    -- ^ @onReady@. Called once the 'GhciProcess' is constructed but before the
+    -- banner wait and initial-build drain — so callers can register the process
+    -- for interruption while the slow @cabal repl@ startup (dependency build
+    -- and recompilation) is still in progress.
     -> Eff es (GhciProcess, [Text])
 startGhciProcess config cmd dir onProgress onReady = do
     p <-
@@ -176,6 +176,22 @@ startGhciProcess config cmd dir onProgress onReady = do
     File.hSetBuffering out LineBuffering
     File.hSetBuffering err LineBuffering
 
+    -- Create the state var and the process handle up front, then register the
+    -- process for interruption *before* the (possibly slow) banner wait. For
+    -- @cabal repl@, dependency building happens before GHCi prints its banner,
+    -- so registering here lets an interrupt terminate the process during that
+    -- window rather than having to wait for the whole startup to complete.
+    stateVar <- newTVarIO (Idle 0)
+    let ghciProcess =
+            GhciProcess
+                { stdin = inp
+                , stdout = out
+                , stderr = err
+                , handle = p
+                , stateVar = stateVar
+                }
+    onReady ghciProcess
+
     -- Send a blank line to kick GHCi into producing output
     liftIO $ TIO.hPutStrLn inp ""
     File.hFlush inp
@@ -193,20 +209,6 @@ startGhciProcess config cmd dir onProgress onReady = do
     for_ config.extraSetupCommands \c ->
         liftIO $ TIO.hPutStrLn inp c
     File.hFlush inp
-
-    -- Create state var
-    stateVar <- newTVarIO (Idle 0)
-
-    let ghciProcess =
-            GhciProcess
-                { stdin = inp
-                , stdout = out
-                , stderr = err
-                , handle = p
-                , stateVar = stateVar
-                }
-
-    onReady ghciProcess
 
     -- Sync: drain until marker 1 seen, then set counter to 2.
     -- Capture lines from both streams — the stderr output contains the initial
@@ -235,8 +237,9 @@ startGhciProcess config cmd dir onProgress onReady = do
 -- fires for each @[N of M] Compiling …@ line as GHCi emits it during the
 -- initial build, so the UI can update its progress bar in real time. The
 -- @onReady@ callback (see 'startGhciProcess') fires once the underlying
--- process exists but before the initial-load drain — useful for registering
--- the process for early termination while initial compilation is in flight.
+-- process exists but before the banner wait and initial-load drain — useful
+-- for registering the process for early termination while @cabal repl@ startup
+-- (dependency build and initial compilation) is still in flight.
 withGhciProcess
     :: (Conc :> es, Concurrent :> es, File :> es, IOE :> es, Timeout :> es)
     => Config
@@ -293,11 +296,15 @@ execGhci ghciProcess command onProgress = do
 
 -- | Interrupt the currently running GHCi command (if any).
 --
--- If a command is in progress (state 'Busy'), sends SIGINT to the GHCi
--- process group and writes a new sync marker so that the in-progress
--- 'drainUntil' unblocks. When GHCi is 'Idle' this is a true no-op: sending
--- SIGINT and a stale sync marker to an idle GHCi leaves leftover marker
--- output in the buffers that would desync the next 'execGhci'.
+-- If a command is in progress (state 'Busy n'), sends SIGINT to the GHCi
+-- process group and re-writes /that command's own/ sync marker (@markerFor n@)
+-- so the in-progress 'drainUntil', which is waiting for exactly that marker,
+-- unblocks. The next command runs as @n + 1@ and waits for @markerFor (n + 1)@,
+-- so any duplicate @markerFor n@ left in the buffers is skipped by 'drainUntil'
+-- rather than mistaken for the next command's marker.
+--
+-- When GHCi is 'Idle' this is a true no-op: sending SIGINT and a sync marker to
+-- an idle GHCi leaves leftover marker output in the buffers.
 interruptGhci :: (Concurrent :> es, File :> es, IOE :> es) => GhciProcess -> Eff es ()
 interruptGhci ghciProcess = do
     decision <- atomically do
@@ -309,7 +316,7 @@ interruptGhci ghciProcess = do
         NoOpIdle -> pure ()
         SendInterruptFor n -> do
             liftIO $ interruptProcessGroupOf (unsafeProcessHandle ghciProcess.handle)
-            sendSyncCommand ghciProcess.stdin (markerFor (n + 1))
+            sendSyncCommand ghciProcess.stdin (markerFor n)
 
 
 -- | Forcefully terminate the GHCi process, closing its handles.
@@ -360,43 +367,52 @@ markerPrefix :: Text
 markerPrefix = "#~TRI-FINISH-"
 
 
--- | Write the synchronisation Haskell expression to GHCi stdin.
+-- | Write the synchronisation Haskell statements to GHCi stdin.
 --
--- After each user command, this expression causes GHCi to emit the finish
--- marker on both stdout and stderr, so 'drainUntil' knows when to stop.
+-- After each user command, these cause GHCi to emit the finish marker on both
+-- stdout and stderr, so 'drainUntil' knows when to stop.
+--
+-- The marker is emitted as two standalone, fully-qualified statements — one per
+-- stream — using only 'System.IO.hPutStrLn'. This is deliberate: a
+-- SIGINT-interrupted ':reload' empties GHCi's interactive scope, dropping the
+-- implicit @import Prelude@, so bare names like @putStrLn@ (and even the @>>@
+-- operator) fall out of scope. A marker built from those would /error/ instead
+-- of printing — its marker would never appear and 'drainUntil' would block
+-- forever waiting for it (the "stuck Building…" stall). Fully-qualified
+-- 'System.IO.hPutStrLn' resolves via GHCi's implicit qualified imports even
+-- with an emptied scope, so the marker survives an interrupt.
 sendSyncCommand :: (File :> es, IOE :> es) => Handle -> Text -> Eff es ()
 sendSyncCommand h marker = do
     -- Use show to produce a valid Haskell string literal for the marker text.
     let markerLit = toText (show @String (toString marker)) -- e.g. "\"#~TRI-FINISH-3~#\""
-        cmd =
-            "putStrLn "
-                <> markerLit
-                <> " >> System.IO.hPutStrLn System.IO.stderr "
-                <> markerLit
-    liftIO $ TIO.hPutStrLn h cmd
+    liftIO $ TIO.hPutStrLn h ("System.IO.hPutStrLn System.IO.stdout " <> markerLit)
+    liftIO $ TIO.hPutStrLn h ("System.IO.hPutStrLn System.IO.stderr " <> markerLit)
     File.hFlush h
 
 
--- | Read lines from a handle until any finish marker is seen (or EOF).
+-- | Read lines from a handle until /this command's/ finish marker is seen (or
+-- EOF).
 --
--- Stops on any line containing the marker prefix, so an interrupt that writes
--- a later marker will unblock a drain waiting for an earlier one. Each
--- non-marker line is passed to @onLine@ as it arrives, so callers can stream
--- progress without waiting for the full drain to complete.
--- Returns accumulated non-marker lines in order. Throws 'UnexpectedExit' on
--- EOF before a marker is seen.
+-- Stops only on a line containing the exact @marker@ it was given. A line
+-- carrying a /different/ finish marker — a stale leftover from a prior command
+-- that was interrupted mid-flight — is skipped rather than matched, so it can
+-- never make a later drain return prematurely (the "0 modules"/hang desync).
+-- Each ordinary line is passed to @onLine@ as it arrives, so callers can stream
+-- progress without waiting for the full drain to complete. Returns accumulated
+-- non-marker lines in order. Throws 'UnexpectedExit' on EOF before the marker.
 drainUntil :: (File :> es) => Handle -> Text -> (Text -> Eff es ()) -> Eff es [Text]
-drainUntil h command onLine = go []
+drainUntil h marker onLine = go []
   where
     go acc = do
         result <- try @E.IOException $ File.hGetLine h
         case result of
             Left _ ->
-                throwIO $ UnexpectedExit command (listToMaybe (reverse acc))
-            Right line ->
-                if markerPrefix `T.isInfixOf` line then
-                    pure (reverse acc)
-                else do
+                throwIO $ UnexpectedExit marker (listToMaybe (reverse acc))
+            Right line
+                | marker `T.isInfixOf` line -> pure (reverse acc)
+                -- A stale marker from an interrupted command: drop it, keep going.
+                | markerPrefix `T.isInfixOf` line -> go acc
+                | otherwise -> do
                     onLine line
                     go (line : acc)
 

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -1,7 +1,7 @@
 module Unit.Tricorder.BuilderSpec (spec_Builder) where
 
 import Control.Concurrent.STM (modifyTVar', newTVarIO, readTVar, retry, writeTVar)
-import Control.Exception (ErrorCall (..), throwIO)
+import Control.Exception (ErrorCall (..))
 import Data.Default (def)
 import Data.Time (UTCTime (..), addUTCTime, fromGregorian)
 import Effectful (runEff, runPureEff)
@@ -9,11 +9,11 @@ import Effectful.Concurrent (Concurrent, runConcurrent)
 import Effectful.Concurrent.STM (atomically)
 import Effectful.Dispatch.Dynamic (interpret_)
 import Effectful.Error.Static (runErrorNoCallStack, throwError)
-import Effectful.Exception (trySync)
+import Effectful.Exception (throwIO)
 import Effectful.Reader.Static (runReader)
 import Effectful.State.Static.Shared (evalState, runState)
 import Effectful.Writer.Static.Shared (Writer, execWriter, tell)
-import Test.Hspec (Spec, describe, expectationFailure, it, shouldBe, shouldMatchList, shouldSatisfy)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldMatchList, shouldSatisfy)
 
 import Control.Concurrent.STM qualified as STM
 import Data.Map.Strict qualified as Map
@@ -44,7 +44,7 @@ import Tricorder.BuildState
     , TestRunCompletion (..)
     )
 import Tricorder.Builder
-    ( BuilderSession (..)
+    ( BuildConfig (..)
     , EnteringNewPhase (..)
     , NewLoadResult (..)
     , compileLoadResultsIntoBuildResults
@@ -81,18 +81,18 @@ spec_Builder = do
     describe "compileLoadResultsIntoBuildResults" testCompileLoadResultsIntoBuildResults
     describe "requestTestRunsForNewBuildResults" testRequestTestRunsForNewBuildResults
     describe "setNewPhase" testSetNewPhase
+    describe "onRestart" testOnRestart
     describe "restartOnCabalChange" testRestartOnCabalChange
-    describe "withCabalChangeRestarts" testWithCabalChangeRestarts
     describe "buildWithGhciOnChange (startup-failure recovery)" testBuildWithGhciRecovery
     describe "reloadOnSourceChange" testReloadOnSourceChange
-    describe "handleSourceChanges (cycle serialization)" testCycleSerialization
+    describe "watchSourceChanges (event coalescing)" testEventCoalescing
     describe "interruptCurrent" testInterruptCurrent
     describe "resolveKnownTargets" testResolveKnownTargets
     describe "fileMatchesAnyTarget" testFileMatchesAnyTarget
 
 
-testRestartOnCabalChange :: Spec
-testRestartOnCabalChange = do
+testOnRestart :: Spec
+testOnRestart = do
     it "transitions BuildStore to the Building phase" do
         (st, _) <- runTest
         st.phase `shouldBe` Building Nothing
@@ -114,8 +114,8 @@ testRestartOnCabalChange = do
                 BuildStore.getState
 
 
-testWithCabalChangeRestarts :: Spec
-testWithCabalChangeRestarts = do
+testRestartOnCabalChange :: Spec
+testRestartOnCabalChange = do
     it "restarts the supervised action when CabalChangeDetected is published" do
         countVar <- newTVarIO @Int 0
 
@@ -123,7 +123,7 @@ testWithCabalChangeRestarts = do
             Conc.scoped do
                 _ <-
                     Conc.fork
-                        $ Builder.withCabalChangeRestarts
+                        $ Builder.restartOnCabalChange
                             (pure ())
                             (pure ())
                             ( \_ -> do
@@ -154,7 +154,7 @@ testWithCabalChangeRestarts = do
 -- fails to start, 'buildWithGhciOnChange' must surface 'BuildFailed' and then
 -- stay able to retry once a source file changes. The original code parked on
 -- 'atomically retry' after 'BuildFailed', so it could only ever recover via a
--- *cabal* change (the coordinator cancelling its scope) — a source edit that
+-- *cabal* change (runBuilder cancelling its scope) — a source edit that
 -- fixed the underlying problem was ignored and the daemon stayed stuck.
 testBuildWithGhciRecovery :: Spec
 testBuildWithGhciRecovery = do
@@ -167,7 +167,7 @@ testBuildWithGhciRecovery = do
                 ]
                 do
                     Conc.scoped do
-                        Conc.fork_ (Builder.buildWithGhciOnChange (def @BuilderSession))
+                        Conc.fork_ (Builder.buildWithGhciOnChange (def @BuildConfig))
                         Delay.wait (40 :: Millisecond) -- let the first launch fail + subscribe
                         publish (SourceChangeDetected "/abs/path/Foo.hs" Modified)
                         Delay.wait (60 :: Millisecond) -- let the retry land
@@ -263,6 +263,17 @@ testReloadOnSourceChange = do
         describe "when the file is not loaded" $ it "is a no-op" do
             phases <- runTest Map.empty noTargets distinctCtrls (SourceChangeDetected "/abs/path/Unknown.hs" Removed)
             phases `shouldBe` []
+
+    describe "when the reload throws (e.g. interrupted mid-flight)" do
+        it "resolves to BuildFailed instead of stranding the UI in Building" do
+            phases <- runTest knownFoo noTargets throwingCtrls (SourceChangeDetected "/abs/path/Foo.hs" Modified)
+            -- Regression: a reload that errors must resolve the build, not
+            -- leave 'Building' as the terminal phase (the daemon would be
+            -- stuck until the next change happened to succeed).
+            viaNonEmpty last [p | EnteringNewPhase _ p <- phases]
+                `shouldSatisfy` \case
+                    Just (BuildFailed _) -> True
+                    _ -> False
   where
     runTest initialModuleMap initialTargets ctrls event =
         runEff
@@ -279,7 +290,7 @@ testReloadOnSourceChange = do
             . execWriter @[EnteringNewPhase]
             . runBuildStoreCapture
             . runTestRunnerScripted []
-            $ reloadOnSourceChange (def @BuilderSession) ctrls event
+            $ reloadOnSourceChange (def @BuildConfig) ctrls event
 
     flow lr =
         [ EnteringNewPhase (BuildId 1) (Building Nothing)
@@ -306,6 +317,9 @@ testReloadOnSourceChange = do
             , add = \_ -> pure addLr
             , unadd = \_ -> pure unaddLr
             }
+
+    -- A reload that throws, as if SIGINT'd by a second rapid source change.
+    throwingCtrls = distinctCtrls {reload = throwIO (ErrorCall "reload interrupted")}
 
     knownFoo =
         Map.fromList
@@ -481,7 +495,7 @@ testRequestTestRunsForNewBuildResults = do
                 . runBuildStoreCapture
                 . runTestRunnerAbortAfterFirst (mkTestRun "test:foo")
                 $ requestTestRunsForNewBuildResults
-                    BuilderSession
+                    BuildConfig
                         { command = ""
                         , targets = []
                         , testTargets = ["test:foo", "test:bar"]
@@ -507,7 +521,7 @@ testRequestTestRunsForNewBuildResults = do
             . runBuildStoreCapture
             . runTestRunnerScripted script
             $ requestTestRunsForNewBuildResults
-                BuilderSession {command = "", targets = [], testTargets, watchDirs = []}
+                BuildConfig {command = "", targets = [], testTargets, watchDirs = []}
                 partial
 
     mkPhase = EnteringNewPhase (BuildId 1)
@@ -874,61 +888,23 @@ emptyDaemonInfo =
 
 
 --------------------------------------------------------------------------------
--- Cycle serialization (withCycleLock)
+-- Event coalescing (watchSourceChanges)
 --
--- Regression for the parallel-cycles bug. When two source-change events
--- arrive more than 200ms apart, debounce fires both callbacks, and if the
--- first 'reloadOnSourceChange' is still in flight when the second fires,
--- the two cycles (including their test loops) would run concurrently
--- without the lock. The user-visible symptom was the previous build's
--- test suite still running alongside the new build's.
---
--- 'handleSourceChanges' wraps each 'reloadOnSourceChange' invocation in
--- 'withCycleLock'. Here we exercise the lock primitive itself with
--- multiple concurrent acquisitions, asserting that at no point are two
--- holders in the critical section simultaneously.
+-- Regression for the parallel-cycles bug. When source-change events arrive
+-- more than 200ms apart, debounce fires each callback separately. While one
+-- cycle is in flight, the rest must collapse into AT MOST ONE trailing cycle
+-- rather than queueing N back-to-back cycles — otherwise a 'status --wait'
+-- caller wouldn't see "Done" until the last queued cycle finished. This
+-- mirrors the single-slot register + single-worker pattern that
+-- 'watchSourceChanges' uses to coalesce a burst into one trailing reload.
 --------------------------------------------------------------------------------
 
-testCycleSerialization :: Spec
-testCycleSerialization = do
-    it "serialises concurrent acquisitions (max one holder at a time)" do
-        inProgressRef <- newTVarIO (0 :: Int)
-        maxConcurrentRef <- newTVarIO (0 :: Int)
-        let worker lock = Builder.withCycleLock lock do
-                atomically do
-                    modifyTVar' inProgressRef (+ 1)
-                    cur <- readTVar inProgressRef
-                    modifyTVar' maxConcurrentRef (max cur)
-                Delay.wait (10 :: Millisecond)
-                atomically (modifyTVar' inProgressRef (subtract 1))
-        runEff . runConcurrent . runDelay . runConc $ do
-            lock <- Builder.newCycleLock
-            Conc.scoped do
-                threads <- replicateM 5 (Conc.fork (worker lock))
-                traverse_ Conc.await threads
-        finalMax <- STM.atomically (readTVar maxConcurrentRef)
-        finalMax `shouldBe` 1
-
-    it "releases the lock even if the action throws" do
-        result <- runEff . runConcurrent . runDelay $ do
-            lock <- Builder.newCycleLock
-            firstAttempt <-
-                trySync
-                    $ Builder.withCycleLock lock
-                    $ liftIO
-                    $ throwIO (ErrorCall "boom")
-            -- A second acquisition must succeed — if 'withCycleLock' had
-            -- failed to release on exception, this would deadlock.
-            Builder.withCycleLock lock (pure ())
-            pure firstAttempt
-        case result of
-            Left _ -> pure ()
-            Right () -> expectationFailure "expected the exception to propagate"
-
+testEventCoalescing :: Spec
+testEventCoalescing = do
     -- Whenever 'interruptCurrent' cannot drop the in-flight cycle promptly
     -- (e.g. a 'status --wait' caller has registered as a waiter, gating
     -- 'interruptCurrent' to a no-op), additional source-change events would
-    -- previously each queue their own follow-up cycle behind 'withCycleLock'.
+    -- previously each queue their own follow-up cycle.
     -- N touches spaced wider than the 200ms debounce window therefore
     -- produced N back-to-back cycles after the in-flight one finished — and
     -- a 'status --wait' caller wouldn't see "Done" until the last queued
@@ -937,7 +913,7 @@ testCycleSerialization = do
     -- Desired behaviour: while a cycle is in flight, additional source
     -- changes coalesce into AT MOST ONE trailing cycle, regardless of how
     -- many events arrived. This mirrors the single-slot register +
-    -- single-worker pattern that 'handleSourceChanges' uses.
+    -- single-worker pattern that 'watchSourceChanges' uses.
     it "coalesces source-change events into one follow-up cycle while busy" do
         cycleRunsRef <- newTVarIO (0 :: Int)
         releaseFirst <- STM.newEmptyTMVarIO @()

--- a/tricorder/test/Unit/Tricorder/Effects/GhciSession/GhciProcessSpec.hs
+++ b/tricorder/test/Unit/Tricorder/Effects/GhciSession/GhciProcessSpec.hs
@@ -49,7 +49,126 @@ spec_GhciProcess :: Spec
 spec_GhciProcess = do
     describe "decideInterrupt" testDecideInterrupt
     describe "execGhci" testExecGhciScope
+    describe "execGhci (stale marker desync)" testExecGhciStaleMarker
+    describe "execGhci (sync marker scope independence)" testSyncMarkerScopeIndependent
     describe "waitForBannerOrFail" testWaitForBannerOrFail
+
+
+-- | Regression for the touch-during-reload desync. Interrupting a *Busy* GHCi
+-- (a reload in flight) leaves a stale sync marker in the stdout/stderr buffers
+-- ahead of the next command's real output. Because 'drainUntil' used to stop on
+-- ANY marker-prefix line, the next 'execGhci' matched that stale marker and
+-- returned *before its command ran* — surfacing as @All good. (0 modules)@ (or,
+-- on the other timing, a hang). 'execGhci' must skip markers that aren't its
+-- own and stop only on the marker it is waiting for.
+testExecGhciStaleMarker :: Spec
+testExecGhciStaleMarker =
+    it "skips a stale leftover marker and returns the command's real output" do
+        (stdinR, stdinW) <- Process.createPipe
+        (stdoutR, stdoutW) <- Process.createPipe
+        (stderrR, stderrW) <- Process.createPipe
+        -- A dummy process handle to fill the record; 'execGhci' never uses it.
+        p <-
+            startProcess
+                $ setStdin createPipe
+                $ setStdout createPipe
+                $ setStderr createPipe
+                $ shell "true"
+        _ <- waitExitCode p
+        stateVar <- newTVarIO (Idle 9)
+        let gp =
+                GhciProcess
+                    { stdin = stdinW
+                    , stdout = stdoutR
+                    , stderr = stderrR
+                    , handle = p
+                    , stateVar
+                    }
+            -- Mirrors 'markerFor': "#~TRI-FINISH-<n>~#".
+            marker n = "#~TRI-FINISH-" <> show (n :: Int) <> "~#" :: Text
+        result <-
+            runEff
+                . runConcurrent
+                . runTimeout
+                . runDelay
+                . runFile
+                . runConc
+                $ do
+                    -- A stale 'marker 5' (left by a prior interrupted reload)
+                    -- precedes the fresh command's real output + its 'marker 9'
+                    -- (state is 'Idle 9', so 'execGhci' waits for marker 9).
+                    for_ [marker 5, "out-line", marker 9] (File.hPutBsLn stdoutW . encodeUtf8)
+                    for_ [marker 5, "err-line", marker 9] (File.hPutBsLn stderrW . encodeUtf8)
+                    File.hClose stdoutW
+                    File.hClose stderrW
+                    -- Keep the stdin read-end alive across the write inside
+                    -- 'execGhci' (otherwise it is GC-finalised → broken pipe).
+                    r <- execGhci gp "reload" (\_ -> pure ())
+                    File.hClose stdinR
+                    pure r
+        _ <- (Right <$> stopProcess p) `catch` \(_ :: SomeException) -> pure (Left ())
+        result `shouldBe` ["out-line", "err-line"]
+
+
+-- | Root-cause regression for the "stuck Building…" stall. A SIGINT-interrupted
+-- ':reload' empties GHCi's interactive scope — it drops the implicit
+-- @import Prelude@ (verified against ghci 9.10). A sync marker built from bare
+-- Prelude names then fails to run instead of printing: @putStrLn@ is no longer
+-- in scope, and neither is the @>>@ operator. The marker never appears, so
+-- 'drainUntil' blocks until the watchdog fires. The marker must therefore use
+-- only fully-qualified 'System.IO.hPutStrLn' statements (which survive the
+-- emptied scope), one per stream, with no bare names or operators.
+--
+-- We assert on exactly what 'execGhci' writes to GHCi's stdin.
+testSyncMarkerScopeIndependent :: Spec
+testSyncMarkerScopeIndependent =
+    it "writes the finish marker using only fully-qualified names (no bare putStrLn / >>)" do
+        (stdinR, stdinW) <- Process.createPipe
+        (stdoutR, stdoutW) <- Process.createPipe
+        (stderrR, stderrW) <- Process.createPipe
+        p <-
+            startProcess
+                $ setStdin createPipe
+                $ setStdout createPipe
+                $ setStderr createPipe
+                $ shell "true"
+        _ <- waitExitCode p
+        stateVar <- newTVarIO (Idle 9)
+        let gp =
+                GhciProcess
+                    { stdin = stdinW
+                    , stdout = stdoutR
+                    , stderr = stderrR
+                    , handle = p
+                    , stateVar
+                    }
+            marker = "#~TRI-FINISH-9~#" :: Text
+        written <-
+            runEff
+                . runConcurrent
+                . runTimeout
+                . runDelay
+                . runFile
+                . runConc
+                $ do
+                    -- Pre-seed the marker on both streams so the drain returns
+                    -- immediately; we only care about what was written to stdin.
+                    File.hPutBsLn stdoutW (encodeUtf8 marker)
+                    File.hPutBsLn stderrW (encodeUtf8 marker)
+                    File.hClose stdoutW
+                    File.hClose stderrW
+                    _ <- execGhci gp ":reload" (\_ -> pure ())
+                    File.hClose stdinW
+                    let readAll acc =
+                            trySync (File.hGetLine stdinR) >>= \case
+                                Left (_ :: SomeException) -> pure (reverse acc)
+                                Right l -> readAll (l : acc)
+                    readAll []
+        _ <- (Right <$> stopProcess p) `catch` \(_ :: SomeException) -> pure (Left ())
+        let blob = T.intercalate "\n" written
+        (" >> " `T.isInfixOf` blob) `shouldBe` False
+        ("System.IO.hPutStrLn System.IO.stdout" `T.isInfixOf` blob) `shouldBe` True
+        ("System.IO.hPutStrLn System.IO.stderr" `T.isInfixOf` blob) `shouldBe` True
 
 
 -- | Regression: when the build command exits before printing a GHCi banner,


### PR DESCRIPTION
The daemon could get permanently stuck showing `Building…` when a file was touched rapidly while a reload/test cycle was in flight. Root cause: a SIGINT-interrupted `:reload` empties GHCi's interactive scope (drops the implicit `import Prelude`), so the sync marker — built from bare `putStrLn` and the `>>` operator — errored instead of printing. The drain then blocked forever waiting for a marker that never arrived.

GhciProcess:
- Emit the finish marker as two standalone, fully-qualified `System.IO.hPutStrLn` statements (one per stream, no bare names or operators) so it survives an emptied scope and an interrupt reliably unblocks the in-flight drain.
- `drainUntil` matches the command's exact marker and skips stale leftover markers from an interrupted command, so a desync can't make a later drain return early ("0 modules") or hang.
- `interruptGhci` re-writes the in-flight command's own marker on SIGINT to unblock the drain it targets.
- Register the process for interruption before the banner wait, so a change during `cabal repl` startup can terminate it promptly instead of waiting for the whole startup to finish.

Builder:
- Restructure around an explicit two-level supervision model: BuildConfig (the tricorder session/project config) and successive GHCi sessions, with the source-change loop coalescing bursts through a single-slot register.
- A reload that errors now resolves the UI to BuildFailed instead of stranding it in Building.
- Tighten the export surface and drop dead code.

Adds regression tests for the scope-independent marker and the stale-marker desync.