### PR TITLE
feat: display views as tabs

### DIFF
--- a/tricorder/src/Tricorder/UI.hs
+++ b/tricorder/src/Tricorder/UI.hs
@@ -7,18 +7,11 @@ import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.Console (Console)
 import Atelier.Effects.Delay (Delay)
 import Atelier.Effects.File (File)
-import Brick
-    ( App (..)
-    , attrMap
-    , attrName
-    , neverShowCursor
-    )
+import Brick (App (..), neverShowCursor)
 import Brick.Keybindings (KeyConfig)
 import Effectful.Reader.Static (Reader, ask)
 
 import Atelier.Effects.Conc qualified as Conc
-import Graphics.Vty.Attributes qualified as Attr
-import Graphics.Vty.Attributes.Color qualified as Color
 
 import Tricorder.Effects.Brick (Brick)
 import Tricorder.Effects.BrickChan (BrickChan)
@@ -28,7 +21,7 @@ import Tricorder.Socket.Client (queryWatch)
 import Tricorder.UI.Event (Event (..), handleEvent)
 import Tricorder.UI.Keys (KeyEvent, dispatcher)
 import Tricorder.UI.State (State (..), Viewports (..))
-import Tricorder.UI.View (view)
+import Tricorder.UI.View (mkAttrMap, view)
 
 import Tricorder.Effects.Brick qualified as Brick
 import Tricorder.Effects.BrickChan qualified as BrickChan
@@ -74,16 +67,6 @@ watchApp kc =
         { appDraw = view kc
         , appHandleEvent = handleEvent $ dispatcher kc
         , appStartEvent = pure ()
-        , appAttrMap =
-            const
-                ( attrMap
-                    Attr.defAttr
-                    [ (attrName "ok", Attr.withForeColor Attr.defAttr Color.green)
-                    , (attrName "warning", Attr.withForeColor Attr.defAttr Color.yellow)
-                    , (attrName "error", Attr.withForeColor Attr.defAttr Color.red)
-                    , (attrName "emphasis", Attr.withStyle Attr.defAttr Attr.bold)
-                    , (attrName "subtle", Attr.withForeColor Attr.defAttr $ Color.rgbColor @Int 148 148 148)
-                    ]
-                )
+        , appAttrMap = mkAttrMap
         , appChooseCursor = neverShowCursor
         }

--- a/tricorder/src/Tricorder/UI/Keys.hs
+++ b/tricorder/src/Tricorder/UI/Keys.hs
@@ -5,6 +5,7 @@ module Tricorder.UI.Keys
     , dispatcher
     , viewKeybindings
     , mkKeyConfig
+    , keybindForRoute
     ) where
 
 import Atelier.Effects.Console (Console)
@@ -37,6 +38,7 @@ import Brick.Keybindings
     , onEvent
     , parseBindingList
     )
+import Brick.Keybindings.KeyConfig (firstActiveBinding)
 import Brick.Keybindings.Pretty (ppBinding)
 import Brick.Widgets.Core (hBox)
 import Control.Monad.State (gets, modify)
@@ -54,26 +56,29 @@ import Data.Set qualified as Set
 import Data.Text qualified as T
 
 import Tricorder.UI.Misc (warn)
+import Tricorder.UI.Route (Route)
 import Tricorder.UI.State
