### PR TITLE
fix: surface location-less GHCi load failures without false positives

### DIFF
--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -57,6 +57,7 @@ import Tricorder.Builder.Dispatch
     , emptyBuilderState
     , filterToWatchDirs
     , mergeDiagnostics
+    , preserveFailureVisibility
     )
 import Tricorder.Effects.BuildStore (BuildStore)
 import Tricorder.Effects.GhciSession (GhciSession, LoadResult (..))
@@ -491,7 +492,8 @@ compileLoadResultsIntoBuildResults session newLoadResult = do
     let filteredResult =
             loadResult
                 { GhciSession.diagnostics =
-                    filterToWatchDirs projectRoot watchDirs loadResult.diagnostics
+                    preserveFailureVisibility loadResult.diagnostics
+                        $ filterToWatchDirs projectRoot watchDirs loadResult.diagnostics
                 }
 
     newAccumulated <- state \s ->

--- a/tricorder/src/Tricorder/Builder/Dispatch.hs
+++ b/tricorder/src/Tricorder/Builder/Dispatch.hs
@@ -8,6 +8,7 @@ module Tricorder.Builder.Dispatch
     , fileMatchesAnyTarget
     , filterToWatchDirs
     , mergeDiagnostics
+    , preserveFailureVisibility
     ) where
 
 import Atelier.Effects.FileWatcher (FileEvent (..))
@@ -18,9 +19,13 @@ import Data.List qualified as List
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 
-import Tricorder.BuildState (Diagnostic (..))
+import Tricorder.BuildState (Diagnostic (..), Severity (..))
 import Tricorder.Effects.GhciSession (LoadResult (..), LoadedModule (..))
-import Tricorder.Effects.GhciSession.GhciParser (pathSuffixesAsModuleName)
+import Tricorder.Effects.GhciSession.GhciParser
+    ( isLocationLess
+    , pathSuffixesAsModuleName
+    , unattributedFailure
+    )
 
 
 -- | The Builder's per-GHCi-session cache: what it last saw from GHCi plus its
@@ -57,9 +62,16 @@ type DiagnosticMap = Map FilePath [Diagnostic]
 -- by any new diagnostics produced for them in this cycle. Files absent from
 -- 'compiledFiles' were skipped by incremental compilation and retain their
 -- previous diagnostics unchanged.
+--
+-- Location-less diagnostics (see 'isLocationLess') are never keyed to a real
+-- source file, so they would never appear in 'compiledFiles' and would persist
+-- forever once raised. They describe the current load's outcome, so we clear
+-- them every cycle and let this cycle's 'diagnostics' re-add them if the
+-- failure is still present.
 mergeDiagnostics :: DiagnosticMap -> LoadResult -> DiagnosticMap
 mergeDiagnostics prev LoadResult {compiledFiles, diagnostics} =
-    let cleared = foldr Map.delete prev compiledFiles
+    let retained = Map.filterWithKey (\f _ -> not (isLocationLess f)) prev
+        cleared = foldr Map.delete retained compiledFiles
         newByFile = Map.fromListWith (++) [(d.file, [d]) | d <- diagnostics]
     in  Map.union newByFile cleared
 
@@ -141,10 +153,16 @@ dispatch knownTargets known fp event = case known of
 -- those with mangled filenames produced by the C preprocessor (e.g.
 -- @"In file included from ..."@) are dropped here, before they can enter the
 -- accumulation map where they would be impossible to evict.
+--
+-- Location-less diagnostics (see 'isLocationLess') are always kept: they carry
+-- no path to test against a watch dir, but they represent genuine build-level
+-- failures (e.g. a home-unit GHC plugin that can't load under
+-- @--enable-multi-repl@) that must not be dropped, or the build would silently
+-- read as clean.
 filterToWatchDirs :: FilePath -> [FilePath] -> [Diagnostic] -> [Diagnostic]
 filterToWatchDirs _ [] diags = diags
 filterToWatchDirs projectRoot watchDirs diags =
-    filter (isUnderAnyWatchDir . (.file)) diags
+    filter (\d -> isLocationLess d.file || isUnderAnyWatchDir d.file) diags
   where
     absWatchDirs = map toAbsWd watchDirs
     toAbsWd wd
@@ -158,3 +176,23 @@ filterToWatchDirs projectRoot watchDirs diags =
         | otherwise =
             let absFile = projectRoot </> drop 2 file
             in  any (\wd -> (wd ++ "/") `isPrefixOf` absFile || wd == absFile) absWatchDirs
