### PR TITLE
Export IOMode from Effects.File

### DIFF
--- a/atelier-core/src/Atelier/Effects/File.hs
+++ b/atelier-core/src/Atelier/Effects/File.hs
@@ -10,6 +10,7 @@ module Atelier.Effects.File
     ( File
     , Handle
     , BufferMode (..)
+    , IOMode (..)
     , withFile
     , hClose
     , hFlush


### PR DESCRIPTION
To avoid needing to import System.IO/GHC.IO to use withFile, also re-export IOMode.