-    ( ActiveView (..)
-    , State (..)
+    ( State (..)
     , Viewports (..)
-    , currentView
-    , cycleTestView
-    , popView
-    , pushView
+    , currentRoute
+    , cycleTestFilter
+    , popRoute
+    , pushRoute
+    , viewToViewport
     )
+
+import Tricorder.UI.Route qualified as Route
 
 
 -- When adding a new event here, also list it in the README under "Custom Key Bindings".
 data KeyEvent
     = ToggleDaemonInfoView
-    | Quit
+    | ToggleHelp
+    | CycleTestView
     | ExitView
     | ScrollUp
     | ScrollDown
-    | ToggleHelp
-    | CycleTestView
+    | Quit
     deriving stock (Bounded, Enum, Eq, Ord, Show)
 
 
@@ -93,24 +98,24 @@ keys :: KeyEvents KeyEvent
 keys =
     keyEvents
         [ ("toggle daemon info", ToggleDaemonInfoView)
-        , ("quit", Quit)
+        , ("toggle help", ToggleHelp)
+        , ("cycle test view", CycleTestView)
         , ("exit view", ExitView)
         , ("scroll up", ScrollUp)
         , ("scroll down", ScrollDown)
-        , ("toggle help", ToggleHelp)
-        , ("cycle test view", CycleTestView)
+        , ("quit", Quit)
         ]
 
 
 bindings :: [(KeyEvent, [Binding])]
 bindings =
     [ (ToggleDaemonInfoView, [bind 'g'])
-    , (Quit, [bind 'q', ctrl 'c'])
+    , (ToggleHelp, [bind 'h'])
+    , (CycleTestView, [bind 't'])
     , (ExitView, [binding KEsc []])
     , (ScrollUp, [binding KUp []])
     , (ScrollDown, [binding KDown []])
-    , (ToggleHelp, [bind 'h'])
-    , (CycleTestView, [bind 't'])
+    , (Quit, [bind 'q', ctrl 'c'])
     ]
 
 
@@ -164,43 +169,41 @@ dispatcher cfg =
             cfg
             [ onEvent ToggleDaemonInfoView "Toggle daemon info view" do
                 modify \s ->
-                    if currentView s == Just ViewDaemonInfo then
-                        popView s
+                    if currentRoute s == Route.DaemonInfo then
+                        popRoute s
                     else
-                        pushView ViewDaemonInfo s
-            , onEvent Quit "Exit" do
-                halt
-            , onEvent ExitView "Exit or go back" do
-                stack <- gets (.viewStack)
-                if null stack then halt else modify popView
-            , onEvent ScrollUp "Scroll up" do
-                av <- gets currentView
-                unless (av == Just ViewHelp) do
-                    let vp = case av of
-                            Just (ViewTestResults _) -> TestViewport
-                            _ -> DiagnosticViewport
-                    vScrollBy (viewportScroll vp) (-1)
-            , onEvent ScrollDown "Scroll down" do
-                av <- gets currentView
-                unless (av == Just ViewHelp) do
-                    let vp = case av of
-                            Just (ViewTestResults _) -> TestViewport
-                            _ -> DiagnosticViewport
-                    vScrollBy (viewportScroll vp) 1
+                        pushRoute Route.DaemonInfo s
             , onEvent ToggleHelp "Toggle help" do
                 modify \s ->
-                    if currentView s == Just ViewHelp then
-                        popView s
+                    if currentRoute s == Route.Help then
+                        popRoute s
                     else
-                        pushView ViewHelp s
+                        pushRoute Route.Help s
             , onEvent CycleTestView "Cycle test results view" do
-                modify \s -> case currentView s of
-                    Just (ViewTestResults tv) ->
-                        if tv == maxBound then
-                            popView s
+                modify \s -> case currentRoute s of
+                    Route.Tests ->
+                        if s.testFilter == maxBound then
+                            popRoute s {testFilter = minBound}
                         else
-                            pushView (ViewTestResults (cycleTestView tv)) (popView s)
-                    _ -> pushView (ViewTestResults minBound) s
+                            s {testFilter = cycleTestFilter s.testFilter}
+                    _ -> pushRoute Route.Tests s
+            , onEvent ExitView "Exit or go back" do
+                gets (.routeHistory) >>= \case
+                    (_ :| []) -> halt
+                    _ -> modify popRoute
+            , onEvent ScrollUp "Scroll up" do
+                mvp <- gets (viewToViewport . currentRoute)
+                case mvp of
+                    Just vp -> vScrollBy (viewportScroll vp) (-1)
+                    Nothing -> pure ()
+            , onEvent ScrollDown "Scroll down" do
+                mvp <- gets (viewToViewport . currentRoute)
+                case mvp of
+                    Just vp ->
+                        vScrollBy (viewportScroll vp) 1
+                    Nothing -> pure ()
+            , onEvent Quit "Exit" do
+                halt
             ]
   where
     stringify =
@@ -218,13 +221,21 @@ viewKeybindings kc =
 
 
 viewEventAndTriggers :: (Ord k, Show k) => KeyConfig k -> Text -> [EventTrigger k] -> Widget n
-viewEventAndTriggers kc eventName trigger =
+viewEventAndTriggers kc eventName triggers =
     hBox
         [ warn $ txt $ eventName <> ": "
-        , txt $ showBindings $ mconcat $ getBindings <$> trigger
+        , txt $ showBindings $ mconcat $ getBindings <$> triggers
         ]
   where
     showBindings = T.intercalate ", " . fmap ppBinding . sort . toList
     getBindings = \case
         ByKey k -> Set.singleton k
         ByEvent e -> Set.fromList $ allActiveBindings kc e
+
+
+keybindForRoute :: KeyConfig KeyEvent -> Route -> Maybe Binding
+keybindForRoute kc = \case
+    Route.Main -> Nothing
+    Route.DaemonInfo -> firstActiveBinding kc ToggleDaemonInfoView
+    Route.Help -> firstActiveBinding kc ToggleHelp
+    Route.Tests -> firstActiveBinding kc CycleTestView

--- a/tricorder/src/Tricorder/UI/Keys.hs
+++ b/tricorder/src/Tricorder/UI/Keys.hs
@@ -62,8 +62,7 @@ import Tricorder.UI.State
     , Viewports (..)
     , currentRoute
     , cycleTestFilter
-    , popRoute
-    , pushRoute
+    , navigate
     , viewToViewport
     )
 