+
+
+-- | Keep a failed build from ever reading as clean after watch-dir filtering.
+--
+-- 'filterToWatchDirs' drops diagnostics outside the watched directories. If a
+-- load failed but every error it produced lay outside those dirs (e.g. a
+-- compile error in a sibling home unit not under @watchDirs@), filtering would
+-- leave no diagnostics and the broken build would look green. Detecting that an
+-- error was present /before/ filtering but none survived, we re-attach the
+-- location-less synthetic failure (which filtering always keeps) so the failure
+-- still surfaces.
+--
+-- Takes the pre-filter diagnostics and the post-filter diagnostics; returns the
+-- post-filter list, with the synthetic failure appended only when needed.
+preserveFailureVisibility :: [Diagnostic] -> [Diagnostic] -> [Diagnostic]
+preserveFailureVisibility raw filtered
+    | any isError raw && not (any isError filtered) = filtered ++ [unattributedFailure]
+    | otherwise = filtered
+  where
+    isError d = d.severity == SError

--- a/tricorder/src/Tricorder/Effects/GhciSession.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession.hs
@@ -15,6 +15,7 @@ module Tricorder.Effects.GhciSession
 
 import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.File (File)
+import Atelier.Effects.Log (Log)
 import Atelier.Effects.Process (Process)
 import Atelier.Effects.Timeout (Timeout)
 import Data.Default (def)
@@ -105,6 +106,7 @@ runGhciSession
        , Conc :> es
        , Concurrent :> es
        , File :> es
+       , Log :> es
        , Process :> es
        , Timeout :> es
        )

--- a/tricorder/src/Tricorder/Effects/GhciSession/GhciParser.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession/GhciParser.hs
@@ -536,7 +536,7 @@ unattributedFailure =
         , endLine = 0
         , endCol = 0
         , title = "GHCi reported a failed load with no located error"
-        , text = "GHCi reported a failed load with no located error.\nCheck the full GHCi output for details.\n"
+        , text = "GHCi reported a failed load with no located error.\nRun `tricorder log` to see the full GHCi output.\n"
         }
 
 

--- a/tricorder/src/Tricorder/Effects/GhciSession/GhciParser.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession/GhciParser.hs
@@ -3,10 +3,14 @@ module Tricorder.Effects.GhciSession.GhciParser
     , GhciLoading (..)
     , GhciMessage (..)
     , GhciSeverity (..)
+    , LoadOutcome (..)
     , LoadResult (..)
     , LoadedModule (..)
     , Position (..)
+    , collectResult
     , collectResultCustom
+    , isLocationLess
+    , reloadFailed
     , parseProgressLine
     , parseReload
     , parseShowModules
@@ -17,6 +21,7 @@ module Tricorder.Effects.GhciSession.GhciParser
     , extractTitle
     , toAbsolute
     , toRelative
+    , unattributedFailure
     ) where
 
 import Data.Char (isAlpha, isDigit, isSpace, toLower)
@@ -74,11 +79,18 @@ data GhciMessage = GhciMessage
     deriving stock (Eq, Show)
 
 
+-- | The terminal summary GHCi emits to close a load: @Ok, N modules loaded.@
+-- on success or @Failed, …@ on failure.
+data LoadOutcome = LoadSucceeded | LoadFailed
+    deriving stock (Eq, Show)
+
+
 -- | A structured item from GHCi's reload output.
 data GhciLoad
     = GLoading GhciLoading
     | GMessage GhciMessage
     | GLoadConfig FilePath
+    | GSummary LoadOutcome
     deriving stock (Eq, Show)
 
 
@@ -268,9 +280,13 @@ reloadItem =
           do
             (_, stripped) <- satisfyStripped ("[" `T.isPrefixOf`)
             pure (runTP loadingLineP stripped)
-        , -- Pattern: summary lines "Ok, ..." / "Failed, ..." — discard
-          fmap (const Nothing)
-            $ satisfyStripped (\s -> "Ok, " `T.isPrefixOf` s || "Failed, " `T.isPrefixOf` s)
+        , -- Pattern: terminal summary line "Ok, ..." / "Failed, ..."
+          fmap Just $ do
+            (_, stripped) <-
+                satisfyStripped (\s -> "Ok, " `T.isPrefixOf` s || "Failed, " `T.isPrefixOf` s)
+            pure
+                $ GSummary
+                $ if "Failed, " `T.isPrefixOf` stripped then LoadFailed else LoadSucceeded
         , -- Pattern: "<no location info>: error:"
           fmap Just $ do
             (origLine, _) <- satisfyStripped ("<no location info>: error:" `T.isPrefixOf`)
@@ -488,6 +504,70 @@ collectResultCustom projectRoot loads modules targets =
             }
 
 
