### PR TITLE
docs: add Haddock docs across atelier packages

### DIFF
--- a/atelier-core/src/Atelier/Component.hs
+++ b/atelier-core/src/Atelier/Component.hs
@@ -1,8 +1,19 @@
+-- | A small component model for assembling long-running applications.
+--
+-- A 'Component' bundles a named unit of work with a lifecycle: one-off 'setup',
+-- a set of 'listeners' and 'triggers' that run as forked threads, and a
+-- post-'start' action. 'runSystem' drives a collection of components through
+-- these phases in lockstep, so that (for example) every component has finished
+-- 'setup' before any 'start' action runs and publishes events the others react
+-- to.
 module Atelier.Component
-    ( Component (..)
+    ( -- * Components
+      Component (..)
     , defaultComponent
     , Listener
     , Trigger
+
+      -- * Running
     , runComponent
     , runSystem
     ) where
@@ -17,14 +28,19 @@ import Atelier.Effects.Conc qualified as Conc
 import Atelier.Effects.Log qualified as Log
 
 
--- | Type aliases for semantic clarity
+-- | A listener reacts to events and runs forever; it never returns normally,
+-- hence the 'Void' result.
 type Listener es = Eff es Void
 
 
+-- | A trigger initiates periodic or scheduled work and, like a 'Listener', runs
+-- forever and never returns normally.
 type Trigger es = Eff es Void
 
 
--- | Component interface for modular application structure
+-- | A named unit of application work together with its lifecycle hooks.
+--
+-- Build one by overriding the fields of 'defaultComponent' you care about.
 data Component es = Component
     { name :: ~Text
     -- ^ Component name for tracing
@@ -39,6 +55,10 @@ data Component es = Component
     }
 
 
+-- | A 'Component' with no-op lifecycle hooks and no listeners or triggers.
+--
+-- Override the fields you need. 'name' is deliberately left as an 'error' so a
+-- component created without a name fails fast rather than tracing anonymously.
 defaultComponent :: (HasCallStack) => Component es
 defaultComponent =
     Component

--- a/atelier-core/src/Atelier/Config.hs
+++ b/atelier-core/src/Atelier/Config.hs
@@ -1,5 +1,43 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 
+-- | Layered application configuration.
+--
+-- A configuration is assembled from a base JSON\/YAML document plus environment
+-- variable overrides, then decoded on demand by type-level key:
+--
+-- * 'envOverrides' turns @PREFIX__A__B=value@ variables into a nested JSON
+--   'Value';
+-- * 'deepMerge' overlays that onto the base document, producing a
+--   'LoadedConfig';
+-- * 'extractConfig' and 'extractNestedConfig' decode a section by 'Symbol' key,
+--   falling back to the target type's 'Default' instance when the key is
+--   missing or fails to decode;
+-- * 'runConfig' hands a decoded section to a computation as a 'Reader'.
+--
+-- == Worked example
+--
+-- Given a base document (say, decoded from a @base.yaml@ holding
+-- @server: { port: 8080, host: localhost }@) and a @MYAPP@ environment prefix:
+--
+-- @
+-- data Server = Server { port :: Int, host :: Text }
+--     deriving stock (Generic)
+--     deriving (FromJSON) via (QuietSnake Server)
+--
+-- instance Default Server where
+--     def = Server { port = 80, host = \"0.0.0.0\" }
+--
+-- loadServer :: (Env :> es) => Value -> Eff es Server
+-- loadServer base = do
+--     overrides <- envOverrides \"MYAPP\"            -- e.g. MYAPP__SERVER__PORT=9090
+--     let loaded = LoadedConfig (deepMerge base overrides)
+--     pure (extractNestedConfig \@\"server\" loaded)
+-- @
+--
+-- With @MYAPP__SERVER__PORT=9090@ set in the environment, @loadServer@ yields
+-- @Server { port = 9090, host = \"localhost\" }@: the env override wins on
+-- @port@, the base document supplies @host@, and the 'Default' instance would
+-- cover any field absent from both.
 module Atelier.Config
     ( envOverrides
     , deepMerge
@@ -71,6 +109,8 @@ deepMerge (Object l) (Object r) = Object $ KM.unionWith deepMerge l r
 deepMerge _ r = r
 
 
+-- | A fully merged configuration document (base overlaid with overrides), ready
+-- to have sections extracted from it by key.
 newtype LoadedConfig = LoadedConfig Value
 
 

--- a/atelier-core/src/Atelier/Effects/Await.hs
+++ b/atelier-core/src/Atelier/Effects/Await.hs
@@ -1,3 +1,10 @@
+-- | The consuming half of a 'Yield'\/'Await' coroutine pair.
+--
+-- An 'Await' computation requests values one at a time, analogous to the
+-- @Reader@\/@Input@ effects. Pair it with a 'Yield' producer — for example via
+-- 'awaitYield' — to stream values from one computation into another. The effect
+-- and its operations live in "Atelier.Effects.Internal.Coroutine" and are
+-- re-exported here.
 module Atelier.Effects.Await
     ( -- * Effect
       Await

--- a/atelier-core/src/Atelier/Effects/Cache.hs
+++ b/atelier-core/src/Atelier/Effects/Cache.hs
@@ -42,10 +42,16 @@ import Atelier.Effects.Delay qualified as Delay
 import Atelier.Effects.Log qualified as Log
 
 
+-- | Effect for a generic key-value cache.
 data Cache key value :: Effect where
+    -- | Look up a key, returning 'Nothing' if it is absent.
     CacheLookup :: key -> Cache key value m (Maybe value)
+    -- | Insert or overwrite the value at a key.
     CacheInsert :: key -> value -> Cache key value m ()
+    -- | Remove a key from the cache.
     CacheDelete :: key -> Cache key value m ()
+    -- | Apply a function to a key's current value (or its absence), store the
+    -- result, and return it.
     CacheModify :: key -> (Maybe value -> value) -> Cache key value m value
 
 
@@ -80,6 +86,10 @@ runCacheTtl act = do
     runCacheTtlWithWait (Delay.wait $ nominalDiffTime @Microsecond cfg.cleanupInterval) act
 
 
+-- | Like 'runCacheTtl', but with the cleanup cadence supplied explicitly as a
+-- waiting action rather than read from 'Config'. Each time the action
+-- completes, expired entries are swept. Useful for tests that drive cleanup
+-- deterministically.
 runCacheTtlWithWait
     :: forall key value es a
      . ( Clock :> es

--- a/atelier-core/src/Atelier/Effects/Cache/Config.hs
+++ b/atelier-core/src/Atelier/Effects/Cache/Config.hs
@@ -1,3 +1,8 @@
+-- | Configuration shared by the TTL cache interpreters.
+--
+-- 'Config' controls how long entries live and how often the background eviction
+-- sweep runs. It is re-exported by "Atelier.Effects.Cache" and
+-- "Atelier.Effects.Tally".
 module Atelier.Effects.Cache.Config
     ( Config (..)
     ) where

--- a/atelier-core/src/Atelier/Effects/Cache/Singleflight.hs
+++ b/atelier-core/src/Atelier/Effects/Cache/Singleflight.hs
@@ -1,3 +1,11 @@
+-- | A singleflight cache effect: deduplicate concurrent computations of the
+-- same key.
+--
+-- When several threads request the same key at once, the first runs the
+-- computation while the rest wait and share its result — so an expensive lookup
+-- happens once per key per in-flight window. Results (and exceptions) can also
+-- be seeded with 'updateCache' or invalidated with 'removeFromCache'. Each
+-- operation is traced (see "Atelier.Effects.Monitoring.Tracing").
 module Atelier.Effects.Cache.Singleflight
     ( Singleflight
     , withCache

--- a/atelier-core/src/Atelier/Effects/Chan.hs
+++ b/atelier-core/src/Atelier/Effects/Chan.hs
@@ -1,7 +1,28 @@
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
--- | Module: Atelier.Effects.Chan
--- Description: Effect for creating and operating on bidirectional channels
+-- | A typed, unbounded channel effect backed by @unagi-chan@.
+--
+-- Exposes the split in\/out ends of a fast concurrent queue as an effect, plus a
+-- batched read ('readChanBatched') for draining several items at once. The
+-- 'InChan' and 'OutChan' types are re-exported so callers need not depend on
+-- @unagi-chan@ directly.
+--
+-- @
+-- -- write a few items (writeChan never blocks), then drain them in one batch:
+-- pipeline :: (Chan :> es, Timeout :> es) => Eff es (NonEmpty Int)
+-- pipeline = do
+--     (inn, out) <- newChan
+--     traverse_ (writeChan inn) [1 .. 10]
+--     readChanBatched (50 :: Millisecond) 100 out   -- one blocking read, up to 100 items
+--
+-- -- dupChan gives a second, independent read end that sees later writes:
+-- broadcast :: (Chan :> es) => Eff es (Int, Int)
+-- broadcast = do
+--     (inn, out1) <- newChan
+--     out2 <- dupChan inn
+--     writeChan inn 7
+--     (,) <$> readChan out1 <*> readChan out2       -- (7, 7)
+-- @
 module Atelier.Effects.Chan
     ( -- * Effect
       Chan
@@ -39,25 +60,32 @@ type instance DispatchOf Chan = Static WithSideEffects
 data instance StaticRep Chan = Chan
 
 
+-- | Run the 'Chan' effect, allowing channel operations to perform their IO.
 runChan :: forall a es. (IOE :> es) => Eff (Chan : es) a -> Eff es a
 runChan = evalStaticRep Chan
 
 
+-- | Create a new channel, returning its write ('InChan') and read ('OutChan')
+-- ends.
 newChan :: forall a es. (Chan :> es) => Eff es (InChan a, OutChan a)
 newChan =
     unsafeEff_ Unagi.newChan
 
 
+-- | Read the next item from a channel, blocking until one is available.
 readChan :: forall a es. (Chan :> es) => OutChan a -> Eff es a
 readChan outChan =
     unsafeEff_ $ Unagi.readChan outChan
 
 
+-- | Write an item to a channel. Never blocks (the channel is unbounded).
 writeChan :: forall a es. (Chan :> es) => InChan a -> a -> Eff es ()
 writeChan inChan val =
     unsafeEff_ $ Unagi.writeChan inChan val
 
 
+-- | Duplicate a channel, producing a new read end that observes every item
+-- written after the duplication.
 dupChan :: forall a es. (Chan :> es) => InChan a -> Eff es (OutChan a)
 dupChan inChan =
     unsafeEff_ $ Unagi.dupChan inChan

--- a/atelier-core/src/Atelier/Effects/Clock.hs
+++ b/atelier-core/src/Atelier/Effects/Clock.hs
@@ -1,3 +1,8 @@
+-- | A clock effect for reading the current time and time zone.
+--
+-- Putting wall-clock reads behind an effect keeps time-dependent code testable:
+-- 'runClock' uses the system clock, while 'runClockConst', 'runClockState' and
+-- 'runClockList' supply deterministic times for tests.
 module Atelier.Effects.Clock
     ( Clock
     , UTCTime
@@ -18,26 +23,34 @@ import Effectful.State.Static.Shared (State, evalState, get, put)
 import Effectful.TH (makeEffect)
 
 
+-- | Effect for reading the current time and time zone.
 data Clock :: Effect where
+    -- | The current wall-clock time, in UTC.
     CurrentTime :: Clock m UTCTime
+    -- | The system's current time zone.
     CurrentTimeZone :: Clock m TimeZone
 
 
 makeEffect ''Clock
 
 
+-- | Interpret 'Clock' against the real system clock.
 runClock :: (IOE :> es) => Eff (Clock : es) a -> Eff es a
 runClock = interpret_ $ \case
     CurrentTime -> liftIO getCurrentTime
     CurrentTimeZone -> liftIO getCurrentTimeZone
 
 
+-- | Interpret 'Clock' so 'currentTime' always returns a fixed time. The time
+-- zone is reported as 'utc'.
 runClockConst :: UTCTime -> Eff (Clock : es) a -> Eff es a
 runClockConst time = interpret_ $ \case
     CurrentTime -> pure time
     CurrentTimeZone -> pure utc
 
 
+-- | Interpret 'Clock' so 'currentTime' reads from a mutable 'State' cell,
+-- letting a test advance \"now\" explicitly. The time zone is reported as 'utc'.
 runClockState :: (State UTCTime :> es) => Eff (Clock : es) a -> Eff es a
 runClockState = interpret_ $ \case
     CurrentTime -> get

--- a/atelier-core/src/Atelier/Effects/Conc.hs
+++ b/atelier-core/src/Atelier/Effects/Conc.hs
@@ -1,3 +1,10 @@
+-- | Structured concurrency built on @ki@.
+--
+-- 'Conc' exposes forking, awaiting, racing and nurseries ('scoped') as an
+-- effect, so concurrent code stays in 'Eff' and inherits structured-concurrency
+-- guarantees: every child thread is bound to a scope and is cancelled when that
+-- scope closes. The base interpreter ('runConc') ignores tracing; use
+-- "Atelier.Effects.Conc.Traced" to propagate OpenTelemetry context across forks.
 module Atelier.Effects.Conc
     ( -- * Effect
       Conc (..)
@@ -54,18 +61,26 @@ data Conc :: Effect where
     -- | Fork a thread that never terminates (e.g. a server loop).
     -- The @Void@ return type enforces this — use 'fork' for threads that exit.
     Fork_ :: m Void -> Conc m ()
+    -- | Block until a forked 'Thread' finishes and return its result.
     Await :: Thread a -> Conc m a
+    -- | Block until every thread in the current scope has finished.
     AwaitAll :: Conc m ()
+    -- | Like 'Fork', but the thread captures a synchronous exception of type @e@
+    -- as a 'Left' instead of propagating it to the enclosing scope.
     ForkTry :: (Exception e) => m a -> Conc m (Thread (Either e a))
     -- | Races two computations concurrently and returns the result of the
     -- operation that finished first.
     Race :: m a -> m b -> Conc m (Either a b)
+    -- | Open a nursery scope. Threads forked inside it are awaited or cancelled
+    -- when the action returns.
     Scoped :: m a -> Conc m a
 
 
+-- | A concurrency scope (nursery) that forked threads are bound to.
 newtype Scope = Scope Ki.Scope
 
 
+-- | A handle to a forked thread, awaited with 'await'.
 newtype Thread a = Thread (Ki.Thread a)
 
 
@@ -153,5 +168,8 @@ runConc eff = withEffToIO concStrat $ \unlift ->
         unlift $ runConcBase (Scope scope) eff
 
 
+-- | The unlift strategy used when running forked actions: a persistent,
+-- unlimited concurrent unlift, so forked threads may themselves use the effects
+-- of the enclosing computation. Shared with "Atelier.Effects.Conc.Traced".
 concStrat :: UnliftStrategy
 concStrat = ConcUnlift Persistent Unlimited

--- a/atelier-core/src/Atelier/Effects/Console.hs
+++ b/atelier-core/src/Atelier/Effects/Console.hs
@@ -1,3 +1,8 @@
+-- | An effect for writing bytes and text to an output stream.
+--
+-- The single primitive is 'putStr' (raw bytes); 'putStrLn', 'putText' and
+-- 'putTextLn' build on it. 'runConsole' writes to stdout, 'runConsoleHandle' to
+-- any 'Handle', and 'runConsoleToList' captures output for tests.
 module Atelier.Effects.Console
     ( -- * Effect
       Console
@@ -22,34 +27,43 @@ import Prelude
 import Data.ByteString.Char8 qualified as B8
 
 
+-- | Effect for writing output to a stream.
 data Console :: Effect where
+    -- | Write raw bytes to the output.
     PutStr :: ByteString -> Console m ()
 
 
 makeEffect ''Console
 
 
+-- | Write a 'ByteString' followed by a newline.
 putStrLn :: (Console :> es) => ByteString -> Eff es ()
 putStrLn = putStr . (<> "\n")
 
 
+-- | Write 'Text', encoded as UTF-8 bytes.
 putText :: (Console :> es) => Text -> Eff es ()
 putText = putStr . encodeUtf8
 
 
+-- | Write 'Text' as UTF-8 bytes, followed by a newline.
 putTextLn :: (Console :> es) => Text -> Eff es ()
 putTextLn = putStrLn . encodeUtf8
 
 
+-- | Interpret 'Console' by writing to the given 'Handle'.
 runConsoleHandle :: (IOE :> es) => Handle -> Eff (Console : es) a -> Eff es a
 runConsoleHandle h = interpret_ \case
     PutStr s -> liftIO $ B8.hPut h s
 
 
+-- | Interpret 'Console' by writing to 'stdout'.
 runConsole :: (IOE :> es) => Eff (Console : es) a -> Eff es a
 runConsole = runConsoleHandle stdout
 
 
+-- | Interpret 'Console' by collecting all writes into a list, in order. Useful
+-- for asserting on output in tests.
 runConsoleToList :: Eff (Console : es) a -> Eff es (a, [ByteString])
 runConsoleToList = reinterpret_ (fmap (second reverse) . runState []) \case
     PutStr s -> modify (s :)

--- a/atelier-core/src/Atelier/Effects/Debounce.hs
+++ b/atelier-core/src/Atelier/Effects/Debounce.hs
@@ -12,8 +12,17 @@
 -- == Example
 --
 -- @
--- watchFilePaths watches \path event ->
---     debouncedWith 100 mergeFileEvent path event (handleChange path)
+-- -- Coalesce rapid saves per file: only the last edit within a 200ms window
+-- -- triggers a rebuild, keyed by path.
+-- onEdit :: (Debounce FilePath :> es) => FilePath -> Eff es ()
+-- onEdit path = debounced 200 path (rebuild path)
+--
+-- -- Or merge the burst instead of keeping just the last value. Here every
+-- -- event seen within the window is combined (list append) before a single
+-- -- rebuild fires with the full batch.
+-- onChange :: (Debounce FilePath :> es) => FilePath -> FileEvent -> Eff es ()
+-- onChange path event =
+--     debouncedWith 200 (<>) path [event] (rebuildWith path)
 -- @
 module Atelier.Effects.Debounce
     ( -- * Effect
@@ -49,6 +58,8 @@ import Atelier.Effects.Conc qualified as Conc
 import Atelier.Effects.Delay qualified as Delay
 
 
+-- | Effect for coalescing rapid bursts of keyed events into a single delayed
+-- callback.
 data Debounce key :: Effect where
     -- | Schedule @callback merged@ after the settle window. If another call
     -- with the same @key@ arrives before the window expires, the two values are
@@ -73,9 +84,14 @@ debounced :: (Debounce key :> es) => Millisecond -> key -> Eff es a -> Eff es ()
 debounced settleMs key action = debouncedWith settleMs (\_ _ -> ()) key () (\_ -> action)
 
 
+-- | Per-key debounce state: the latest (merged) pending argument and a
+-- generation counter used to tell whether a scheduled fire is still the most
+-- recent call for that key.
 data Entry = Entry
     { arg :: Maybe Dynamic
+    -- ^ The latest pending argument (type-erased), or 'Nothing' once consumed.
     , generation :: Int
+    -- ^ Counter bumped on every call for the key; identifies the latest one.
     }
 
 

--- a/atelier-core/src/Atelier/Effects/Delay.hs
+++ b/atelier-core/src/Atelier/Effects/Delay.hs
@@ -1,3 +1,17 @@
+-- | An effect for delaying execution.
+--
+-- 'wait' suspends the current thread for a 'TimeUnit' duration; 'every' repeats
+-- an action forever with a fixed gap between runs. 'runDelay' performs real
+-- delays, while 'runDelayNoOp' skips them so time-based code runs instantly
+-- under test.
+--
+-- @
+-- -- pause within a workflow:
+-- wait (250 :: Millisecond)
+--
+-- -- run a health check every 30 seconds, forever (the caller forks it):
+-- fork_ $ every (30 :: Second) checkHealth
+-- @
 module Atelier.Effects.Delay
     ( Delay
     , wait
@@ -13,6 +27,7 @@ import Effectful.Dispatch.Dynamic (interpret_)
 import Effectful.TH (makeEffect)
 
 
+-- | Effect for suspending execution for a given duration.
 data Delay :: Effect where
     -- | Halt the thread and wait for the passed duration before continuing.
     Wait :: (TimeUnit t) => t -> Delay m ()
@@ -30,6 +45,7 @@ every delay action = forever do
     wait delay
 
 
+-- | Interpret 'Delay' using real thread delays.
 runDelay :: (Concurrent :> es) => Eff (Delay : es) a -> Eff es a
 runDelay = interpret_ \(Wait delay) ->
     threadDelay $ fromIntegral (toMicroseconds delay)

--- a/atelier-core/src/Atelier/Effects/Env.hs
+++ b/atelier-core/src/Atelier/Effects/Env.hs
@@ -1,3 +1,7 @@
+-- | An effect for reading process environment variables.
+--
+-- 'runEnv' reads the real process environment; 'runEnvConst' supplies a fixed
+-- association list for tests.
 module Atelier.Effects.Env
     ( Env
     , getEnvironment
@@ -12,16 +16,20 @@ import Effectful.TH (makeEffect)
 import System.Environment qualified as System
 
 
+-- | Effect for reading the process environment.
 data Env :: Effect where
+    -- | The full environment as a list of @(name, value)@ pairs.
     GetEnvironment :: Env m [(String, String)]
 
 
 makeEffect ''Env
 
 
+-- | Interpret 'Env' against the real process environment.
 runEnv :: (IOE :> es) => Eff (Env : es) a -> Eff es a
 runEnv = interpret_ $ \GetEnvironment -> liftIO System.getEnvironment
 
 
+-- | Interpret 'Env' with a fixed environment, for tests.
 runEnvConst :: [(String, String)] -> Eff (Env : es) a -> Eff es a
 runEnvConst env = interpret_ $ \GetEnvironment -> pure env

--- a/atelier-core/src/Atelier/Effects/Exit.hs
+++ b/atelier-core/src/Atelier/Effects/Exit.hs
@@ -1,3 +1,7 @@
+-- | An effect for terminating the program with an exit code.
+--
+-- 'runExit' really exits the process; 'runExitNoOp' captures the exit code
+-- instead, so tests can assert on it without killing the test runner.
 module Atelier.Effects.Exit
     ( -- * Effect
       Exit
@@ -19,21 +23,26 @@ import System.Exit (ExitCode (..))
 import System.Exit qualified as IO
 
 
+-- | Effect for terminating the program with an exit code.
 data Exit :: Effect where
+    -- | Terminate the program with the given 'ExitCode'. Does not return.
     ExitWith :: ExitCode -> Exit m a
 
 
 makeEffect ''Exit
 
 
+-- | Exit the program successfully (exit code 0).
 exitSuccess :: (Exit :> es) => Eff es a
 exitSuccess = exitWith ExitSuccess
 
 
+-- | Exit the program with a generic failure (exit code 1).
 exitFailure :: (Exit :> es) => Eff es a
 exitFailure = exitWith (ExitFailure 1)
 
 
+-- | Interpret 'Exit' by actually terminating the process.
 runExit :: (IOE :> es) => Eff (Exit : es) a -> Eff es a
 runExit = interpret_ \(ExitWith code) -> liftIO (IO.exitWith code)
 

--- a/atelier-core/src/Atelier/Effects/File.hs
+++ b/atelier-core/src/Atelier/Effects/File.hs
@@ -1,5 +1,11 @@
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
+-- | A handle-based file IO effect.
+--
+-- A thin 'Eff' wrapper over the handle operations in "System.IO" and
+-- "Data.Text.IO" ('withFile', 'hPutText', 'hGetLine', …), so file IO passes
+-- through the effect system instead of raw 'IO'. 'Handle' and 'BufferMode' are
+-- re-exported for convenience.
 module Atelier.Effects.File
     ( File
     , Handle

--- a/atelier-core/src/Atelier/Effects/FileSystem.hs
+++ b/atelier-core/src/Atelier/Effects/FileSystem.hs
@@ -1,3 +1,9 @@
+-- | An effect for filesystem operations: reading files, listing and creating
+-- directories, and querying paths.
+--
+-- 'runFileSystemIO' performs real filesystem IO; 'runFileSystemNoOp' returns
+-- inert results; and 'runFileSystemState' simulates a filesystem backed by an
+-- in-memory 'Map' for tests. 'followFile' tails a file as it grows.
 module Atelier.Effects.FileSystem
     ( FileSystem (..)
     , readFileBs
@@ -40,22 +46,34 @@ import Atelier.Time (Millisecond)
 import Atelier.Effects.Delay qualified as Delay
 
 
+-- | Effect for filesystem access.
 data FileSystem :: Effect where
+    -- | Read a file's full contents strictly.
     ReadFileBs :: FilePath -> FileSystem m ByteString
+    -- | Read a file from the given byte offset to the end, lazily.
     ReadFileLbsFrom :: FilePath -> FileOffset -> FileSystem m LBS.ByteString
+    -- | Does a regular file exist at the path?
     DoesFileExist :: FilePath -> FileSystem m Bool
+    -- | Does anything (file or directory) exist at the path?
     DoesPathExist :: FilePath -> FileSystem m Bool
+    -- | List the entries of a directory.
     ListDirectory :: FilePath -> FileSystem m [FilePath]
+    -- | Create a directory. The 'Bool' requests creation of missing parents.
     CreateDirectoryIfMissing :: Bool -> FilePath -> FileSystem m ()
+    -- | Delete a file.
     RemoveFile :: FilePath -> FileSystem m ()
+    -- | Resolve a path to a canonical, absolute form.
     CanonicalizePath :: FilePath -> FileSystem m FilePath
+    -- | The process's current working directory.
     GetCurrentDirectory :: FileSystem m FilePath
+    -- | The XDG runtime directory (@$XDG_RUNTIME_DIR@), falling back to @\/tmp@.
     GetXdgRuntimeDir :: FileSystem m FilePath
 
 
 makeEffect ''FileSystem
 
 
+-- | Read a file's full contents lazily (equivalent to reading from offset 0).
 readFileLbs :: (FileSystem :> es) => FilePath -> Eff es LBS.ByteString
 readFileLbs path = readFileLbsFrom path 0
 
@@ -76,6 +94,7 @@ followFile path onChunk = go 0
         go (offset + fromIntegral (LBS.length newContent))
 
 
+-- | Interpret 'FileSystem' against the real filesystem.
 runFileSystemIO :: (IOE :> es) => Eff (FileSystem : es) a -> Eff es a
 runFileSystemIO = interpret_ $ \case
     ReadFileBs path -> liftIO $ BS.readFile path
@@ -95,6 +114,8 @@ runFileSystemIO = interpret_ $ \case
     GetXdgRuntimeDir -> liftIO $ fromMaybe "/tmp" <$> lookupEnv "XDG_RUNTIME_DIR"
 
 
+-- | Interpret 'FileSystem' with inert results: reads return empty, existence
+-- checks return 'False', and mutations do nothing. Useful for tests.
 runFileSystemNoOp :: Eff (FileSystem : es) a -> Eff es a
 runFileSystemNoOp = interpret_ $ \case
     ReadFileBs _ -> pure mempty

--- a/atelier-core/src/Atelier/Effects/Input.hs
+++ b/atelier-core/src/Atelier/Effects/Input.hs
@@ -1,3 +1,8 @@
+-- | An effect for requesting a value from the environment on each call.
+--
+-- Unlike 'Effectful.Reader.Static.Reader', 'Input' makes no assumption that the
+-- value is stable across the computation — each 'input' may observe a different
+-- value. See the 'Input' type below for the full comparison.
 module Atelier.Effects.Input
     ( Input
     , input

--- a/atelier-core/src/Atelier/Effects/Internal/Coroutine.hs
+++ b/atelier-core/src/Atelier/Effects/Internal/Coroutine.hs
@@ -1,3 +1,9 @@
+-- | Internal: the shared implementation of the 'Yield' and 'Await' coroutine
+-- effects.
+--
+-- Both effects, along with their operations and interpreters, are defined here;
+-- "Atelier.Effects.Yield" and "Atelier.Effects.Await" re-export curated subsets
+-- for public use. Exposed chiefly for testing — prefer the public modules.
 module Atelier.Effects.Internal.Coroutine
     ( -- * Yield
       Yield (..)

--- a/atelier-core/src/Atelier/Effects/Iterator.hs
+++ b/atelier-core/src/Atelier/Effects/Iterator.hs
@@ -1,3 +1,9 @@
+-- | A pull-based iterator over a (possibly infinite) stream of values.
+--
+-- Where the 'Yield' effect pushes values to a consumer, an 'Iterator' is pulled
+-- one value at a time with 'next'. 'fromEvents' adapts a 'Sub' event source into
+-- an iterator with a buffered, race-free subscription, and a stream can be
+-- narrowed with 'filter' and 'changes'.
 module Atelier.Effects.Iterator
     ( Iterator
     , next
@@ -18,8 +24,12 @@ import Atelier.Effects.Conc qualified as Conc
 import Atelier.Effects.Publishing qualified as Sub
 
 
--- | An pull-based iterator of (potentially infinite) values.
-newtype Iterator es a = Iterator {next :: Eff es a}
+-- | A pull-based iterator of (potentially infinite) values.
+newtype Iterator es a = Iterator
+    { next :: Eff es a
+    -- ^ Pull the next value from the iterator, performing whatever effects that
+    -- requires.
+    }
     deriving (Functor) via (Eff es)
 
 

--- a/atelier-core/src/Atelier/Effects/Log.hs
+++ b/atelier-core/src/Atelier/Effects/Log.hs
@@ -60,17 +60,27 @@ import Atelier.Types.JsonReadShow (JsonReadShow (..))
 import Atelier.Types.QuietSnake (QuietSnake (..))
 
 
+-- | Effect for structured logging with hierarchical namespaces.
 data Log :: Effect where
+    -- | Emit a fully-formed log 'Message'.
     LogMsg :: Message -> Log m ()
+    -- | Run an action with an extra namespace segment appended to the current
+    -- one.
     WithNamespace :: Namespace -> m a -> Log m a
+    -- | Get the namespace in effect for the current action.
     GetNamespace :: Log m Namespace
 
 
+-- | A single log record.
 data Message = Message
     { namespace :: Namespace
+    -- ^ The hierarchical namespace the message was logged under.
     , text :: Text
+    -- ^ The human-readable message body.
     , severity :: Severity
+    -- ^ The severity level of the message.
     , stack :: CallStack
+    -- ^ The call site, captured via 'HasCallStack'.
     }
 
 
@@ -85,18 +95,25 @@ instance Semigroup Namespace where
     Namespace a <> Namespace b = Namespace (a <> "." <> b)
 
 
+-- | Logging configuration.
 data Config = Config
     { minimumSeverity :: Severity
+    -- ^ Messages below this severity are discarded.
     }
     deriving stock (Eq, Generic, Show)
     deriving (FromJSON) via QuietSnake Config
 
 
+-- | Log severity levels, ordered from least to most severe.
 data Severity
-    = DEBUG
-    | INFO
-    | WARN
-    | ERROR
+    = -- | Verbose diagnostic detail.
+      DEBUG
+    | -- | Normal operational information.
+      INFO
+    | -- | Something unexpected, but recoverable.
+      WARN
+    | -- | A failure that needs attention.
+      ERROR
     deriving stock (Bounded, Enum, Eq, Ord, Read, Show)
     deriving (FromJSON) via (JsonReadShow Severity)
 
@@ -111,6 +128,8 @@ instance Default Config where
 makeEffect ''Log
 
 
+-- | Log a message at the given severity, capturing the current namespace and
+-- call site.
 log :: (HasCallStack, Log :> es) => Severity -> Text -> Eff es ()
 log severity text = do
     namespace <- getNamespace
@@ -124,18 +143,22 @@ log severity text = do
                 }
 
 
+-- | Log a message at 'DEBUG' severity.
 debug :: (HasCallStack, Log :> es) => Text -> Eff es ()
 debug = withFrozenCallStack $ log DEBUG
 
 
+-- | Log a message at 'INFO' severity.
 info :: (HasCallStack, Log :> es) => Text -> Eff es ()
 info = withFrozenCallStack $ log INFO
 
 
+-- | Log a message at 'WARN' severity.
 warn :: (HasCallStack, Log :> es) => Text -> Eff es ()
 warn = withFrozenCallStack $ log WARN
 
 
+-- | Log a message at 'ERROR' severity.
 err :: (HasCallStack, Log :> es) => Text -> Eff es ()
 err = withFrozenCallStack $ log ERROR
 
@@ -149,6 +172,11 @@ runLogNoOp = reinterpret (runReader (Namespace "")) $ \env -> \case
     GetNamespace -> ask
 
 
+-- | Interpret 'Log' by writing formatted messages to stdout.
+--
+-- The minimum severity defaults to 'Config'\'s @minimumSeverity@, but can be
+-- overridden at runtime by the @DEBUG@, @LOGGING@ or @LOG@ environment
+-- variables (checked in that order).
 runLog :: (Env :> es, IOE :> es, Reader Config :> es) => Eff (Log : es) a -> Eff es a
 runLog action = do
     config <- ask
@@ -191,6 +219,7 @@ runLogToHandle handle minSeverity action =
         GetNamespace -> ask
 
 
+-- | Interpret 'Log' by collecting messages into a 'Writer', for tests.
 runLogWriter :: (Writer [Message] :> es) => Eff (Log : es) a -> Eff es a
 runLogWriter = reinterpret (runReader (Namespace "")) $ \env -> \case
     LogMsg msg -> tell [msg]

--- a/atelier-core/src/Atelier/Effects/Monitoring/Metrics.hs
+++ b/atelier-core/src/Atelier/Effects/Monitoring/Metrics.hs
@@ -57,14 +57,21 @@ import Atelier.Effects.Monitoring.Metrics.Registry qualified as Registry
 
 -- | Metrics effect for tracking application metrics
 data Metrics :: Effect where
+    -- | Set a named gauge to a specific value.
     GaugeSet :: Text -> Double -> Metrics m ()
+    -- | Increment a named gauge by 1.
     GaugeInc :: Text -> Metrics m ()
+    -- | Decrement a named gauge by 1.
     GaugeDec :: Text -> Metrics m ()
+    -- | Increment a named counter by 1.
     CounterInc :: Text -> Metrics m ()
+    -- | Add a value to a named counter.
     CounterAdd :: Text -> Double -> Metrics m ()
+    -- | Observe a value in a named histogram.
     HistogramObserve :: Text -> Double -> Metrics m ()
     -- | Time an action and record its duration to a histogram metric
     WithHistogramTiming :: Text -> m a -> Metrics m a
+    -- | Export all collected metrics in Prometheus text format.
     ExportMetrics :: Metrics m Text
 
 

--- a/atelier-core/src/Atelier/Effects/Monitoring/Metrics/Registry.hs
+++ b/atelier-core/src/Atelier/Effects/Monitoring/Metrics/Registry.hs
@@ -18,6 +18,8 @@ import Data.Map.Strict qualified as Map
 import Prometheus qualified as Prom
 
 
+-- | Mutable handles to the registered Prometheus metrics, keyed by name and
+-- created on first use.
 data MetricHandles = MetricHandles
     { gauges :: IORef (Map Text Prom.Gauge)
     , counters :: IORef (Map Text Prom.Counter)

--- a/atelier-core/src/Atelier/Effects/Monitoring/Metrics/Server.hs
+++ b/atelier-core/src/Atelier/Effects/Monitoring/Metrics/Server.hs
@@ -34,6 +34,7 @@ data MetricsServer :: Effect where
 makeEffect ''MetricsServer
 
 
+-- | Interpret 'MetricsServer' by running a real Warp HTTP server.
 runMetricsServerIO :: (IOE :> es) => Eff (MetricsServer : es) a -> Eff es a
 runMetricsServerIO = interpret_ \case
     RunMetricsServer port -> liftIO $ Warp.run port metricsApp

--- a/atelier-core/src/Atelier/Effects/Monitoring/Tracing.hs
+++ b/atelier-core/src/Atelier/Effects/Monitoring/Tracing.hs
@@ -88,8 +88,10 @@ instance Default TracingConfig where
 
 -- | Span status for indicating success or failure
 data SpanStatus
-    = Ok
-    | Error Text
+    = -- | The operation completed successfully.
+      Ok
+    | -- | The operation failed, with an explanatory message.
+      Error Text
     deriving stock (Eq, Show)
 
 
@@ -129,6 +131,9 @@ instance OT.ToAttribute Attr where
     toAttribute (Attr a) = OT.toAttribute a
 
 
+-- | Wrapper that turns any 'Show'able value into an OpenTelemetry attribute via
+-- its 'Show' instance. Derive an attribute instance @via 'ToAttributeShow' T@,
+-- or wrap a value directly.
 newtype ToAttributeShow a = ToAttributeShow
     { getToAttributeShow :: a
     }

--- a/atelier-core/src/Atelier/Effects/Monitoring/Tracing/Provider.hs
+++ b/atelier-core/src/Atelier/Effects/Monitoring/Tracing/Provider.hs
@@ -13,9 +13,13 @@ import OpenTelemetry.Attributes qualified as OT
 import OpenTelemetry.Trace qualified as OT
 
 
+-- | Handles to the initialised OpenTelemetry tracer provider and a tracer
+-- derived from it.
 data TracingState = TracingState
     { tracerProvider :: OT.TracerProvider
+    -- ^ The global tracer provider; flushed and shut down on teardown.
     , tracer :: OT.Tracer
+    -- ^ The tracer used to create spans.
     }
 
 

--- a/atelier-core/src/Atelier/Effects/Posix/Daemons.hs
+++ b/atelier-core/src/Atelier/Effects/Posix/Daemons.hs
@@ -1,3 +1,8 @@
+-- | An effect for managing detached daemon processes via PID files.
+--
+-- 'daemonize' forks a program into the background, 'isRunning' checks a daemon's
+-- PID file, and 'forceKillAndWait' terminates one. Backed by the @daemons@
+-- package.
 module Atelier.Effects.Posix.Daemons
     ( Daemons
     , PidFile (..)
@@ -16,6 +21,7 @@ import Effectful.TH (makeEffect)
 import System.Posix.Daemon qualified as Daemons
 
 
+-- | Effect for managing detached daemon processes.
 data Daemons :: Effect where
     -- | Daemonize the given program, ensuring it is cleanly separated from the
     -- spawning process.
@@ -26,12 +32,14 @@ data Daemons :: Effect where
     ForceKillAndWait :: PidFile -> Daemons m (Either SomeException ())
 
 
+-- | The path to a daemon's PID file, used to track and control it.
 newtype PidFile = PidFile {getPidFile :: FilePath}
 
 
 makeEffect ''Daemons
 
 
+-- | Interpret 'Daemons' using the @daemons@ package.
 runDaemons :: (IOE :> es) => Eff (Daemons : es) a -> Eff es a
 runDaemons act = do
     interpretWith act \env -> \case

--- a/atelier-core/src/Atelier/Effects/Publishing.hs
+++ b/atelier-core/src/Atelier/Effects/Publishing.hs
@@ -1,3 +1,14 @@
+-- | A typed publish/subscribe effect pair.
+--
+-- 'Pub' publishes events of a given type; 'Sub' subscribes and delivers each
+-- published event to a listener. 'runPubSub' wires the two together over an
+-- internal broadcast channel, propagating tracing context from publisher to
+-- listener; 'runPubWriter' instead records published events to a 'Writer', for
+-- tests.
+--
+-- Subscriptions are established asynchronously, so a listener you intend to
+-- publish to should be started with 'forkListener' or 'forkListener_', which
+-- block until the subscription is live and therefore cannot miss early events.
 module Atelier.Effects.Publishing
     ( Pub
     , Sub
@@ -41,10 +52,13 @@ import Atelier.Effects.Clock qualified as Clock
 import Atelier.Effects.Monitoring.Tracing qualified as Tracing
 
 
+-- | Effect for publishing events of type @event@.
 data Pub (event :: Type) :: Effect where
+    -- | Publish an event to all current subscribers.
     Publish :: event -> Pub event m ()
 
 
+-- | Effect for subscribing to events of type @event@.
 data Sub (event :: Type) :: Effect where
     -- | Subscribe, then run @onSubscribed@ once the subscription is established
     -- — after the internal channel has been duplicated and before any event is
@@ -66,6 +80,7 @@ listen :: (Sub event :> es) => (UTCTime -> event -> Eff es ()) -> Eff es Void
 listen = listenWith (pure ())
 
 
+-- | Like 'listen', but the listener ignores the event timestamp.
 listen_ :: (Sub event :> es) => (event -> Eff es ()) -> Eff es Void
 listen_ listener = listen $ \_timestamp event -> listener event
 

--- a/atelier-core/src/Atelier/Effects/Tally.hs
+++ b/atelier-core/src/Atelier/Effects/Tally.hs
@@ -82,6 +82,9 @@ runTally = reinterpret (runCacheTtl @key @Int) $ \env -> \case
         unlift $ continuation (classify count)
 
 
+-- | Interpret 'Tally' with a fixed count for every key, ignoring real
+-- tallying. The classifier is always handed @c@, making the outcome
+-- deterministic for tests.
 runTallyConst :: Int -> Eff (Tally key : es) a -> Eff es a
 runTallyConst c = interpret \env -> \case
     WithTallyCheck _ classify f -> localSeqUnlift env \unlift -> unlift $ f (classify c)

--- a/atelier-core/src/Atelier/Effects/Timeout.hs
+++ b/atelier-core/src/Atelier/Effects/Timeout.hs
@@ -1,3 +1,16 @@
+-- | An effect for bounding a computation by a wall-clock deadline.
+--
+-- 'timeout' runs an action, returning 'Nothing' if it does not finish within
+-- the given 'TimeUnit' duration; 'timeout_' is the variant that discards the
+-- result. When the deadline passes the action is cancelled with an asynchronous
+-- exception.
+--
+-- @
+-- result <- timeout (5 :: Second) fetchRemote
+-- case result of
+--     Just value -> use value
+--     Nothing    -> logWarn \"fetch timed out\"
+-- @
 module Atelier.Effects.Timeout
     ( Timeout
     , timeout
@@ -14,7 +27,10 @@ import System.Timeout qualified as IO
 import Atelier.Time (TimeUnit (..))
 
 
+-- | Effect for bounding a computation by a wall-clock deadline.
 data Timeout :: Effect where
+    -- | Run an action, returning 'Just' its result if it completes within the
+    -- duration, or 'Nothing' if the deadline passes first.
     Timeout :: (TimeUnit t) => t -> m a -> Timeout m (Maybe a)
 
 
@@ -28,6 +44,7 @@ timeout_ :: (TimeUnit t, Timeout :> es) => t -> Eff es a -> Eff es ()
 timeout_ t m = const () <$> timeout t m
 
 
+-- | Interpret 'Timeout' using 'System.Timeout.timeout'.
 runTimeout :: (HasCallStack, IOE :> es) => Eff (Timeout : es) a -> Eff es a
 runTimeout = interpret \env -> \case
     Timeout delay action ->

--- a/atelier-core/src/Atelier/Effects/UUID.hs
+++ b/atelier-core/src/Atelier/Effects/UUID.hs
@@ -1,3 +1,8 @@
+-- | An effect for generating UUIDs.
+--
+-- 'runGenUUID' produces fresh random (version 4) UUIDs; 'runGenUUIDConst'
+-- returns a fixed UUID every time, for deterministic tests. The 'UUID' type is
+-- re-exported from @uuid@.
 module Atelier.Effects.UUID
     ( GenUUID
     , UUID
@@ -13,16 +18,20 @@ import Effectful.Dispatch.Dynamic (interpret_)
 import Effectful.TH (makeEffect)
 
 
+-- | Effect for generating UUIDs.
 data GenUUID :: Effect where
+    -- | Generate a UUID.
     Gen :: GenUUID m UUID
 
 
 makeEffect ''GenUUID
 
 
+-- | Interpret 'GenUUID' by generating fresh random (version 4) UUIDs.
 runGenUUID :: (IOE :> es) => Eff (GenUUID : es) a -> Eff es a
 runGenUUID = interpret_ \Gen -> liftIO nextRandom
 
 
+-- | Interpret 'GenUUID' so 'gen' always returns the given fixed UUID, for tests.
 runGenUUIDConst :: UUID -> Eff (GenUUID : es) a -> Eff es a
 runGenUUIDConst uuid = interpret_ \Gen -> pure uuid

--- a/atelier-core/src/Atelier/Effects/Yield.hs
+++ b/atelier-core/src/Atelier/Effects/Yield.hs
@@ -1,3 +1,10 @@
+-- | The producing half of a 'Yield'\/'Await' coroutine pair.
+--
+-- A 'Yield' computation emits values one at a time, analogous to the
+-- @Writer@\/@Output@ effects. The interpreters here collect the stream
+-- ('yieldToList', 'withYieldToList'), drive it ('forEach'), or transform it
+-- ('map', 'mapMaybe', 'filter', 'changes', 'enumerate'). The effect itself lives
+-- in "Atelier.Effects.Internal.Coroutine" and is re-exported here.
 module Atelier.Effects.Yield
     ( -- * Effect
       Yield
@@ -46,12 +53,16 @@ import Atelier.Effects.Internal.Coroutine
     )
 
 
+-- | Forward only the 'yield'ed values that satisfy a predicate, dropping the
+-- rest from the stream.
 filter :: (a -> Bool) -> Eff (Yield a : es) r -> Eff (Yield a : es) r
 filter p = interpose_ \(Yield x) ->
     when (p x) do
         yield x
 
 
+-- | Re-yield values that differ from a reference value (supplied as the first
+-- argument).
 changes :: forall a es r. (Eq a) => a -> Eff (Yield a : es) r -> Eff (Yield a : es) r
 changes initial = impose_ (evalState initial) \(Yield x) -> do
     curr <- get

--- a/atelier-core/src/Atelier/Exception.hs
+++ b/atelier-core/src/Atelier/Exception.hs
@@ -1,3 +1,9 @@
+-- | Helpers for telling synchronous exceptions apart from asynchronous ones.
+--
+-- Synchronous exceptions are genuine failures worth catching, logging, or
+-- retrying; asynchronous ones (thread cancellation, @SIGINT@) usually signal an
+-- intentional shutdown and should be allowed to propagate. The @*SyncIO@
+-- helpers catch only the former and re-throw the latter.
 module Atelier.Exception
     ( isGracefulShutdown
     , trySyncIO
@@ -24,6 +30,8 @@ trySyncIO :: IO a -> IO (Either SomeException a)
 trySyncIO f = withFrozenCallStack catchSyncIO (fmap Right f) (pure . Left)
 
 
+-- | Like @Control.Exception.catch@, but only synchronous exceptions reach the
+-- handler; asynchronous exceptions are re-thrown unchanged.
 catchSyncIO :: (HasCallStack) => IO a -> (SomeException -> IO a) -> IO a
 catchSyncIO f g =
     f `E.catch` \e ->

--- a/atelier-core/src/Atelier/Time.hs
+++ b/atelier-core/src/Atelier/Time.hs
@@ -1,5 +1,21 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
+-- | Strongly-typed time units and conversions.
+--
+-- Re-exports the duration types from "Data.Time.Units" — so a single import
+-- covers 'Microsecond', 'Millisecond', 'Second', 'Minute' and 'Hour' — and adds
+-- conversion helpers plus JSON instances for those types. Each unit serialises
+-- as an integer count of itself: a 'Second' as a whole number of seconds, a
+-- 'Millisecond' as milliseconds, and so on.
+--
+-- Note: the 'FromJSON' and 'ToJSON' instances for the time-unit types are
+-- orphans, defined here because neither @aeson@ nor @time-units@ provides them.
+--
+-- @
+-- nominalDiffTime 1.5 :: Millisecond        -- 1.5s rounded to 1500ms
+-- convertUnit (5 :: Minute) :: Second       -- 300
+-- toMicroseconds (2 :: Second)              -- 2000000
+-- @
 module Atelier.Time
     ( -- * Time units
       TimeUnit
@@ -21,6 +37,8 @@ import Data.Time (NominalDiffTime)
 import Data.Time.Units (Hour, Microsecond, Millisecond, Minute, Second, TimeUnit, convertUnit, fromMicroseconds, toMicroseconds)
 
 
+-- | Convert a 'NominalDiffTime' to any 'TimeUnit', rounding to the nearest
+-- whole unit (the conversion goes through microsecond precision).
 nominalDiffTime :: (TimeUnit t) => NominalDiffTime -> t
 nominalDiffTime = fromMicroseconds . round @Double . (* 1_000_000) . realToFrac
 

--- a/atelier-core/src/Atelier/Types/Base64.hs
+++ b/atelier-core/src/Atelier/Types/Base64.hs
@@ -1,3 +1,13 @@
+-- | A 'ByteString' that serialises to and from JSON as a Base64-encoded string.
+--
+-- Use it directly as a field type, or derive the JSON instances for a
+-- @ByteString@ newtype via it, to carry binary data through JSON without
+-- tripping over non-UTF-8 bytes:
+--
+-- @
+-- newtype Token = Token ByteString
+--     deriving (ToJSON, FromJSON) via Base64
+-- @
 module Atelier.Types.Base64
     ( Base64 (..)
     ) where
@@ -7,7 +17,7 @@ import Data.Aeson (FromJSON (..), ToJSON (..), withText)
 import Data.ByteString.Base64 qualified as Base64
 
 
--- | Newtype wrapper for deriving ToJSON/FromJSON with Base64 encoding.
+-- | A 'ByteString' whose JSON representation is Base64-encoded text.
 newtype Base64 = Base64 {getBase64 :: ByteString}
 
 

--- a/atelier-core/src/Atelier/Types/HttpApiDataReadShow.hs
+++ b/atelier-core/src/Atelier/Types/HttpApiDataReadShow.hs
@@ -1,8 +1,25 @@
+-- | Derive 'FromHttpApiData' and 'ToHttpApiData' for a type from its 'Read' and
+-- 'Show' instances.
+--
+-- Handy for values that appear in URL path segments or query strings and whose
+-- textual form is exactly their 'Show' output, such as small enums:
+--
+-- @
+-- data Mode = Fast | Slow
+--     deriving stock (Read, Show)
+--     deriving (FromHttpApiData, ToHttpApiData) via (HttpApiDataReadShow Mode)
+-- @
+--
+-- The encoding is the bare 'Show' output, so @Fast@ travels on the wire as the
+-- segment @\/mode\/Fast@ or the query parameter @?mode=Slow@, and is read back
+-- with 'Read'. Values whose 'Show' output contains characters that need
+-- percent-encoding (spaces, @\/@, @&@) are best avoided here.
 module Atelier.Types.HttpApiDataReadShow (HttpApiDataReadShow (..)) where
 
 import Web.HttpApiData (FromHttpApiData (..), ToHttpApiData (..))
 
 
+-- | Carrier for deriving HTTP-API-data instances via 'Read' and 'Show'.
 newtype HttpApiDataReadShow a
     = HttpApiDataReadShow {getHttpApiDataReadShow :: a}
 

--- a/atelier-core/src/Atelier/Types/JsonReadShow.hs
+++ b/atelier-core/src/Atelier/Types/JsonReadShow.hs
@@ -1,9 +1,24 @@
+-- | Derive 'FromJSON' and 'ToJSON' for a type from its 'Read' and 'Show'
+-- instances, encoding each value as a JSON string.
+--
+-- A value is stored as its 'Show' output and parsed back with 'readMaybe'. On
+-- failure the error message names the type (via 'Typeable'), e.g.
+-- @Failed to read Mode@.
+--
+-- @
+-- data Mode = Fast | Slow
+--     deriving stock (Read, Show)
+--     deriving (FromJSON, ToJSON) via (JsonReadShow Mode)
+-- @
+--
+-- Here @Fast@ serialises to the JSON string @\"Fast\"@.
 module Atelier.Types.JsonReadShow (JsonReadShow (..)) where
 
 import Data.Aeson (FromJSON (..), ToJSON (..), Value (..), withText)
 import Data.Typeable (typeRep)
 
 
+-- | Carrier for deriving JSON instances via 'Read' and 'Show'.
 newtype JsonReadShow a = JsonReadShow {getJsonReadShow :: a}
 
 

--- a/atelier-core/src/Atelier/Types/QuietSnake.hs
+++ b/atelier-core/src/Atelier/Types/QuietSnake.hs
@@ -1,5 +1,18 @@
 {-# LANGUAGE UndecidableInstances #-}
 
+-- | Derive 'FromJSON' and 'ToJSON' for a record so its Haskell field names map
+-- to @quiet_snake_case@ JSON keys.
+--
+-- \"Quiet\" snake case lowercases and underscore-separates words without an
+-- extra leading underscore, so the field @maxRetries@ becomes the JSON key
+-- @max_retries@. Derive via this wrapper to keep idiomatic Haskell field names
+-- while exposing snake-case JSON:
+--
+-- @
+-- data Settings = Settings { maxRetries :: Int, dryRun :: Bool }
+--     deriving stock (Generic)
+--     deriving (FromJSON, ToJSON) via (QuietSnake Settings)
+-- @
 module Atelier.Types.QuietSnake
     ( QuietSnake (..)
     ) where
@@ -11,7 +24,7 @@ import GHC.Generics (Rep)
 import Text.Casing (quietSnake)
 
 
--- | Newtype wrapper for deriving FromJSON with quiet_snake_case field names
+-- | Carrier for deriving @quiet_snake_case@ JSON instances generically.
 newtype QuietSnake a = QuietSnake {getQuietSnake :: a}
 
 

--- a/atelier-core/src/Atelier/Types/WithDefaults.hs
+++ b/atelier-core/src/Atelier/Types/WithDefaults.hs
@@ -1,3 +1,20 @@
+-- | Merge a type's 'Default' value into incoming JSON before parsing, so fields
+-- absent from the input fall back to their defaults instead of failing.
+--
+-- Derive 'FromJSON' via this wrapper when partial JSON should be completed from
+-- a 'Default' instance. Missing non-'Maybe' fields then take their default
+-- value rather than causing a parse error:
+--
+-- @
+-- data Config = Config { retries :: Int, verbose :: Bool }
+--     deriving stock (Generic)
+--     deriving (FromJSON) via (WithDefaults Config)
+--
+-- instance Default Config where
+--     def = Config { retries = 3, verbose = False }
+-- @
+--
+-- Parsing @{\"verbose\": true}@ then yields @Config { retries = 3, verbose = True }@.
 module Atelier.Types.WithDefaults
     ( WithDefaults (..)
     ) where
@@ -8,9 +25,8 @@ import Data.Default (Default (..))
 import Data.Aeson.KeyMap qualified as KM
 
 
--- | Newtype wrapper that merges default-instance values into incoming JSON before
--- parsing, so non-Maybe fields absent from the input fall back to their 'Default'
--- values rather than causing a parse failure.
+-- | Carrier that fills missing JSON fields from a type's 'Default' instance
+-- before parsing.
 newtype WithDefaults a = WithDefaults {getWithDefaults :: a}
 
 

--- a/atelier-db/src/Atelier/Effects/DB.hs
+++ b/atelier-db/src/Atelier/Effects/DB.hs
@@ -1,3 +1,10 @@
+-- | Database access effects for Hasql connection pools.
+--
+-- 'DBRead' runs read-only statements against a reader pool; 'DBWrite' runs
+-- transactions against a writer pool. Both record OpenTelemetry spans, and
+-- 'DBRead' additionally emits Prometheus metrics (named via
+-- 'DBReadMetricNames'). Failures surface through the @Error Text@ effect.
+-- 'runDB' installs both effects over a shared 'DBPools'.
 module Atelier.Effects.DB
     ( DBRead
     , DBWrite
@@ -29,21 +36,26 @@ import Atelier.Effects.DB.Config (DBPools)
 import Atelier.Effects.DB.Config qualified as DB
 
 
--- | Metric names for database read operations
+-- | Names of the Prometheus metrics recorded for database read operations.
 data DBReadMetricNames = DBReadMetricNames
     { queries :: Text
+    -- ^ Counter incremented once per query.
     , errors :: Text
+    -- ^ Counter incremented when a query fails.
     , duration :: Text
+    -- ^ Histogram recording query duration.
     }
 
 
--- | Effect for read-only database queries
+-- | Effect for read-only database queries.
 data DBRead :: Effect where
+    -- | Run a named read-only statement and return its result.
     RunQuery :: Text -> Statement () b -> DBRead m b
 
 
--- | Effect for write database transactions
+-- | Effect for write database transactions.
 data DBWrite :: Effect where
+    -- | Run a named transaction and return its result.
     RunTransaction :: Text -> Transaction.Transaction a -> DBWrite m a
 
 
@@ -51,6 +63,8 @@ makeEffect ''DBRead
 makeEffect ''DBWrite
 
 
+-- | Interpret 'DBRead' against the reader pool, tracing each query and
+-- recording the given metrics.
 runDBRead
     :: (Error Text :> es, IOE :> es, Metrics :> es, Reader DBPools :> es, Tracing :> es)
     => DBReadMetricNames
@@ -74,6 +88,7 @@ runDBRead metricNames eff = do
                         pure value
 
 
+-- | Interpret 'DBWrite' against the writer pool, tracing each transaction.
 runDBWrite
     :: (Error Text :> es, IOE :> es, Reader DBPools :> es, Tracing :> es)
     => Eff (DBWrite : es) a

--- a/atelier-db/src/Atelier/Effects/DB/Config.hs
+++ b/atelier-db/src/Atelier/Effects/DB/Config.hs
@@ -1,3 +1,8 @@
+-- | Database connection configuration and pool acquisition.
+--
+-- 'DBConfig' describes how to reach a database as one user, and 'PoolConfig'
+-- tunes its connection pool. 'acquireDatabasePools' builds separate reader and
+-- writer pools ('DBPools'), typically using distinct least-privilege roles.
 module Atelier.Effects.DB.Config
     ( DBConfig (..)
     , DBPools (..)
@@ -17,33 +22,45 @@ import Hasql.Pool qualified as Pool
 import Hasql.Pool.Config qualified as Pool
 
 
--- | Connection pool configuration
+-- | Connection pool configuration.
 data PoolConfig = PoolConfig
     { size :: Int
+    -- ^ Maximum number of connections in the pool.
     , acquisitionTimeoutSeconds :: Int
+    -- ^ How long to wait for a free connection before failing.
     , agingTimeoutSeconds :: Int
+    -- ^ Maximum lifetime of a connection before it is retired.
     , idlenessTimeoutSeconds :: Int
+    -- ^ How long an idle connection is kept before being closed.
     }
     deriving stock (Eq, Generic, Show)
     deriving (FromJSON) via QuietSnake PoolConfig
 
 
--- | Database configuration for a single user
+-- | Connection details for reaching a database as a single user.
 data DBConfig = DBConfig
     { host :: Text
+    -- ^ Database server host.
     , port :: Word16
+    -- ^ Database server port.
     , user :: Text
+    -- ^ Role to connect as.
     , password :: Text
+    -- ^ Password for the role.
     , databaseName :: Text
+    -- ^ Name of the database to connect to.
     , pool :: PoolConfig
+    -- ^ Connection pool settings.
     }
     deriving stock (Eq, Show)
 
 
--- | Separate connection pools for read and write operations
+-- | Separate connection pools for read and write operations.
 data DBPools = DBPools
     { readerPool :: Pool.Pool
+    -- ^ Pool for read-only queries.
     , writerPool :: Pool.Pool
+    -- ^ Pool for write transactions.
     }
 
 

--- a/atelier-db/src/Atelier/Effects/DB/Rel8.hs
+++ b/atelier-db/src/Atelier/Effects/DB/Rel8.hs
@@ -1,3 +1,9 @@
+-- | Rel8 query helpers layered over the 'DBRead' and 'DBWrite' effects.
+--
+-- Thin wrappers that build Hasql @Statement@s from Rel8 queries and run them
+-- through the database effects: 'select' and 'select1' for reads, and 'transact'
+-- with 'insert_', 'update_', 'delete_' and 'selectTx' for writes. The Hasql
+-- 'Transaction' type is re-exported for building transaction bodies.
 module Atelier.Effects.DB.Rel8
     ( Transaction
     , select

--- a/atelier-prelude/src/Prelude.hs
+++ b/atelier-prelude/src/Prelude.hs
@@ -1,4 +1,4 @@
--- | This Prelude is meant to mimic the `relude` package's `Relude` module,
+-- | This Prelude is meant to mimic the @relude@ package's "Relude" module,
 -- with the following exceptions:
 --
 -- - No MTL classes or monads.

--- a/atelier-testing/src/Atelier/Testing/Database.hs
+++ b/atelier-testing/src/Atelier/Testing/Database.hs
@@ -1,3 +1,10 @@
+-- | Hspec helpers for running tests against a real, ephemeral PostgreSQL
+-- database.
+--
+-- 'withCleanTestDatabase' starts a temporary PostgreSQL server once per test
+-- process, applies your migrations into a template database, and hands each spec
+-- group a fresh database (as 'DBPools') that is truncated between individual
+-- tests. Configure it with a 'TmpDbConfig'.
 module Atelier.Testing.Database
     ( TmpDbConfig (..)
     , withCleanTestDatabase


### PR DESCRIPTION
Document the public API of atelier-prelude, atelier-core, atelier-db and atelier-testing for Hackage readiness:

- Add module headers, per-declaration docs (effect types, GADT constructors, record fields, interpreters) and usage examples
- Fix atelier-prelude header formatting: `@relude@` and a working "Relude" module link
- Modernize `Atelier.Effects.Chan`'s old `Module:/Description:` header
- Resolve ambiguous and out-of-scope Haddock identifier links

Every owned declaration is documented; the remaining coverage gaps are external re-exports that link to their source packages.