@@ -170,27 +169,27 @@ dispatcher cfg =
             [ onEvent ToggleDaemonInfoView "Toggle daemon info view" do
                 modify \s ->
                     if currentRoute s == Route.DaemonInfo then
-                        popRoute s
+                        navigate Route.Main s
                     else
-                        pushRoute Route.DaemonInfo s
+                        navigate Route.DaemonInfo s
             , onEvent ToggleHelp "Toggle help" do
                 modify \s ->
                     if currentRoute s == Route.Help then
-                        popRoute s
+                        navigate Route.Main s
                     else
-                        pushRoute Route.Help s
+                        navigate Route.Help s
             , onEvent CycleTestView "Cycle test results view" do
                 modify \s -> case currentRoute s of
                     Route.Tests ->
                         if s.testFilter == maxBound then
-                            popRoute s {testFilter = minBound}
+                            navigate Route.Main s {testFilter = minBound}
                         else
                             s {testFilter = cycleTestFilter s.testFilter}
-                    _ -> pushRoute Route.Tests s
+                    _ -> navigate Route.Tests s
             , onEvent ExitView "Exit or go back" do
-                gets (.routeHistory) >>= \case
-                    (_ :| []) -> halt
-                    _ -> modify popRoute
+                gets (.route) >>= \case
+                    Route.Main -> halt
+                    _ -> modify $ navigate Route.Main
             , onEvent ScrollUp "Scroll up" do
                 mvp <- gets (viewToViewport . currentRoute)
                 case mvp of

--- a/tricorder/src/Tricorder/UI/Route.hs
+++ b/tricorder/src/Tricorder/UI/Route.hs
@@ -1,0 +1,20 @@
+module Tricorder.UI.Route
+    ( Route (..)
+    , name
+    ) where
+
+
+data Route
+    = Main
+    | Help
+    | DaemonInfo
+    | Tests
+    deriving stock (Bounded, Enum, Eq)
+
+
+name :: Route -> Text
+name = \case
+    Main -> "Dashboard"
+    Help -> "Help"
+    DaemonInfo -> "Daemon info"
+    Tests -> "Tests"

--- a/tricorder/src/Tricorder/UI/State.hs
+++ b/tricorder/src/Tricorder/UI/State.hs
@@ -7,15 +7,13 @@ module Tricorder.UI.State
     , currentRoute
     , viewToViewport
     , cycleTestFilter
-    , pushRoute
-    , popRoute
+    , navigate
     ) where
 
 import Atelier.Effects.Clock (Clock, TimeZone)
 import Prelude hiding (init)
 
 import Atelier.Effects.Clock qualified as Clock