+-- | Assemble a 'LoadResult' from the raw reload output plus the @:show
+-- modules@ / @:show targets@ output.
+--
+-- This is 'collectResultCustom' wrapped with a safety net: if GHCi's reload
+-- ended in a @Failed,@ summary but no error diagnostic was captured (e.g. a
+-- location-less failure we don't otherwise attribute to a file), a synthetic
+-- error diagnostic is appended so the build can never be reported as clean
+-- while GHCi considers it failed.
+collectResult :: FilePath -> [Text] -> [(Text, FilePath)] -> [Text] -> LoadResult
+collectResult projectRoot reloadLines modules targets =
+    let loads = parseReload reloadLines
+        base = collectResultCustom projectRoot loads modules targets
+        hasError = any (\d -> d.severity == SError) base.diagnostics
+    in  if reloadFailed loads && not hasError then
+            base {diagnostics = base.diagnostics ++ [unattributedFailure]}
+        else
+            base
+
+
+-- | Synthetic diagnostic for a failed load with no located error. Without a
+-- source span it cannot point anywhere, but it stops the build reading as
+-- clean and tells the user where to look.
+unattributedFailure :: Diagnostic
+unattributedFailure =
+    BuildState.Diagnostic
+        { severity = SError
+        , file = "<no location info>"
+        , line = 0
+        , col = 0
+        , endLine = 0
+        , endCol = 0
+        , title = "GHCi reported a failed load with no located error"
+        , text = "GHCi reported a failed load with no located error.\nCheck the full GHCi output for details.\n"
+        }
+
+
+-- | Whether GHCi's load ended in failure, decided from the 'GSummary' items
+-- 'parseReload' produces — the single place that classifies GHCi's terminal
+-- @Ok, …@ / @Failed, …@ summary line.
+--
+-- GHCi emits the real summary last, after all compilation output. Output
+-- produced /during/ the load (a Template Haskell splice, top-level IO run while
+-- interpreting) can contain an earlier line that looks like a summary, so only
+-- the /last/ 'GSummary' reflects the true outcome.
+reloadFailed :: [GhciLoad] -> Bool
+reloadFailed loads =
+    case [outcome | GSummary outcome <- loads] of
+        [] -> False
+        outcomes -> List.last outcomes == LoadFailed
+
+
+-- | Whether a diagnostic file is a GHCi location-less pseudo-file — a fully
+-- @\<…\>@-bracketed marker such as @\<no location info\>@ or @\<interactive\>@
+-- rather than a real source path. These carry no source span but can still
+-- represent genuine build-level failures, so callers treat them specially
+-- (kept rather than dropped, cleared every cycle rather than retained).
+--
+-- We require both the opening @\<@ and a closing @\>@ so a real (if exotic)
+-- path that merely starts with @\<@, e.g. @\<generated\>/Foo.hs@, is not
+-- mistaken for a marker.
+isLocationLess :: FilePath -> Bool
+isLocationLess f = "<" `List.isPrefixOf` f && ">" `List.isSuffixOf` f
+
+
 -- | Path↔module-name map for the next cycle: this round's @:show modules@
 -- plus carryover from @prev@ for targets that failed mid-session and so
 -- dropped out. Never-compiled targets are absent here (no path↔name
@@ -514,7 +594,12 @@ resolveKnownTargets prev lr =
 toDiagnostics :: (FilePath -> FilePath) -> [GhciLoad] -> [BuildState.Diagnostic]
 toDiagnostics rel loads = mapMaybe toMsg loads
   where
-    toMsg (GMessage m) | '<' : _ <- m.file = Nothing
+    -- Location-less messages (e.g. @<no location info>@, @<interactive>@) carry
+    -- no source span. We keep the *errors* — a @<no location info>@ error is a
+    -- genuine load failure (e.g. a home-unit GHC plugin that can't be loaded in
+    -- @--enable-multi-repl@) and must not be silently dropped — but discard
+    -- location-less warnings, which are just noise without a file to attach to.
+    toMsg (GMessage m) | isLocationLess m.file, m.severity /= GError = Nothing
     toMsg (GMessage m) =
         Just
             BuildState.Diagnostic

--- a/tricorder/src/Tricorder/Effects/GhciSession/GhciProcess.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession/GhciProcess.hs
@@ -48,9 +48,8 @@ import Data.Text qualified as T
 import Tricorder.Effects.GhciSession.GhciParser
     ( GhciLoading (..)
     , LoadResult (..)
-    , collectResultCustom
+    , collectResult
     , parseProgressLine
-    , parseReload
     , parseShowModules
     , parseShowTargets
     , stripAnsi
@@ -514,14 +513,13 @@ collectGhciResult
     -> FilePath
     -> Eff es LoadResult
 collectGhciResult process lines' projectRoot = do
-    let loads = parseReload lines'
-        noProgress = \_ -> pure ()
+    let noProgress = \_ -> pure ()
     moduleLines <- execGhci process ":show modules" noProgress
     targetLines <- execGhci process ":show targets" noProgress
     pure
-        $ collectResultCustom
+        $ collectResult
             projectRoot
-            loads
+            lines'
             (parseShowModules moduleLines)
             (parseShowTargets targetLines)
 

--- a/tricorder/src/Tricorder/Effects/GhciSession/GhciProcess.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession/GhciProcess.hs
@@ -18,6 +18,7 @@ module Tricorder.Effects.GhciSession.GhciProcess
 
 import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.File (BufferMode (..), File, Handle)
+import Atelier.Effects.Log (Log)
 import Atelier.Effects.Process
     ( Process
     , RunningProcess
@@ -42,6 +43,7 @@ import Effectful.Exception (bracket, finally, throwIO, trySync)
 
 import Atelier.Effects.Conc qualified as Conc
 import Atelier.Effects.File qualified as File
+import Atelier.Effects.Log qualified as Log
 import Atelier.Effects.Process qualified as Process
 import Data.Text qualified as T
 
@@ -53,6 +55,7 @@ import Tricorder.Effects.GhciSession.GhciParser
     , parseShowModules
     , parseShowTargets
     , stripAnsi
+    , unattributedFailure
     )
 
 
@@ -507,7 +510,7 @@ startupExitedMessage ex =
 -- Progress is emitted live by 'drainUntil' as lines arrive, so no replay
 -- callback is needed here — this function only assembles the final result.
 collectGhciResult
-    :: (Conc :> es, Concurrent :> es, File :> es)
+    :: (Conc :> es, Concurrent :> es, File :> es, Log :> es)
     => GhciProcess
     -> [Text]
     -> FilePath
@@ -516,18 +519,27 @@ collectGhciResult process lines' projectRoot = do
     let noProgress = \_ -> pure ()
     moduleLines <- execGhci process ":show modules" noProgress
     targetLines <- execGhci process ":show targets" noProgress
-    pure
-        $ collectResult
-            projectRoot
-            lines'
-            (parseShowModules moduleLines)
-            (parseShowTargets targetLines)
+    let result =
+            collectResult
+                projectRoot
+                lines'
+                (parseShowModules moduleLines)
+                (parseShowTargets targetLines)
+    -- A failed load with no located error produces only the synthetic
+    -- 'unattributedFailure'. The parsed diagnostics tell the user nothing in
+    -- that case, so log the raw GHCi output — it's the only way to see what
+    -- actually went wrong, and the synthetic diagnostic points here.
+    when (any (== unattributedFailure) result.diagnostics)
+        $ Log.info
+        $ "GHCi reported a failed load with no located error. Full GHCi output:\n"
+            <> T.unlines lines'
+    pure result
 
 
 -- | Execute @:reload@ and return the assembled 'LoadResult'. Progress events
 -- fire live via @onProgress@ as each @[N of M] Compiling …@ line is read.
 reloadGhci
-    :: (Conc :> es, Concurrent :> es, File :> es)
+    :: (Conc :> es, Concurrent :> es, File :> es, Log :> es)
     => GhciProcess
     -> FilePath
     -> (GhciLoading -> Eff es ())
@@ -540,7 +552,7 @@ reloadGhci process projectRoot onProgress = do
 -- | Execute @:add@ for the given file and return the assembled 'LoadResult'.
 -- Progress events fire live via @onProgress@ as compilation proceeds.
 addGhci
-    :: (Conc :> es, Concurrent :> es, File :> es)
+    :: (Conc :> es, Concurrent :> es, File :> es, Log :> es)
     => GhciProcess
     -> FilePath -- the file to :add
     -> FilePath -- projectRoot
@@ -555,7 +567,7 @@ addGhci process filePath projectRoot onProgress = do
 -- 'LoadResult'. Progress events fire live via @onProgress@ as compilation
 -- proceeds.
 unaddGhci
-    :: (Conc :> es, Concurrent :> es, File :> es)
+    :: (Conc :> es, Concurrent :> es, File :> es, Log :> es)
     => GhciProcess
     -> Text -- the module name to :unadd
     -> FilePath -- projectRoot

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -754,7 +754,7 @@ testMergeDiagnostics = do
         let merged = mergeDiagnostics Map.empty result
         Map.lookup warnMsg.file merged `shouldBe` Just [warnMsg]
 
-    it "clears a stale location-less diagnostic when the cycle reports none" do
+    describe "when the cycle reports none" $ it "clears a stale location-less diagnostic" do
         -- <no location info> is never in compiledFiles, so without special
         -- handling it would persist forever. A cycle with no location-less
         -- diagnostic must evict it.
@@ -826,7 +826,7 @@ testFilterToWatchDirs = do
             nixD = errMsg {file = "/nix/store/abc123/ghcautoconf.h"}
         filterToWatchDirs root ["."] [d, nixD] `shouldBe` [d]
 
-    it "keeps location-less <no location info> errors despite no path" do
+    describe "when diagnostic has no path it" $ it "keeps location-less <no location info> errors" do
         -- A home-unit GHC plugin that can't load under --enable-multi-repl
         -- produces a <no location info> error. It has no path to test against a
         -- watch dir, but must survive or the failed build reads as clean.
@@ -840,7 +840,7 @@ testFilterToWatchDirs = do
         let d = errMsg {file = "<generated>/Foo.hs"}
         filterToWatchDirs root watchDirs [d] `shouldBe` []
 
-    it "a failed load does not read as clean when its only error is out of watch dirs" do
+    describe "when its only error is out of watch dirs" $ it "a failed load does not read as clean" do
         -- collectResult only injects its synthetic failure when no SError is
         -- present. Here GHCi Failed with a single *located* error in a file
         -- outside the watch dirs, so collectResult adds no synthetic — and then

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -62,9 +62,10 @@ import Tricorder.Builder.Dispatch
     , fileMatchesAnyTarget
     , filterToWatchDirs
     , mergeDiagnostics
+    , preserveFailureVisibility
     )
 import Tricorder.Effects.GhciSession (Controls (..), LoadResult (..), LoadedModule (..), runGhciSessionScripted)
-import Tricorder.Effects.GhciSession.GhciParser (extractTitle, resolveKnownTargets)
+import Tricorder.Effects.GhciSession.GhciParser (collectResult, extractTitle, resolveKnownTargets)
 import Tricorder.Effects.TestRunner (TestRunner (..), runTestRunnerScripted)
 import Tricorder.Runtime (ProjectRoot (..))
 
@@ -753,6 +754,37 @@ testMergeDiagnostics = do
         let merged = mergeDiagnostics Map.empty result
         Map.lookup warnMsg.file merged `shouldBe` Just [warnMsg]
 
+    it "clears a stale location-less diagnostic when the cycle reports none" do
+        -- <no location info> is never in compiledFiles, so without special
+        -- handling it would persist forever. A cycle with no location-less
+        -- diagnostic must evict it.
+        let noLoc = errMsg {file = "<no location info>"}
+            prev = Map.fromList [(noLoc.file, [noLoc])]
+            result =
+                LoadResult
+                    { moduleCount = 1
+                    , compiledFiles = Set.singleton errMsg.file
+                    , loadedModules = Map.empty
+                    , targetNames = []
+                    , diagnostics = []
+                    }
+        let merged = mergeDiagnostics prev result
+        Map.lookup noLoc.file merged `shouldBe` Nothing
+
+    it "refreshes a location-less diagnostic that is still present" do
+        let noLoc = errMsg {file = "<no location info>"}
+            prev = Map.fromList [(noLoc.file, [noLoc])]
+            result =
+                LoadResult
+                    { moduleCount = 1
+                    , compiledFiles = Set.empty
+                    , loadedModules = Map.empty
+                    , targetNames = []
+                    , diagnostics = [noLoc]
+                    }
+        let merged = mergeDiagnostics prev result
+        Map.lookup noLoc.file merged `shouldBe` Just [noLoc]
+
 
 --------------------------------------------------------------------------------
 -- filterToWatchDirs tests
@@ -793,6 +825,37 @@ testFilterToWatchDirs = do
         let d = errMsg {file = "./src/Foo.hs"}
             nixD = errMsg {file = "/nix/store/abc123/ghcautoconf.h"}
         filterToWatchDirs root ["."] [d, nixD] `shouldBe` [d]
+
+    it "keeps location-less <no location info> errors despite no path" do
+        -- A home-unit GHC plugin that can't load under --enable-multi-repl
+        -- produces a <no location info> error. It has no path to test against a
+        -- watch dir, but must survive or the failed build reads as clean.
+        let d = errMsg {file = "<no location info>"}
+        filterToWatchDirs root watchDirs [d] `shouldBe` [d]
+
+    it "does not treat a real <-prefixed path as a location-less marker" do
+        -- isLocationLess requires a closing '>'. A real (if exotic) path that
+        -- merely starts with '<' is an ordinary out-of-watch file and must be
+        -- dropped, not kept as a build-level marker.
+        let d = errMsg {file = "<generated>/Foo.hs"}
+        filterToWatchDirs root watchDirs [d] `shouldBe` []
+
+    it "a failed load does not read as clean when its only error is out of watch dirs" do
+        -- collectResult only injects its synthetic failure when no SError is
+        -- present. Here GHCi Failed with a single *located* error in a file
+        -- outside the watch dirs, so collectResult adds no synthetic — and then
+        -- filterToWatchDirs drops the out-of-watch error, leaving nothing. The
+        -- Builder pipeline composes preserveFailureVisibility after filtering to
+        -- re-attach the failure, so a failed build never survives with zero
+        -- diagnostics.
+        let reloadOutput =
+                [ "/other/Dep.hs:5:1: error: boom"
+                , "Failed, 0 modules loaded."
+                ]
+            result = collectResult root reloadOutput [] []
+            filtered = filterToWatchDirs root watchDirs result.diagnostics
+        preserveFailureVisibility result.diagnostics filtered
+            `shouldSatisfy` (not . null)
 
 
 --------------------------------------------------------------------------------

--- a/tricorder/test/Unit/Tricorder/Effects/GhciSession/GhciParserSpec.hs
+++ b/tricorder/test/Unit/Tricorder/Effects/GhciSession/GhciParserSpec.hs
@@ -378,7 +378,7 @@ testPluginLoadFailure = do
 -- read as clean in that case, so a synthetic error diagnostic is added.
 testUnattributedFailure :: Spec
 testUnattributedFailure = do
-    it "adds a synthetic error when the load failed but no error was located" do
+    describe "when the load failed but no error was located" $ it "adds a synthetic error" do
         let reloadOutput =
                 [ "[1 of 2] Compiling Lib  ( src/Lib.hs, interpreted )"
                 , "[2 of 2] Compiling Main ( app/Main.hs, interpreted )"
@@ -405,7 +405,7 @@ testUnattributedFailure = do
             result = collectResult "/project" reloadOutput [] []
         result.diagnostics `shouldBe` []
 
-    it "does not flag a clean build when 'Failed,' appears off the summary line" do
+    describe "when 'Failed,' appears off the summary line" $ it "does not flag a clean build" do
         -- The load outcome lives on GHCi's single summary line
         -- ("Ok, …" / "Failed, …"). Output printed *during* the load — e.g. a
         -- Template Haskell splice or top-level IO run while interpreting — can

--- a/tricorder/test/Unit/Tricorder/Effects/GhciSession/GhciParserSpec.hs
+++ b/tricorder/test/Unit/Tricorder/Effects/GhciSession/GhciParserSpec.hs
@@ -2,12 +2,17 @@ module Unit.Tricorder.Effects.GhciSession.GhciParserSpec (spec_GhciParser) where
 
 import Test.Hspec
 
+import Tricorder.BuildState (Diagnostic (..), Severity (..))
 import Tricorder.Effects.GhciSession.GhciParser
     ( GhciLoad (..)
     , GhciLoading (..)
     , GhciMessage (..)
     , GhciSeverity (..)
+    , LoadOutcome (..)
+    , LoadResult (..)
     , Position (..)
+    , collectResult
+    , collectResultCustom
     , parseReload
     , parseShowModules
     , parseShowTargets
@@ -29,6 +34,12 @@ spec_GhciParser = do
 
     describe "parseShowTargets" testShowTargets
 
+    describe "collectResultCustom" do
+        describe "<no location info> plugin load failure" testPluginLoadFailure
+
+    describe "collectResult" do
+        describe "failed load with no located error" testUnattributedFailure
+
 
 --------------------------------------------------------------------------------
 -- parseReload: clean build
@@ -47,6 +58,7 @@ testCleanBuild = do
             `shouldBe` [ GLoading GhciLoading {index = 1, total = 3, moduleName = "Tricorder.BuildState", sourceFile = "src/Tricorder/BuildState.hs"}
                        , GLoading GhciLoading {index = 2, total = 3, moduleName = "Tricorder.Session", sourceFile = "src/Tricorder/Session.hs"}
                        , GLoading GhciLoading {index = 3, total = 3, moduleName = "Main", sourceFile = "app/Main.hs"}
+                       , GSummary LoadSucceeded
                        ]
 
     it "handles padded module index (e.g. [ 1 of 47])" do
@@ -54,10 +66,13 @@ testCleanBuild = do
                 [ "[ 1 of 47] Compiling Main              ( app/Main.hs, interpreted )"
                 , "Ok, 1 module loaded."
                 ]
-        parseReload input `shouldBe` [GLoading GhciLoading {index = 1, total = 47, moduleName = "Main", sourceFile = "app/Main.hs"}]
+        parseReload input
+            `shouldBe` [ GLoading GhciLoading {index = 1, total = 47, moduleName = "Main", sourceFile = "app/Main.hs"}
+                       , GSummary LoadSucceeded
+                       ]
 
-    describe "when only summary line" $ it "returns empty list" do
-        parseReload ["Ok, 0 modules loaded."] `shouldBe` []
+    describe "when only summary line" $ it "returns the summary outcome" do
+        parseReload ["Ok, 0 modules loaded."] `shouldBe` [GSummary LoadSucceeded]
 
 
 --------------------------------------------------------------------------------
@@ -142,7 +157,7 @@ testErrors = do
         parseReload input
             `shouldBe` [GMessage GhciMessage {severity = GError, file = "C:\\path\\file.hs", startPos = Position 10 5, endPos = Position 10 5, messageLines = ["C:\\path\\file.hs:10:5: error: Variable not in scope: foo"]}]
 
-    it "parses mixed Loading and Message items, discarding summary" do
+    it "parses mixed Loading, Message, and summary items" do
         let input =
                 [ "[1 of 2] Compiling Lib ( src/Lib.hs, interpreted )"
                 , "src/Lib.hs:5:1: error: Oops"
@@ -153,6 +168,7 @@ testErrors = do
             `shouldBe` [ GLoading GhciLoading {index = 1, total = 2, moduleName = "Lib", sourceFile = "src/Lib.hs"}
                        , GMessage GhciMessage {severity = GError, file = "src/Lib.hs", startPos = Position 5 1, endPos = Position 5 1, messageLines = ["src/Lib.hs:5:1: error: Oops"]}
                        , GLoading GhciLoading {index = 2, total = 2, moduleName = "Main", sourceFile = "app/Main.hs"}
+                       , GSummary LoadFailed
                        ]
 
 
@@ -180,11 +196,12 @@ testHideSourcePaths = do
                                     , "    Perhaps you meant: 'bar'"
                                     ]
                                 }
+                       , GSummary LoadFailed
                        ]
 
-    describe "when all modules are already up to date" $ it "returns empty list" do
+    describe "when all modules are already up to date" $ it "returns the summary outcome" do
         -- GHCi with -fhide-source-paths and nothing to recompile
-        parseReload ["Ok, 5 modules loaded."] `shouldBe` []
+        parseReload ["Ok, 5 modules loaded."] `shouldBe` [GSummary LoadSucceeded]
 
 
 --------------------------------------------------------------------------------
@@ -240,6 +257,7 @@ testLoadedConfig = do
         parseReload input
             `shouldBe` [ GLoadConfig ".ghci"
                        , GLoading GhciLoading {index = 1, total = 1, moduleName = "Main", sourceFile = "app/Main.hs"}
+                       , GSummary LoadSucceeded
                        ]
 
 
@@ -311,3 +329,93 @@ testShowTargets = do
 
     it "returns empty list for empty input" do
         parseShowTargets [] `shouldBe` []
+
+
+--------------------------------------------------------------------------------
+-- collectResultCustom: <no location info> plugin load failure
+--------------------------------------------------------------------------------
+
+-- | Regression test for the \"All good\" bug with home-unit GHC plugins.
+--
+-- Under @cabal repl --enable-multi-repl@ every unit is interpreted, so a
+-- package used as a GHC plugin in the same project is not available as a
+-- compiled plugin. The unit that depends on it fails to load, GHCi reports the
+-- failure with @\<no location info\>@ (it has no source span), and the load
+-- ends with @Failed, N modules loaded@. This output must still surface as an
+-- error diagnostic — otherwise the build is silently reported as clean.
+testPluginLoadFailure :: Spec
+testPluginLoadFailure = do
+    -- Shape of the GHCi output from `cabal repl --enable-multi-repl` when an
+    -- executable loads a home-unit GHC plugin: the plugin package's modules
+    -- compile, then the unit using the plugin fails with a location-less error.
+    let reloadOutput =
+            [ "[3 of 5] Compiling My.Plugin       ( src/My/Plugin.hs, interpreted )[plugin-pkg-1.0.0-inplace]"
+            , "<no location info>: error:"
+            , "    Could not load module \8216My.Plugin\8217."
+            , "It is a member of the hidden package \8216plugin-pkg-1.0.0\8217."
+            , "Perhaps you need to add \8216plugin-pkg\8217 to the build-depends in your .cabal file."
+            , "Use -v to see a list of the files searched for."
+            , ""
+            , "[5 of 5] Compiling Main            ( test/Tests.hs, interpreted )[app-pkg-0.1.0.0-inplace-test]"
+            , "Failed, 4 modules loaded."
+            ]
+        result = collectResultCustom "/project" (parseReload reloadOutput) [] []
+
+    it "surfaces the plugin load failure as an error diagnostic" do
+        map (.severity) result.diagnostics `shouldContain` [SError]
+
+    it "carries the plugin error message in the diagnostic title" do
+        map (.title) result.diagnostics
+            `shouldContain` ["Could not load module \8216My.Plugin\8217."]
+
+
+--------------------------------------------------------------------------------
+-- collectResult: failed load with no located error
+--------------------------------------------------------------------------------
+
+-- 'collectResult' is the safety net: GHCi can end a load with @Failed, …@
+-- without emitting any error that carries a source span. The build must never
+-- read as clean in that case, so a synthetic error diagnostic is added.
+testUnattributedFailure :: Spec
+testUnattributedFailure = do
+    it "adds a synthetic error when the load failed but no error was located" do
+        let reloadOutput =
+                [ "[1 of 2] Compiling Lib  ( src/Lib.hs, interpreted )"
+                , "[2 of 2] Compiling Main ( app/Main.hs, interpreted )"
+                , "Failed, 1 module loaded."
+                ]
+            result = collectResult "/project" reloadOutput [] []
+        map (.severity) result.diagnostics `shouldBe` [SError]
+
+    it "does not duplicate a failure that already produced a located error" do
+        let reloadOutput =
+                [ "[1 of 1] Compiling Lib ( src/Lib.hs, interpreted )"
+                , "src/Lib.hs:5:1: error: Oops"
+                , "Failed, 0 modules loaded."
+                ]
+            result = collectResult "/project" reloadOutput [] []
+        -- Only the real, located diagnostic — no synthetic one appended.
+        map (.file) result.diagnostics `shouldBe` ["src/Lib.hs"]
+
+    it "adds nothing for a successful load" do
+        let reloadOutput =
+                [ "[1 of 1] Compiling Main ( app/Main.hs, interpreted )"
+                , "Ok, 1 module loaded."
+                ]
+            result = collectResult "/project" reloadOutput [] []
+        result.diagnostics `shouldBe` []
+
+    it "does not flag a clean build when 'Failed,' appears off the summary line" do
+        -- The load outcome lives on GHCi's single summary line
+        -- ("Ok, …" / "Failed, …"). Output printed *during* the load — e.g. a
+        -- Template Haskell splice or top-level IO run while interpreting — can
+        -- contain a line that happens to begin with "Failed,". That must not be
+        -- mistaken for a failed load: the summary here is "Ok," so no synthetic
+        -- error belongs.
+        let reloadOutput =
+                [ "[1 of 1] Compiling Main ( app/Main.hs, interpreted )"
+                , "Failed, retrying with fallback" -- printed by a TH splice
+                , "Ok, 1 module loaded."
+                ]
+            result = collectResult "/project" reloadOutput [] []
+        result.diagnostics `shouldBe` []


### PR DESCRIPTION
## Summary

Makes a GHCi load that fails with a location-less error reliably surface as a build error. The motivating case is a home-unit GHC plugin that can't load under `cabal repl --enable-multi-repl`, which GHCi reports as `<no location info>: error:` with no source span and a `Failed,` summary.

## Changes

- **Single source of truth for load outcome.** `parseReload` now emits GHCi's terminal `Ok,`/`Failed,` summary as a `GSummary LoadOutcome` item. `reloadFailed` reads those items and trusts the **last** one — so output printed *during* a load (e.g. a Template Haskell splice line beginning `Failed,`) no longer triggers a spurious failure.
- **Synthetic failure when nothing is located.** `collectResult` appends a `<no location info>` error when GHCi reports `Failed,` with no located error, so the build can't read clean.
- **Failure survives watch-dir filtering.** `preserveFailureVisibility` re-attaches that synthetic failure after `filterToWatchDirs` when an error existed before filtering but none survived — covering the case where the only error lay outside the watched directories.
- **Location-less diagnostic handling.** `toDiagnostics` keeps location-less *errors* (genuine load failures) but drops location-less *warnings*; `mergeDiagnostics` clears location-less diagnostics each cycle so they can't persist forever; `filterToWatchDirs` keeps them (no path to test against a watch dir).
- **Tighter marker check.** `isLocationLess` now requires a closing `>`, so a real path merely starting with `<` (e.g. `<generated>/Foo.hs`) isn't mistaken for a GHCi marker.