### PR TITLE
chore: make tricorder Hackage-ready

### DIFF
--- a/nix/materialized/aarch64-darwin/.plan.nix/tricorder.nix
+++ b/nix/materialized/aarch64-darwin/.plan.nix/tricorder.nix
@@ -16,10 +16,10 @@
       copyright = "";
       maintainer = "christian.georgii@tweag.io";
       author = "Christian Georgii";
-      homepage = "";
+      homepage = "https://github.com/atelier-hub/tricorder#readme";
       url = "";
-      synopsis = "TODO write a short description";
-      description = "TODO write a long description";
+      synopsis = "Continuous Haskell build status, diagnostics, and tests via a shared daemon";
+      description = "tricorder rebuilds your Haskell project continuously and surfaces build status, diagnostics, test results, and documentation - for developers and LLM coding agents. Like ghcid and ghciwatch it reloads on every change, but builds run in a background daemon so multiple clients (an interactive TUI, a status CLI, an agent skill) share a single build state without triggering redundant rebuilds. It discovers components across multi-package cabal.project workspaces automatically and ships context-friendly output for agentic use via the CLI.";
       buildType = "Simple";
       isLocal = true;
       detailLevel = "FullDetails";

--- a/nix/materialized/x86_64-linux/.plan.nix/tricorder.nix
+++ b/nix/materialized/x86_64-linux/.plan.nix/tricorder.nix
@@ -16,10 +16,10 @@
       copyright = "";
       maintainer = "christian.georgii@tweag.io";
       author = "Christian Georgii";
-      homepage = "";
+      homepage = "https://github.com/atelier-hub/tricorder#readme";
       url = "";
-      synopsis = "TODO write a short description";
-      description = "TODO write a long description";
+      synopsis = "Continuous Haskell build status, diagnostics, and tests via a shared daemon";
+      description = "tricorder rebuilds your Haskell project continuously and surfaces build status, diagnostics, test results, and documentation - for developers and LLM coding agents. Like ghcid and ghciwatch it reloads on every change, but builds run in a background daemon so multiple clients (an interactive TUI, a status CLI, an agent skill) share a single build state without triggering redundant rebuilds. It discovers components across multi-package cabal.project workspaces automatically and ships context-friendly output for agentic use via the CLI.";
       buildType = "Simple";
       isLocal = true;
       detailLevel = "FullDetails";

--- a/tricorder/README.md
+++ b/tricorder/README.md
@@ -2,7 +2,7 @@
 
 `tricorder` empowers developers and LLM coding agents working with Haskell by surfacing the right information at each stage: build status, diagnostics, test results, and documentation.
 