-import Data.List.NonEmpty qualified as NonEmpty
 
 import Tricorder.BuildState (BuildState (..))
 import Tricorder.UI.Route (Route)
@@ -33,7 +31,7 @@ data Viewports
 data State = State
     { buildState :: Processed Text BuildState
     , timeZone :: TimeZone
-    , routeHistory :: NonEmpty Route
+    , route :: Route
     , testFilter :: TestFilter
     }
 
@@ -53,7 +51,7 @@ data Processed e a
 
 
 currentRoute :: State -> Route
-currentRoute = NonEmpty.head . (.routeHistory)
+currentRoute = (.route)
 
 
 viewToViewport :: Route -> Maybe Viewports
@@ -63,17 +61,8 @@ viewToViewport = \case
     _ -> Nothing
 
 
-pushRoute :: Route -> State -> State
-pushRoute v s = s {routeHistory = v :| toList s.routeHistory}
-
-
-popRoute :: State -> State
-popRoute s =
-    s
-        { routeHistory = case s.routeHistory of
-            _ :| [] -> Route.Main :| []
-            _ :| (x : xs) -> x :| xs
-        }
+navigate :: Route -> State -> State
+navigate route s = s {route}
 
 
 init :: (Clock :> es) => Eff es State
@@ -83,6 +72,6 @@ init = do
         State
             { buildState = Waiting
             , timeZone = tz
-            , routeHistory = Route.Main :| []
+            , route = Route.Main
             , testFilter = minBound
             }

--- a/tricorder/src/Tricorder/UI/State.hs
+++ b/tricorder/src/Tricorder/UI/State.hs
@@ -2,21 +2,25 @@ module Tricorder.UI.State
     ( Viewports (..)
     , State (..)
     , Processed (..)
+    , TestFilter (..)
     , init
-    , ActiveView (..)
-    , TestView (..)
-    , currentView
-    , pushView
-    , popView
-    , cycleTestView
+    , currentRoute
+    , viewToViewport
+    , cycleTestFilter
+    , pushRoute
+    , popRoute
     ) where
 
 import Atelier.Effects.Clock (Clock, TimeZone)
 import Prelude hiding (init)
 
 import Atelier.Effects.Clock qualified as Clock
+import Data.List.NonEmpty qualified as NonEmpty
 
 import Tricorder.BuildState (BuildState (..))
+import Tricorder.UI.Route (Route)
+
+import Tricorder.UI.Route qualified as Route
 
 
 data Viewports
@@ -29,8 +33,17 @@ data Viewports
 data State = State
     { buildState :: Processed Text BuildState
     , timeZone :: TimeZone
-    , viewStack :: [ActiveView]
+    , routeHistory :: NonEmpty Route
+    , testFilter :: TestFilter
     }
+
+
+data TestFilter = TestFilterAll | TestFilterFailedOnly
+    deriving stock (Bounded, Enum, Eq)
+
+
+cycleTestFilter :: TestFilter -> TestFilter
+cycleTestFilter x = if x == maxBound then minBound else succ x
 
 
 data Processed e a
@@ -39,31 +52,28 @@ data Processed e a
     | Success a
 
 
-data ActiveView
-    = ViewHelp
-    | ViewDaemonInfo
-    | ViewTestResults TestView
-    deriving stock (Eq)
+currentRoute :: State -> Route
+currentRoute = NonEmpty.head . (.routeHistory)
 
 
-data TestView = TestViewFailOnly | TestViewFull
-    deriving stock (Bounded, Enum, Eq)
+viewToViewport :: Route -> Maybe Viewports
+viewToViewport = \case
+    Route.Tests -> Just TestViewport
+    Route.Main -> Just DiagnosticViewport
+    _ -> Nothing
 
 
-currentView :: State -> Maybe ActiveView
-currentView = viaNonEmpty head . (.viewStack)
+pushRoute :: Route -> State -> State
+pushRoute v s = s {routeHistory = v :| toList s.routeHistory}
 
 
-pushView :: ActiveView -> State -> State
-pushView v s = s {viewStack = v : s.viewStack}
-
-
-popView :: State -> State
-popView s = s {viewStack = drop 1 s.viewStack}
-
-
-cycleTestView :: TestView -> TestView
-cycleTestView v = if v == maxBound then minBound else succ v
+popRoute :: State -> State
+popRoute s =
+    s
+        { routeHistory = case s.routeHistory of
+            _ :| [] -> Route.Main :| []
+            _ :| (x : xs) -> x :| xs
+        }
 
 
 init :: (Clock :> es) => Eff es State
