### PR TITLE
docs: add package READMEs and release metadata

### DIFF
--- a/atelier-core/README.md
+++ b/atelier-core/README.md
@@ -1,34 +1,33 @@
-# Atelier
+# atelier-core
 
-A family of Haskell packages providing foundational infrastructure for
-effect-based applications, built on
-[Effectful](https://github.com/haskell-effectful/effectful).
+Foundational effects and utilities for effect-based applications, built on [Effectful](https://github.com/haskell-effectful/effectful). Part of the **atelier** toolkit.
 
-## Packages
+## Overview
 
-### `atelier-core`
-
-Core effects and utilities:
+`atelier-core` provides a set of composable Effectful effects and supporting types for building structured, observable applications.
 
 | Module | Purpose |
 |---|---|
 | `Atelier.Component` | Structured component lifecycle (`setup → listeners → start`) |
 | `Atelier.Config` | Configuration with environment variable overrides |
 | `Atelier.Effects.Log` | Structured logging with hierarchical namespaces |
-| `Atelier.Effects.Conc` | Thread management via Ki (structured concurrency) |
+| `Atelier.Effects.Conc` | Thread management via [Ki](https://github.com/awkward-squad/ki) (structured concurrency) |
 | `Atelier.Effects.Cache` | Caching with singleflight deduplication |
-| `Atelier.Effects.Publishing` | Event publishing |
-| `Atelier.Effects.Monitoring.*` | OpenTelemetry tracing and Prometheus metrics |
+| `Atelier.Effects.Publishing` | Event publishing with context propagation |
+| `Atelier.Effects.Monitoring.Tracing` | OpenTelemetry tracing |
+| `Atelier.Effects.Monitoring.Metrics` | Prometheus metrics |
+| `Atelier.Effects.FileWatcher` | Filesystem change notifications |
+| `Atelier.Effects.Process` | External process management |
 
-### `atelier-db`
+It also wraps a number of `IO`-based primitives (environment, clock, file system, console, POSIX) as effects so they can be interpreted and tested explicitly: `Atelier.Effects.Env`, `Atelier.Effects.Clock`, `Atelier.Effects.FileSystem`, `Atelier.Effects.Console`, `Atelier.Effects.Posix.*`, and more.
 
-Relational database access via Rel8/Hasql, exposed as an Effectful effect
-(`Atelier.Effects.DB`).
+## Part of atelier
 
-### `atelier-prelude`
+- [`atelier-prelude`](https://github.com/atelier-hub/tricorder/tree/main/atelier-prelude) — relude-based prelude with Effectful conventions
+- [`atelier-core`](https://github.com/atelier-hub/tricorder/tree/main/atelier-core) — this package
+- [`atelier-db`](https://github.com/atelier-hub/tricorder/tree/main/atelier-db) — relational database effect (Hasql/Rel8)
+- [`atelier-testing`](https://github.com/atelier-hub/tricorder/tree/main/atelier-testing) — database-backed test utilities
 
-Custom prelude based on [relude](https://github.com/kowainik/relude), enforcing Effectful conventions.
+## License
 
-### `atelier-testing`
-
-Test utilities for database-backed tests using [tmp-postgres](https://github.com/jfischoff/tmp-postgres).
+MIT — see [LICENSE](LICENSE).

--- a/atelier-core/atelier-core.cabal
+++ b/atelier-core/atelier-core.cabal
@@ -12,7 +12,7 @@ category:       Control
 homepage:       https://github.com/atelier-hub/tricorder#readme
 bug-reports:    https://github.com/atelier-hub/tricorder/issues
 author:         Christian Georgii
-maintainer:     cgeorgii@gmail.com
+maintainer:     christian.georgii@tweag.io
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple

--- a/atelier-core/package.yaml
+++ b/atelier-core/package.yaml
@@ -3,7 +3,7 @@ version:             0.1.0.0
 synopsis:            Foundational Effectful-based effects and utilities
 description:         Core effects and utilities for effect-based applications, built on Effectful — part of the atelier toolkit.
 author:              Christian Georgii
-maintainer:          cgeorgii@gmail.com
+maintainer:          christian.georgii@tweag.io
 license:             MIT
 license-file:        LICENSE
 github:              atelier-hub/tricorder

--- a/atelier-db/README.md
+++ b/atelier-db/README.md
@@ -1,0 +1,24 @@
+# atelier-db
+
+Relational database access via [Hasql](https://github.com/nikita-volkov/hasql) and [Rel8](https://github.com/circuithub/rel8), exposed as an [Effectful](https://github.com/haskell-effectful/effectful) effect. Part of the **atelier** toolkit.
+
+## Overview
+
+`atelier-db` exposes database access as a first-class effect so queries can be interpreted, mocked, and composed alongside the rest of your application's effects.
+
+| Module | Purpose |
+|---|---|
+| `Atelier.Effects.DB` | The `DB` effect and its interpreters |
+| `Atelier.Effects.DB.Config` | Connection configuration |
+| `Atelier.Effects.DB.Rel8` | Rel8 query helpers over the `DB` effect |
+
+## Part of atelier
+
+- [`atelier-prelude`](https://github.com/atelier-hub/tricorder/tree/main/atelier-prelude) — relude-based prelude with Effectful conventions
+- [`atelier-core`](https://github.com/atelier-hub/tricorder/tree/main/atelier-core) — foundational effects and utilities
+- [`atelier-db`](https://github.com/atelier-hub/tricorder/tree/main/atelier-db) — this package
+- [`atelier-testing`](https://github.com/atelier-hub/tricorder/tree/main/atelier-testing) — database-backed test utilities
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/atelier-db/atelier-db.cabal
+++ b/atelier-db/atelier-db.cabal
@@ -12,12 +12,13 @@ category:       Database
 homepage:       https://github.com/atelier-hub/tricorder#readme
 bug-reports:    https://github.com/atelier-hub/tricorder/issues
 author:         Christian Georgii
-maintainer:     cgeorgii@gmail.com
+maintainer:     christian.georgii@tweag.io
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 extra-doc-files:
     CHANGELOG.md
+    README.md
 
 source-repository head
   type: git

--- a/atelier-db/package.yaml
+++ b/atelier-db/package.yaml
@@ -3,7 +3,7 @@ version:             0.1.0.0
 synopsis:            Relational database effect for atelier (Hasql/Rel8)
 description:         Relational database access via Hasql and Rel8, exposed as an Effectful effect — part of the atelier toolkit.
 author:              Christian Georgii
-maintainer:          cgeorgii@gmail.com
+maintainer:          christian.georgii@tweag.io
 license:             MIT
 license-file:        LICENSE
 github:              atelier-hub/tricorder
@@ -11,6 +11,7 @@ category:            Database
 
 extra-doc-files:
 - CHANGELOG.md
+- README.md
 
 language: GHC2021
 

--- a/atelier-prelude/README.md
+++ b/atelier-prelude/README.md
@@ -1,0 +1,47 @@
+# atelier-prelude
+
+A custom prelude based on [relude](https://github.com/kowainik/relude), adapted for [Effectful](https://github.com/haskell-effectful/effectful) conventions. Part of the **atelier** toolkit.
+
+## Usage
+
+`atelier-prelude` exposes a module named `Prelude`. To make it the implicit prelude, hide `base`'s `Prelude` with a mixin — GHC's automatic `import Prelude` then resolves to this one, with no `NoImplicitPrelude` and no per-module imports.
+
+In `package.yaml` (hpack):
+
+```yaml
+dependencies:
+- name: base
+  mixin:
+  - hiding (Prelude)
+- atelier-prelude
+```
+
+or in a `.cabal` file:
+
+```cabal
+build-depends: base, atelier-prelude
+mixins:        base hiding (Prelude)
+```
+
+Add `-Wno-implicit-prelude` to your `ghc-options` to silence the implicit-prelude warning.
+
+## What's different from relude
+
+Lifted, `IO`-based operations from relude are intentionally **not** re-exported, so that effects are threaded explicitly through Effectful rather than performed in `IO`:
+
+- `Relude.Lifted.*` (system, environment, handle, terminal, file operations)
+- `Relude.File`
+- `Relude.Print` (console output)
+
+Use the corresponding `atelier-core` effects instead — e.g. `Atelier.Effects.Env`, `Atelier.Effects.File`, `Atelier.Effects.Console`.
+
+## Part of atelier
+
+- [`atelier-prelude`](https://github.com/atelier-hub/tricorder/tree/main/atelier-prelude) — this package
+- [`atelier-core`](https://github.com/atelier-hub/tricorder/tree/main/atelier-core) — foundational effects and utilities
+- [`atelier-db`](https://github.com/atelier-hub/tricorder/tree/main/atelier-db) — relational database effect (Hasql/Rel8)
+- [`atelier-testing`](https://github.com/atelier-hub/tricorder/tree/main/atelier-testing) — database-backed test utilities
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/atelier-prelude/atelier-prelude.cabal
+++ b/atelier-prelude/atelier-prelude.cabal
@@ -9,15 +9,16 @@ version:        0.1.0.0
 synopsis:       Custom relude-based prelude with Effectful conventions
 description:    A custom prelude based on relude, adapted for Effectful — part of the atelier toolkit.
 category:       Prelude
-homepage:       https://github.com/atelier-hub/tricorder#readme
+homepage:       https://github.com/atelier-hub/tricorder/tree/main/atelier-prelude
 bug-reports:    https://github.com/atelier-hub/tricorder/issues
 author:         Christian Georgii
-maintainer:     cgeorgii@gmail.com
+maintainer:     christian.georgii@tweag.io
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 extra-doc-files:
     CHANGELOG.md
+    README.md
 
 source-repository head
   type: git

--- a/atelier-prelude/package.yaml
+++ b/atelier-prelude/package.yaml
@@ -3,14 +3,16 @@ version:             0.1.0.0
 synopsis:            Custom relude-based prelude with Effectful conventions
 description:         A custom prelude based on relude, adapted for Effectful — part of the atelier toolkit.
 author:              Christian Georgii
-maintainer:          cgeorgii@gmail.com
+maintainer:          christian.georgii@tweag.io
 license:             MIT
 license-file:        LICENSE
 github:              atelier-hub/tricorder
+homepage:            https://github.com/atelier-hub/tricorder/tree/main/atelier-prelude
 category:            Prelude
 
 extra-doc-files:
 - CHANGELOG.md
+- README.md
 
 language: GHC2021
 

--- a/atelier-testing/README.md
+++ b/atelier-testing/README.md
@@ -1,0 +1,22 @@
+# atelier-testing
+
+Test utilities for database-backed tests using [tmp-postgres](https://github.com/jfischoff/tmp-postgres). Part of the **atelier** toolkit.
+
+## Overview
+
+`atelier-testing` spins up a throwaway PostgreSQL instance for integration tests, so suites that exercise [`atelier-db`](https://github.com/atelier-hub/tricorder/tree/main/atelier-db) can run against a real database without external setup.
+
+| Module | Purpose |
+|---|---|
+| `Atelier.Testing.Database` | Provision and tear down a temporary PostgreSQL database for tests |
+
+## Part of atelier
+
+- [`atelier-prelude`](https://github.com/atelier-hub/tricorder/tree/main/atelier-prelude) — relude-based prelude with Effectful conventions
+- [`atelier-core`](https://github.com/atelier-hub/tricorder/tree/main/atelier-core) — foundational effects and utilities
+- [`atelier-db`](https://github.com/atelier-hub/tricorder/tree/main/atelier-db) — relational database effect (Hasql/Rel8)
+- [`atelier-testing`](https://github.com/atelier-hub/tricorder/tree/main/atelier-testing) — this package
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/atelier-testing/atelier-testing.cabal
+++ b/atelier-testing/atelier-testing.cabal
@@ -12,12 +12,13 @@ category:       Testing
 homepage:       https://github.com/atelier-hub/tricorder#readme
 bug-reports:    https://github.com/atelier-hub/tricorder/issues
 author:         Christian Georgii
-maintainer:     cgeorgii@gmail.com
+maintainer:     christian.georgii@tweag.io
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple
 extra-doc-files:
     CHANGELOG.md
+    README.md
 
 source-repository head
   type: git

--- a/atelier-testing/package.yaml
+++ b/atelier-testing/package.yaml
@@ -3,7 +3,7 @@ version:             0.1.0.0
 synopsis:            Database-backed test utilities for atelier
 description:         Test utilities for database-backed tests using tmp-postgres — part of the atelier toolkit.
 author:              Christian Georgii
-maintainer:          cgeorgii@gmail.com
+maintainer:          christian.georgii@tweag.io
 license:             MIT
 license-file:        LICENSE
 github:              atelier-hub/tricorder
@@ -11,6 +11,7 @@ category:            Testing
 
 extra-doc-files:
 - CHANGELOG.md
+- README.md
 
 language: GHC2021
 

--- a/nix/materialized/aarch64-darwin/.plan.nix/atelier-core.nix
+++ b/nix/materialized/aarch64-darwin/.plan.nix/atelier-core.nix
@@ -14,7 +14,7 @@
       identifier = { name = "atelier-core"; version = "0.1.0.0"; };
       license = "MIT";
       copyright = "";
-      maintainer = "cgeorgii@gmail.com";
+      maintainer = "christian.georgii@tweag.io";
       author = "Christian Georgii";
       homepage = "https://github.com/atelier-hub/tricorder#readme";
       url = "";

--- a/nix/materialized/aarch64-darwin/.plan.nix/atelier-db.nix
+++ b/nix/materialized/aarch64-darwin/.plan.nix/atelier-db.nix
@@ -14,7 +14,7 @@
       identifier = { name = "atelier-db"; version = "0.1.0.0"; };
       license = "MIT";
       copyright = "";
-      maintainer = "cgeorgii@gmail.com";
+      maintainer = "christian.georgii@tweag.io";
       author = "Christian Georgii";
       homepage = "https://github.com/atelier-hub/tricorder#readme";
       url = "";
@@ -28,7 +28,7 @@
       dataFiles = [];
       extraSrcFiles = [];
       extraTmpFiles = [];
-      extraDocFiles = [ "CHANGELOG.md" ];
+      extraDocFiles = [ "CHANGELOG.md" "README.md" ];
     };
     components = {
       "library" = {

--- a/nix/materialized/aarch64-darwin/.plan.nix/atelier-prelude.nix
+++ b/nix/materialized/aarch64-darwin/.plan.nix/atelier-prelude.nix
@@ -14,9 +14,9 @@
       identifier = { name = "atelier-prelude"; version = "0.1.0.0"; };
       license = "MIT";
       copyright = "";
-      maintainer = "cgeorgii@gmail.com";
+      maintainer = "christian.georgii@tweag.io";
       author = "Christian Georgii";
-      homepage = "https://github.com/atelier-hub/tricorder#readme";
+      homepage = "https://github.com/atelier-hub/tricorder/tree/main/atelier-prelude";
       url = "";
       synopsis = "Custom relude-based prelude with Effectful conventions";
       description = "A custom prelude based on relude, adapted for Effectful — part of the atelier toolkit.";
@@ -28,7 +28,7 @@
       dataFiles = [];
       extraSrcFiles = [];
       extraTmpFiles = [];
-      extraDocFiles = [ "CHANGELOG.md" ];
+      extraDocFiles = [ "CHANGELOG.md" "README.md" ];
     };
     components = {
       "library" = {

--- a/nix/materialized/aarch64-darwin/.plan.nix/atelier-testing.nix
+++ b/nix/materialized/aarch64-darwin/.plan.nix/atelier-testing.nix
@@ -14,7 +14,7 @@
       identifier = { name = "atelier-testing"; version = "0.1.0.0"; };
       license = "MIT";
       copyright = "";
-      maintainer = "cgeorgii@gmail.com";
+      maintainer = "christian.georgii@tweag.io";
       author = "Christian Georgii";
       homepage = "https://github.com/atelier-hub/tricorder#readme";
       url = "";
@@ -28,7 +28,7 @@
       dataFiles = [];
       extraSrcFiles = [];
       extraTmpFiles = [];
-      extraDocFiles = [ "CHANGELOG.md" ];
+      extraDocFiles = [ "CHANGELOG.md" "README.md" ];
     };
     components = {
       "library" = {

--- a/nix/materialized/aarch64-darwin/.plan.nix/tricorder.nix
+++ b/nix/materialized/aarch64-darwin/.plan.nix/tricorder.nix
@@ -14,7 +14,7 @@
       identifier = { name = "tricorder"; version = "0.1.0.0"; };
       license = "MIT";
       copyright = "";
-      maintainer = "cgeorgii@gmail.com";
+      maintainer = "christian.georgii@tweag.io";
       author = "Christian Georgii";
       homepage = "";
       url = "";
@@ -23,12 +23,12 @@
       buildType = "Simple";
       isLocal = true;
       detailLevel = "FullDetails";
-      licenseFiles = [];
+      licenseFiles = [ "LICENSE" ];
       dataDir = ".";
       dataFiles = [];
       extraSrcFiles = [];
       extraTmpFiles = [];
-      extraDocFiles = [];
+      extraDocFiles = [ "README.md" ];
     };
     components = {
       sublibs = {

--- a/nix/materialized/x86_64-linux/.plan.nix/atelier-core.nix
+++ b/nix/materialized/x86_64-linux/.plan.nix/atelier-core.nix
@@ -14,7 +14,7 @@
       identifier = { name = "atelier-core"; version = "0.1.0.0"; };
       license = "MIT";
       copyright = "";
-      maintainer = "cgeorgii@gmail.com";
+      maintainer = "christian.georgii@tweag.io";
       author = "Christian Georgii";
       homepage = "https://github.com/atelier-hub/tricorder#readme";
       url = "";

--- a/nix/materialized/x86_64-linux/.plan.nix/atelier-db.nix
+++ b/nix/materialized/x86_64-linux/.plan.nix/atelier-db.nix
@@ -14,7 +14,7 @@
       identifier = { name = "atelier-db"; version = "0.1.0.0"; };
       license = "MIT";
       copyright = "";
-      maintainer = "cgeorgii@gmail.com";
+      maintainer = "christian.georgii@tweag.io";
       author = "Christian Georgii";
       homepage = "https://github.com/atelier-hub/tricorder#readme";
       url = "";
@@ -28,7 +28,7 @@
       dataFiles = [];
       extraSrcFiles = [];
       extraTmpFiles = [];
-      extraDocFiles = [ "CHANGELOG.md" ];
+      extraDocFiles = [ "CHANGELOG.md" "README.md" ];
     };
     components = {
       "library" = {

--- a/nix/materialized/x86_64-linux/.plan.nix/atelier-prelude.nix
+++ b/nix/materialized/x86_64-linux/.plan.nix/atelier-prelude.nix
@@ -14,9 +14,9 @@
       identifier = { name = "atelier-prelude"; version = "0.1.0.0"; };
       license = "MIT";
       copyright = "";
-      maintainer = "cgeorgii@gmail.com";
+      maintainer = "christian.georgii@tweag.io";
       author = "Christian Georgii";
-      homepage = "https://github.com/atelier-hub/tricorder#readme";
+      homepage = "https://github.com/atelier-hub/tricorder/tree/main/atelier-prelude";
       url = "";
       synopsis = "Custom relude-based prelude with Effectful conventions";
       description = "A custom prelude based on relude, adapted for Effectful — part of the atelier toolkit.";
@@ -28,7 +28,7 @@
       dataFiles = [];
       extraSrcFiles = [];
       extraTmpFiles = [];
-      extraDocFiles = [ "CHANGELOG.md" ];
+      extraDocFiles = [ "CHANGELOG.md" "README.md" ];
     };
     components = {
       "library" = {

--- a/nix/materialized/x86_64-linux/.plan.nix/atelier-testing.nix
+++ b/nix/materialized/x86_64-linux/.plan.nix/atelier-testing.nix
@@ -14,7 +14,7 @@
       identifier = { name = "atelier-testing"; version = "0.1.0.0"; };
       license = "MIT";
       copyright = "";
-      maintainer = "cgeorgii@gmail.com";
+      maintainer = "christian.georgii@tweag.io";
       author = "Christian Georgii";
       homepage = "https://github.com/atelier-hub/tricorder#readme";
       url = "";
@@ -28,7 +28,7 @@
       dataFiles = [];
       extraSrcFiles = [];
       extraTmpFiles = [];
-      extraDocFiles = [ "CHANGELOG.md" ];
+      extraDocFiles = [ "CHANGELOG.md" "README.md" ];
     };
     components = {
       "library" = {

--- a/nix/materialized/x86_64-linux/.plan.nix/tricorder.nix
+++ b/nix/materialized/x86_64-linux/.plan.nix/tricorder.nix
@@ -14,7 +14,7 @@
       identifier = { name = "tricorder"; version = "0.1.0.0"; };
       license = "MIT";
       copyright = "";
-      maintainer = "cgeorgii@gmail.com";
+      maintainer = "christian.georgii@tweag.io";
       author = "Christian Georgii";
       homepage = "";
       url = "";
@@ -23,12 +23,12 @@
       buildType = "Simple";
       isLocal = true;
       detailLevel = "FullDetails";
-      licenseFiles = [];
+      licenseFiles = [ "LICENSE" ];
       dataDir = ".";
       dataFiles = [];
       extraSrcFiles = [];
       extraTmpFiles = [];
-      extraDocFiles = [];
+      extraDocFiles = [ "README.md" ];
     };
     components = {
       sublibs = {

--- a/tricorder/LICENSE
+++ b/tricorder/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Christian Georgii
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tricorder/README.md
+++ b/tricorder/README.md
@@ -1,0 +1,20 @@
+# tricorder
+
+`tricorder` empowers developers and LLM coding agents working with Haskell by surfacing the right information at each stage: build status, diagnostics, test results, and documentation.
+
+Like `ghcid` and `ghciwatch`, it rebuilds continuously on every change and reports diagnostics — but it runs builds in a background daemon so multiple clients (an interactive TUI, a `tricorder status` CLI, a Claude Code skill) can query a single shared build state without triggering redundant rebuilds. It discovers components across multi-package `cabal.project` workspaces automatically and ships machine-readable (`--json`) output for agentic use.
+
+See the [repository README](https://github.com/atelier-hub/tricorder#readme) for installation (Nix, Home Manager, NixOS), Claude Code plugin setup, configuration, and custom key bindings.
+
+## Built on atelier
+
+`tricorder` is built on the **atelier** toolkit, also developed in this repository:
+
+- [`atelier-prelude`](https://github.com/atelier-hub/tricorder/tree/main/atelier-prelude) — relude-based prelude with Effectful conventions
+- [`atelier-core`](https://github.com/atelier-hub/tricorder/tree/main/atelier-core) — foundational effects and utilities
+- [`atelier-db`](https://github.com/atelier-hub/tricorder/tree/main/atelier-db) — relational database effect (Hasql/Rel8)
+- [`atelier-testing`](https://github.com/atelier-hub/tricorder/tree/main/atelier-testing) — database-backed test utilities
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/tricorder/package.yaml
+++ b/tricorder/package.yaml
@@ -3,8 +3,12 @@ version:             0.1.0.0
 synopsis:            TODO write a short description
 description:         TODO write a long description
 author:              Christian Georgii
-maintainer:          cgeorgii@gmail.com
+maintainer:          christian.georgii@tweag.io
 license:             MIT
+license-file:        LICENSE
+
+extra-doc-files:
+- README.md
 
 language: GHC2021
 

--- a/tricorder/tricorder.cabal
+++ b/tricorder/tricorder.cabal
@@ -9,9 +9,12 @@ version:        0.1.0.0
 synopsis:       TODO write a short description
 description:    TODO write a long description
 author:         Christian Georgii
-maintainer:     cgeorgii@gmail.com
+maintainer:     christian.georgii@tweag.io
 license:        MIT
+license-file:   LICENSE
 build-type:     Simple
+extra-doc-files:
+    README.md
 
 library tricorder-internal
   exposed-modules:


### PR DESCRIPTION
- Add per-package READMEs for **atelier-prelude**, **atelier-db**, **atelier-testing** and **tricorder**; rewrite **atelier-core**'s from a repo-wide overview into a core-focused page
- Wire each README into \`extra-doc-files\` so it bundles into the sdist and renders on Hackage
- Update \`maintainer\` to christian.georgii@tweag.io across all packages
- Point \`atelier-prelude\` \`homepage\` at its subfolder
- Add a \`LICENSE\` and \`license-file\` to tricorder
- Regenerate \`.cabal\` files and nix materialization to match