-Like `ghcid` and `ghciwatch`, it rebuilds continuously on every change and reports diagnostics — but it runs builds in a background daemon so multiple clients (an interactive TUI, a `tricorder status` CLI, a Claude Code skill) can query a single shared build state without triggering redundant rebuilds. It discovers components across multi-package `cabal.project` workspaces automatically and ships machine-readable (`--json`) output for agentic use.
+Like `ghcid` and `ghciwatch`, it rebuilds continuously on every change and reports diagnostics — but it runs builds in a background daemon so multiple clients (an interactive TUI, a `tricorder status` CLI, a Claude Code skill) can query a single shared build state without triggering redundant rebuilds. It discovers components across multi-package `cabal.project` workspaces automatically and ships context-friendly output for agentic use.
 
 See the [repository README](https://github.com/atelier-hub/tricorder#readme) for installation (Nix, Home Manager, NixOS), Claude Code plugin setup, configuration, and custom key bindings.
 

--- a/tricorder/package.yaml
+++ b/tricorder/package.yaml
@@ -1,11 +1,13 @@
 name:                tricorder
 version:             0.1.0.0
-synopsis:            TODO write a short description
-description:         TODO write a long description
+synopsis:            Continuous Haskell build status, diagnostics, and tests via a shared daemon
+description:         tricorder rebuilds your Haskell project continuously and surfaces build status, diagnostics, test results, and documentation - for developers and LLM coding agents. Like ghcid and ghciwatch it reloads on every change, but builds run in a background daemon so multiple clients (an interactive TUI, a status CLI, an agent skill) share a single build state without triggering redundant rebuilds. It discovers components across multi-package cabal.project workspaces automatically and ships context-friendly output for agentic use via the CLI.
 author:              Christian Georgii
 maintainer:          christian.georgii@tweag.io
 license:             MIT
 license-file:        LICENSE
+github:              atelier-hub/tricorder
+category:            Development
 
 extra-doc-files:
 - README.md
@@ -25,13 +27,12 @@ ghc-options:
 - -Wno-implicit-prelude
 - -Wno-unticked-promoted-constructors
 - -Wno-unused-packages
-- -O0
 - -fplugin=Effectful.Plugin
 - -threaded
 
 dependencies:
-- effectful-core
-- effectful-plugin
+- effectful-core >=2.6 && <2.7
+- effectful-plugin >=2.0 && <2.1
 
 default-extensions:
 - BlockArguments
@@ -59,37 +60,38 @@ internal-libraries:
     source-dirs: src
     dependencies:
     - name: base
+      version: ">=4.20 && <4.21"
       mixin:
         - hiding (Prelude)
-    - atelier-prelude
-    - atelier-core
-    - Cabal-syntax
-    - aeson
-    - ansi-terminal
-    - brick
-    - bytestring
-    - casing
-    - containers
-    - data-default
-    - directory
-    - effectful
-    - effectful-th
-    - filepath
-    - hashable
-    - process
-    - template-haskell
-    - megaparsec
-    - mtl
-    - network
-    - optparse-applicative
-    - relude
-    - stm
-    - text
-    - time
-    - time-units
-    - vty
-    - vty-crossplatform
-    - yaml
+    - atelier-prelude >=0.1 && <0.2
+    - atelier-core >=0.1 && <0.2
+    - Cabal-syntax >=3.12 && <3.13
+    - aeson >=2.2 && <2.3
+    - ansi-terminal >=1.1 && <1.2
+    - brick >=2.10 && <2.11
+    - bytestring >=0.12 && <0.13
+    - casing >=0.1 && <0.2
+    - containers >=0.7 && <0.8
+    - data-default >=0.8 && <0.9
+    - directory >=1.3 && <1.4
+    - effectful >=2.6 && <2.7
+    - effectful-th >=1.0 && <1.1
+    - filepath >=1.5 && <1.6
+    - hashable >=1.5 && <1.6
+    - process >=1.6 && <1.7
+    - template-haskell >=2.22 && <2.23
+    - megaparsec >=9.7 && <9.8
+    - mtl >=2.3 && <2.4
+    - network >=3.2 && <3.3
+    - optparse-applicative >=0.19 && <0.20
+    - relude >=1.2 && <1.3
+    - stm >=2.5 && <2.6
+    - text >=2.1 && <2.2
+    - time >=1.12 && <1.13
+    - time-units >=1.0 && <1.1
+    - vty >=6.5 && <6.6
+    - vty-crossplatform >=0.5 && <0.6
+    - yaml >=0.11 && <0.12
 
 executables:
   tricorder-exe:
@@ -99,9 +101,10 @@ executables:
     - '"-with-rtsopts=-N -T"'
     dependencies:
     - name: base
+      version: ">=4.20 && <4.21"
       mixin:
         - hiding (Prelude)
-    - atelier-prelude
+    - atelier-prelude >=0.1 && <0.2
     - tricorder-internal
   tricorder-daemon:
     main:                Main.hs
@@ -110,9 +113,10 @@ executables:
       - '"-with-rtsopts=-N -T"'
     dependencies:
     - name: base
+      version: ">=4.20 && <4.21"
       mixin:
         - hiding (Prelude)
-    - atelier-prelude
+    - atelier-prelude >=0.1 && <0.2
     - tricorder-internal
 
 tests:
@@ -125,24 +129,25 @@ tests:
     - tasty-discover:tasty-discover
     dependencies:
     - name: base
+      version: ">=4.20 && <4.21"
       mixin:
         - hiding (Prelude)
-    - atelier-prelude
+    - atelier-prelude >=0.1 && <0.2
     - tricorder-internal
-    - atelier-core
-    - Cabal-syntax
-    - aeson
-    - containers
-    - data-default
-    - effectful
-    - hspec
-    - process
-    - stm
-    - tasty
-    - tasty-discover
-    - tasty-hspec
-    - text
-    - time
-    - time-units
-    - typed-process
-    - unagi-chan
+    - atelier-core >=0.1 && <0.2
+    - Cabal-syntax >=3.12 && <3.13
+    - aeson >=2.2 && <2.3
+    - containers >=0.7 && <0.8
+    - data-default >=0.8 && <0.9
+    - effectful >=2.6 && <2.7
+    - hspec >=2.11 && <2.12
+    - process >=1.6 && <1.7
+    - stm >=2.5 && <2.6
+    - tasty >=1.5 && <1.6
+    - tasty-discover >=5.2 && <5.3
+    - tasty-hspec >=1.2 && <1.3
+    - text >=2.1 && <2.2
+    - time >=1.12 && <1.13
+    - time-units >=1.0 && <1.1
+    - typed-process >=0.2 && <0.3
+    - unagi-chan >=0.4 && <0.5

--- a/tricorder/tricorder.cabal
+++ b/tricorder/tricorder.cabal
@@ -6,8 +6,11 @@ cabal-version: 2.0
 
 name:           tricorder
 version:        0.1.0.0
-synopsis:       TODO write a short description
-description:    TODO write a long description
+synopsis:       Continuous Haskell build status, diagnostics, and tests via a shared daemon
+description:    tricorder rebuilds your Haskell project continuously and surfaces build status, diagnostics, test results, and documentation - for developers and LLM coding agents. Like ghcid and ghciwatch it reloads on every change, but builds run in a background daemon so multiple clients (an interactive TUI, a status CLI, an agent skill) share a single build state without triggering redundant rebuilds. It discovers components across multi-package cabal.project workspaces automatically and ships context-friendly output for agentic use via the CLI.
+category:       Development
+homepage:       https://github.com/atelier-hub/tricorder#readme
+bug-reports:    https://github.com/atelier-hub/tricorder/issues
 author:         Christian Georgii
 maintainer:     christian.georgii@tweag.io
 license:        MIT
@@ -15,6 +18,10 @@ license-file:   LICENSE
 build-type:     Simple
 extra-doc-files:
     README.md
+
+source-repository head
+  type: git
+  location: https://github.com/atelier-hub/tricorder
 
 library tricorder-internal
   exposed-modules:
@@ -81,40 +88,40 @@ library tricorder-internal
       StrictData
       TemplateHaskell
       TypeFamilies
-  ghc-options: -Weverything -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-missing-poly-kind-signatures -Wno-missing-role-annotations -Wno-missing-local-signatures -Wno-missing-import-lists -Wno-implicit-prelude -Wno-unticked-promoted-constructors -Wno-unused-packages -O0 -fplugin=Effectful.Plugin -threaded
+  ghc-options: -Weverything -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-missing-poly-kind-signatures -Wno-missing-role-annotations -Wno-missing-local-signatures -Wno-missing-import-lists -Wno-implicit-prelude -Wno-unticked-promoted-constructors -Wno-unused-packages -fplugin=Effectful.Plugin -threaded
   build-depends:
-      Cabal-syntax
-    , aeson
-    , ansi-terminal
-    , atelier-core
-    , atelier-prelude
-    , base
-    , brick
-    , bytestring
-    , casing
-    , containers
-    , data-default
-    , directory
-    , effectful
-    , effectful-core
-    , effectful-plugin
-    , effectful-th
-    , filepath
-    , hashable
-    , megaparsec
-    , mtl
-    , network
-    , optparse-applicative
-    , process
-    , relude
-    , stm
-    , template-haskell
-    , text
-    , time
-    , time-units
-    , vty
-    , vty-crossplatform
-    , yaml
+      Cabal-syntax ==3.12.*
+    , aeson ==2.2.*
+    , ansi-terminal ==1.1.*
+    , atelier-core ==0.1.*
+    , atelier-prelude ==0.1.*
+    , base ==4.20.*
+    , brick ==2.10.*
+    , bytestring ==0.12.*
+    , casing ==0.1.*
+    , containers ==0.7.*
+    , data-default ==0.8.*
+    , directory ==1.3.*
+    , effectful ==2.6.*
+    , effectful-core ==2.6.*
+    , effectful-plugin ==2.0.*
+    , effectful-th ==1.0.*
+    , filepath ==1.5.*
+    , hashable ==1.5.*
+    , megaparsec ==9.7.*
+    , mtl ==2.3.*
+    , network ==3.2.*
+    , optparse-applicative ==0.19.*
+    , process ==1.6.*
+    , relude ==1.2.*
+    , stm ==2.5.*
+    , template-haskell ==2.22.*
+    , text ==2.1.*
+    , time ==1.12.*
+    , time-units ==1.0.*
+    , vty ==6.5.*
+    , vty-crossplatform ==0.5.*
+    , yaml ==0.11.*
   mixins:
       base hiding (Prelude)
   default-language: GHC2021
@@ -144,12 +151,12 @@ executable tricorder-daemon
       StrictData
       TemplateHaskell
       TypeFamilies
-  ghc-options: -Weverything -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-missing-poly-kind-signatures -Wno-missing-role-annotations -Wno-missing-local-signatures -Wno-missing-import-lists -Wno-implicit-prelude -Wno-unticked-promoted-constructors -Wno-unused-packages -O0 -fplugin=Effectful.Plugin -threaded "-with-rtsopts=-N -T"
+  ghc-options: -Weverything -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-missing-poly-kind-signatures -Wno-missing-role-annotations -Wno-missing-local-signatures -Wno-missing-import-lists -Wno-implicit-prelude -Wno-unticked-promoted-constructors -Wno-unused-packages -fplugin=Effectful.Plugin -threaded "-with-rtsopts=-N -T"
   build-depends:
-      atelier-prelude
-    , base
-    , effectful-core
-    , effectful-plugin
+      atelier-prelude ==0.1.*
+    , base ==4.20.*
+    , effectful-core ==2.6.*
+    , effectful-plugin ==2.0.*
     , tricorder-internal
   mixins:
       base hiding (Prelude)
@@ -180,12 +187,12 @@ executable tricorder-exe
       StrictData
       TemplateHaskell
       TypeFamilies
-  ghc-options: -Weverything -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-missing-poly-kind-signatures -Wno-missing-role-annotations -Wno-missing-local-signatures -Wno-missing-import-lists -Wno-implicit-prelude -Wno-unticked-promoted-constructors -Wno-unused-packages -O0 -fplugin=Effectful.Plugin -threaded "-with-rtsopts=-N -T"
+  ghc-options: -Weverything -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-missing-poly-kind-signatures -Wno-missing-role-annotations -Wno-missing-local-signatures -Wno-missing-import-lists -Wno-implicit-prelude -Wno-unticked-promoted-constructors -Wno-unused-packages -fplugin=Effectful.Plugin -threaded "-with-rtsopts=-N -T"
   build-depends:
-      atelier-prelude
-    , base
-    , effectful-core
-    , effectful-plugin
+      atelier-prelude ==0.1.*
+    , base ==4.20.*
+    , effectful-core ==2.6.*
+    , effectful-plugin ==2.0.*
     , tricorder-internal
   mixins:
       base hiding (Prelude)
@@ -233,32 +240,32 @@ test-suite tricorder-test
       StrictData
       TemplateHaskell
       TypeFamilies
-  ghc-options: -Weverything -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-missing-poly-kind-signatures -Wno-missing-role-annotations -Wno-missing-local-signatures -Wno-missing-import-lists -Wno-implicit-prelude -Wno-unticked-promoted-constructors -Wno-unused-packages -O0 -fplugin=Effectful.Plugin -threaded -Wno-prepositive-qualified-module
+  ghc-options: -Weverything -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-missing-poly-kind-signatures -Wno-missing-role-annotations -Wno-missing-local-signatures -Wno-missing-import-lists -Wno-implicit-prelude -Wno-unticked-promoted-constructors -Wno-unused-packages -fplugin=Effectful.Plugin -threaded -Wno-prepositive-qualified-module
   build-tool-depends:
       tasty-discover:tasty-discover
   build-depends:
-      Cabal-syntax
-    , aeson
-    , atelier-core
-    , atelier-prelude
-    , base
-    , containers
-    , data-default
-    , effectful
-    , effectful-core
-    , effectful-plugin
-    , hspec
-    , process
-    , stm
-    , tasty
-    , tasty-discover
-    , tasty-hspec
-    , text
-    , time
-    , time-units
+      Cabal-syntax ==3.12.*
+    , aeson ==2.2.*
+    , atelier-core ==0.1.*
+    , atelier-prelude ==0.1.*
+    , base ==4.20.*
+    , containers ==0.7.*
+    , data-default ==0.8.*
+    , effectful ==2.6.*
+    , effectful-core ==2.6.*
+    , effectful-plugin ==2.0.*
+    , hspec ==2.11.*
+    , process ==1.6.*
+    , stm ==2.5.*
+    , tasty ==1.5.*
+    , tasty-discover ==5.2.*
+    , tasty-hspec ==1.2.*
+    , text ==2.1.*
+    , time ==1.12.*
+    , time-units ==1.0.*
     , tricorder-internal
-    , typed-process
-    , unagi-chan
+    , typed-process ==0.2.*
+    , unagi-chan ==0.4.*
   mixins:
       base hiding (Prelude)
   default-language: GHC2021


### PR DESCRIPTION
- Add PVP version bounds to all dependencies across every component
- Fill in synopsis, description, category (Development), and github fields
- Drop the dev-only `-O0` flag so released builds are optimized

`cabal check` is now clean.