@@ -73,5 +83,6 @@ init = do
         State
             { buildState = Waiting
             , timeZone = tz
-            , viewStack = []
+            , routeHistory = Route.Main :| []
+            , testFilter = minBound
             }

--- a/tricorder/src/Tricorder/UI/View.hs
+++ b/tricorder/src/Tricorder/UI/View.hs
@@ -1,22 +1,23 @@
-module Tricorder.UI.View (view) where
+module Tricorder.UI.View (mkAttrMap, view) where
 
 import Atelier.Effects.Clock (TimeZone)
 import Atelier.Time (Millisecond, toMicroseconds)
 import Brick
-    ( AttrName
+    ( AttrMap
+    , AttrName
     , VScrollBarOrientation (..)
     , ViewportType (..)
     , Widget
+    , attrMap
     , attrName
     , vBox
     , viewport
     )
-import Brick.Keybindings (KeyConfig, KeyHandler (..), keyDispatcherToList)
+import Brick.Keybindings (KeyConfig, KeyHandler (..), keyDispatcherToList, ppBinding)
 import Brick.Widgets.Core
     ( Padding (..)
     , emptyWidget
     , hBox
-    , padBottom
     , padLeft
     , txt
     , txtWrap
@@ -29,6 +30,8 @@ import Data.Time (UTCTime, defaultTimeLocale, formatTime, utcToLocalTime)
 import System.FilePath (isAbsolute)
 
 import Data.Text qualified as T
+import Graphics.Vty.Attributes qualified as Attr
+import Graphics.Vty.Attributes.Color qualified as Color
 
 import Tricorder.BuildState
     ( BuildPhase (..)
@@ -45,26 +48,85 @@ import Tricorder.BuildState
     , TestRunError (..)
     )
 import Tricorder.TestOutput (stripGhciNoise)
-import Tricorder.UI.Keys (KeyEvent, viewKeybindings)
+import Tricorder.UI.Keys (KeyEvent, keybindForRoute, viewKeybindings)
 import Tricorder.UI.Misc (emphasis, err, hBoxSpaced, ok, subtle, vBoxSpaced, warn)
-import Tricorder.UI.State (ActiveView (..), Processed (..), State (..), TestView (..), Viewports (..), currentView)
+import Tricorder.UI.Route (Route)
+import Tricorder.UI.State (Processed (..), State (..), TestFilter (..), Viewports (..), currentRoute)
 
 import Tricorder.UI.Keys qualified as Keys
+import Tricorder.UI.Route qualified as Route
 import Tricorder.Version qualified as Version
+
+
+mkAttrMap :: State -> AttrMap
+mkAttrMap =
+    const
+        ( attrMap
+            Attr.defAttr
+            [ (attrName "ok", Attr.withForeColor Attr.defAttr Color.green)
+            , (attrName "warning", Attr.withForeColor Attr.defAttr Color.yellow)
+            , (attrName "error", Attr.withForeColor Attr.defAttr Color.red)
+            , (attrName "emphasis", Attr.withStyle Attr.defAttr Attr.bold)
+            , (attrName "subtle", Attr.withForeColor Attr.defAttr $ Color.rgbColor @Int 148 148 148)
+            ]
+        )
 
 
 view :: KeyConfig KeyEvent -> State -> [Widget Viewports]
 view kc ws =
-    [ case currentView ws of
-        Just ViewHelp ->
-            viewHelp kc
-        Just ViewDaemonInfo ->
-            withHint $ withBuildState ws (viewDaemonInfoPanel ws.timeZone)
-        Just (ViewTestResults tv) ->
-            withHint $ withBuildState ws (viewTestResultsPanel ws.timeZone tv)
-        Nothing ->
-            withHint $ withBuildState ws (viewDefaultPanel ws.timeZone)
+    [ vBoxSpaced
+        1
+        [ vBox
+            [ viewAppHeader ws
+            , viewTabs kc ws
+            ]
+        , case currentRoute ws of
+            Route.Help ->
+                viewHelp kc
+            Route.DaemonInfo ->
+                viewDaemonInfo ws
+            Route.Tests ->
+                viewTests ws
+            Route.Main ->
+                viewMain ws
+        ]
     ]
+
+
+viewTabs :: KeyConfig KeyEvent -> State -> Widget n
+viewTabs kc ws =
+    hBoxSpaced 1
+        $ intersperse (subtle $ txt "-")
+        $ viewRouteTab kc ws <$> universe @Route
+
+
+viewRouteTab :: KeyConfig KeyEvent -> State -> Route -> Widget n
+viewRouteTab kc ws route =
+    style $ txt $ Route.name route <> keyBind
+  where
+    style = if route == currentRoute ws then id else subtle
+    showBinding = (" " <>) . ("[" <>) . (<> "]") . ppBinding
+    keyBind = maybe "" showBinding $ keybindForRoute kc route
+
+
+viewDaemonInfo :: State -> Widget Viewports
+viewDaemonInfo ws =
+    withBuildState ws (viewExpandedDaemonInfo . (.daemonInfo))
+
+
+viewTests :: State -> Widget Viewports
+viewTests ws =
+    withBuildState ws (viewTestResultsPanel ws)
+
+
+viewMain :: State -> Widget Viewports
+viewMain ws = withBuildState ws (viewDefaultPanel ws.timeZone)
+
+
+viewHelp :: KeyConfig KeyEvent -> Widget n
+viewHelp kc = viewKeybindings kc handlers
+  where
+    handlers = (.khHandler) . snd <$> keyDispatcherToList (Keys.dispatcher kc)
 
 
 withBuildState :: State -> (BuildState -> Widget Viewports) -> Widget Viewports
@@ -78,44 +140,39 @@ withBuildState ws render =
             render bs
 
 
-withHint :: Widget n -> Widget n
-withHint content = vBox [padBottom Max content, viewHint]
+viewAppHeader :: State -> Widget n
+viewAppHeader ws =
+    ok
+        $ emphasis
+        $ txt
+        $ "Tricorder"
+            <> maybe
+                ""
+                (" - " <>)
+                (viewHeading ws)
 
 
-viewHelp :: KeyConfig KeyEvent -> Widget n
-viewHelp kc =
-    vBox
-        [ padBottom Max $ vBoxSpaced 1 [ok $ txt "Keymap:", viewKeybindings kc handlers]
-        , subtle $ txt "Press 'h' to go back"
-        ]
-  where
-    handlers = (.khHandler) . snd <$> keyDispatcherToList (Keys.dispatcher kc)
+viewHeading :: State -> Maybe Text
+viewHeading ws = case currentRoute ws of
+    Route.Tests -> case ws.testFilter of
+        TestFilterAll -> Just "Tests"
+        TestFilterFailedOnly -> Just "Tests - Failed only"
+    Route.Help -> Just "Help"
+    Route.DaemonInfo -> Just "Daemon info"
+    Route.Main -> Nothing
 
 
 viewDefaultPanel :: TimeZone -> BuildState -> Widget Viewports
 viewDefaultPanel tz bs = viewBuildPhase tz bs.phase
 
 
-viewDaemonInfoPanel :: TimeZone -> BuildState -> Widget Viewports
-viewDaemonInfoPanel tz bs =
+viewTestResultsPanel :: State -> BuildState -> Widget Viewports
+viewTestResultsPanel ws bs =
     vBoxSpaced
         1
-        [ viewBuildPhaseLine tz bs.phase
-        , viewExpandedDaemonInfo bs.daemonInfo
+        [ viewBuildPhaseLine ws.timeZone bs.phase
+        , viewTestPanel ws.testFilter (phaseTestRuns bs.phase)
         ]
-
-
-viewTestResultsPanel :: TimeZone -> TestView -> BuildState -> Widget Viewports
-viewTestResultsPanel tz tv bs =
-    vBoxSpaced
-        1
-        [ viewBuildPhaseLine tz bs.phase
-        , viewTestPanel tv (phaseTestRuns bs.phase)
-        ]
-
-
-viewHint :: Widget n
-viewHint = subtle $ txt "Press 'h' for help"
 
 
 viewExpandedDaemonInfo :: DaemonInfo -> Widget n
@@ -363,32 +420,32 @@ phaseTestRuns (Done r) = r.testRuns
 phaseTestRuns _ = []
 
 
-viewTestPanel :: TestView -> [TestRun] -> Widget Viewports
+viewTestPanel :: TestFilter -> [TestRun] -> Widget Viewports
 viewTestPanel _ [] = subtle $ txt "No test results."
-viewTestPanel tv runs = scrollableRuns tv runs
+viewTestPanel tvf runs = scrollableRuns tvf runs
 
 
-scrollableRuns :: TestView -> [TestRun] -> Widget Viewports
-scrollableRuns tv runs =
-    vScrollViewport TestViewport (viewTestRunDetail tv <$> runs)
+scrollableRuns :: TestFilter -> [TestRun] -> Widget Viewports
+scrollableRuns tvf runs =
+    vScrollViewport TestViewport (viewTestRunDetail tvf <$> runs)
 
 
-viewTestRunDetail :: TestView -> TestRun -> Widget n
+viewTestRunDetail :: TestFilter -> TestRun -> Widget n
 viewTestRunDetail _ (TestRunning t Nothing) = hBox [txt t, txt "  ", warn $ txt "running..."]
 viewTestRunDetail _ (TestRunning t (Just p)) =
     hBox [txt t, txt "  ", warn $ txt $ "running... (" <> show p.compiled <> "/" <> show p.total <> ")"]
 viewTestRunDetail _ (TestRunErrored e) = hBoxSpaced 1 [txt e.target, err $ txt "error:", txt e.message]
-viewTestRunDetail tv (TestRunCompleted c) =
+viewTestRunDetail tvf (TestRunCompleted c) =
     vBox
         [ hBox [txt c.target, txt "  ", viewCompletionStatus c]
-        , viewTestOutput tv c
+        , viewTestOutput tvf c
         ]
 
 
-viewTestOutput :: TestView -> TestRunCompletion -> Widget n
-viewTestOutput TestViewFull c =
+viewTestOutput :: TestFilter -> TestRunCompletion -> Widget n
+viewTestOutput TestFilterAll c =
     padLeft (Pad 2) $ vBox $ txt <$> stripGhciNoise (T.lines c.output)
-viewTestOutput TestViewFailOnly c
+viewTestOutput TestFilterFailedOnly c
     | not (any isCaseFailed c.testCases) && c.passed = emptyWidget
     | null c.testCases =
         padLeft (Pad 2)

--- a/tricorder/tricorder.cabal
+++ b/tricorder/tricorder.cabal
@@ -61,6 +61,7 @@ library tricorder-internal
       Tricorder.UI.Event
       Tricorder.UI.Keys
       Tricorder.UI.Misc
+      Tricorder.UI.Route
       Tricorder.UI.State
       Tricorder.UI.View
       Tricorder.Version


### PR DESCRIPTION
Show active tab, and treat the individual views as tabs. Show key bind for each tab next to the tab name to make it more apparent what to press to view each tab.

This PR also drops the concept of a "navigation history" where `Esc` attempts to go back to the previous view that was opened. After some testing, I deemed it more confusing than helpful. If the user wants to go to a specific view they were at, it's easier for them to use the key binding that is shown instead of relying on `Esc` acting like a "back" button.

This also makes the Daemon info view a separate view that doesn't show the build result while it is open. The user is unlikely to need this daemon info while viewing the build result.


https://github.com/user-attachments/assets/cf0302c3-7701-4f6b-90f1-0efbf450172c

Depends on https://github.com/atelier-hub/tricorder/pull/196