### PR TITLE
chore: drop modules from materialized files

### DIFF
--- a/.github/workflows/update-materialization.yml
+++ b/.github/workflows/update-materialization.yml
@@ -93,11 +93,11 @@ jobs:
         if: ${{ steps.check-for-change.outputs.upload == 'true' }}
         with:
           name: materialization-${{ matrix.system }}-${{ matrix.ghc-version }}
-          # Include the README.md to make `upload-artifact` base the artifact
+          # Include the hie.yaml to make `upload-artifact` base the artifact
           # in the root of the repo.
           path: |
             nix/materialized/${{ matrix.system }}/${{ matrix.ghc-version }}
-            README.md
+            hie.yaml
           include-hidden-files: true
 
   commit:
@@ -118,7 +118,6 @@ jobs:
       - uses: actions/download-artifact@v8
         with:
           pattern: materialization-*
-          path: nix/materialized
           merge-multiple: true
 
       - uses: peter-evans/create-pull-request@v8

--- a/nix/materialized/aarch64-darwin/ghc9102/.plan.nix/atelier-core.nix
+++ b/nix/materialized/aarch64-darwin/ghc9102/.plan.nix/atelier-core.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -75,54 +75,7 @@
           (hsPkgs."warp" or (errorHandler.buildDepError "warp"))
         ];
         buildable = true;
-        modules = [
-          "Paths_atelier_core"
-          "Atelier/Component"
-          "Atelier/Config"
-          "Atelier/Effects/Arguments"
-          "Atelier/Effects/Await"
-          "Atelier/Effects/Cache"
-          "Atelier/Effects/Cache/Config"
-          "Atelier/Effects/Cache/Singleflight"
-          "Atelier/Effects/Chan"
-          "Atelier/Effects/Clock"
-          "Atelier/Effects/Conc"
-          "Atelier/Effects/Conc/Traced"
-          "Atelier/Effects/Console"
-          "Atelier/Effects/Debounce"
-          "Atelier/Effects/Delay"
-          "Atelier/Effects/Env"
-          "Atelier/Effects/Exit"
-          "Atelier/Effects/File"
-          "Atelier/Effects/FileSystem"
-          "Atelier/Effects/FileWatcher"
-          "Atelier/Effects/Input"
-          "Atelier/Effects/Internal/Coroutine"
-          "Atelier/Effects/Iterator"
-          "Atelier/Effects/Log"
-          "Atelier/Effects/Monitoring/Metrics"
-          "Atelier/Effects/Monitoring/Metrics/Registry"
-          "Atelier/Effects/Monitoring/Metrics/Server"
-          "Atelier/Effects/Monitoring/Tracing"
-          "Atelier/Effects/Monitoring/Tracing/Provider"
-          "Atelier/Effects/Posix/Daemons"
-          "Atelier/Effects/Posix/IO"
-          "Atelier/Effects/Process"
-          "Atelier/Effects/Publishing"
-          "Atelier/Effects/Tally"
-          "Atelier/Effects/Timeout"
-          "Atelier/Effects/UUID"
-          "Atelier/Effects/Yield"
-          "Atelier/Exception"
-          "Atelier/Time"
-          "Atelier/Types/Base64"
-          "Atelier/Types/HttpApiDataReadShow"
-          "Atelier/Types/JsonReadShow"
-          "Atelier/Types/QuietSnake"
-          "Atelier/Types/Semaphore"
-          "Atelier/Types/Semaphore/STM"
-          "Atelier/Types/WithDefaults"
-        ];
+        modules = [ "Paths_atelier_core" ];
         hsSourceDirs = [ "src" ];
       };
       tests = {
@@ -153,32 +106,12 @@
             (hsPkgs.pkgsBuildBuild.tasty-discover.components.exes.tasty-discover or (pkgs.pkgsBuildBuild.tasty-discover or (errorHandler.buildToolDepError "tasty-discover:tasty-discover")))
           ];
           buildable = true;
-          modules = [
-            "Unit/Atelier/ConfigSpec"
-            "Unit/Atelier/Effects/AwaitSpec"
-            "Unit/Atelier/Effects/Cache/SingleflightSpec"
-            "Unit/Atelier/Effects/CacheSpec"
-            "Unit/Atelier/Effects/ChanSpec"
-            "Unit/Atelier/Effects/Conc/TeardownStressSpec"
-            "Unit/Atelier/Effects/Conc/TracedSpec"
-            "Unit/Atelier/Effects/ConcSpec"
-            "Unit/Atelier/Effects/ConsoleSpec"
-            "Unit/Atelier/Effects/DebounceSpec"
-            "Unit/Atelier/Effects/FileSystemSpec"
-            "Unit/Atelier/Effects/FileWatcherSpec"
-            "Unit/Atelier/Effects/IteratorSpec"
-            "Unit/Atelier/Effects/LogSpec"
-            "Unit/Atelier/Effects/PublishingSpec"
-            "Unit/Atelier/Effects/TallySpec"
-            "Unit/Atelier/Effects/YieldSpec"
-            "Unit/Atelier/Types/Semaphore/STMSpec"
-            "Unit/Atelier/Types/SemaphoreSpec"
-            "Unit/Atelier/Types/WithDefaultsSpec"
-            "Paths_atelier_core"
-          ];
+          modules = [ "Paths_atelier_core" ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Driver.hs" ];
         };
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-core; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-core; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/aarch64-darwin/ghc9102/.plan.nix/atelier-db.nix
+++ b/nix/materialized/aarch64-darwin/ghc9102/.plan.nix/atelier-db.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -52,13 +52,10 @@
           (hsPkgs."time" or (errorHandler.buildDepError "time"))
         ];
         buildable = true;
-        modules = [
-          "Paths_atelier_db"
-          "Atelier/Effects/DB"
-          "Atelier/Effects/DB/Config"
-          "Atelier/Effects/DB/Rel8"
-        ];
+        modules = [ "Paths_atelier_db" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-db; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-db; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/aarch64-darwin/ghc9102/.plan.nix/atelier-prelude.nix
+++ b/nix/materialized/aarch64-darwin/ghc9102/.plan.nix/atelier-prelude.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "1.18";
@@ -38,8 +38,10 @@
           (hsPkgs."relude" or (errorHandler.buildDepError "relude"))
         ];
         buildable = true;
-        modules = [ "Paths_atelier_prelude" "Prelude" ];
+        modules = [ "Paths_atelier_prelude" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-prelude; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-prelude; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/aarch64-darwin/ghc9102/.plan.nix/atelier-testing.nix
+++ b/nix/materialized/aarch64-darwin/ghc9102/.plan.nix/atelier-testing.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -50,8 +50,10 @@
           (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
         ];
         buildable = true;
-        modules = [ "Paths_atelier_testing" "Atelier/Testing/Database" ];
+        modules = [ "Paths_atelier_testing" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-testing; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-testing; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/aarch64-darwin/ghc9102/.plan.nix/tricorder.nix
+++ b/nix/materialized/aarch64-darwin/ghc9102/.plan.nix/tricorder.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -68,49 +68,7 @@
             (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))
           ];
           buildable = true;
-          modules = [
-            "Paths_tricorder"
-            "Tricorder"
-            "Tricorder/Arguments"
-            "Tricorder/Builder"
-            "Tricorder/Builder/Dispatch"
-            "Tricorder/BuildState"
-            "Tricorder/CLI"
-            "Tricorder/CLI/Main"
-            "Tricorder/CLI/Render"
-            "Tricorder/Config"
-            "Tricorder/Daemon"
-            "Tricorder/Daemon/Main"
-            "Tricorder/Effects/Brick"
-            "Tricorder/Effects/BrickChan"
-            "Tricorder/Effects/BuildStore"
-            "Tricorder/Effects/GhciSession"
-            "Tricorder/Effects/GhciSession/GhciParser"
-            "Tricorder/Effects/GhciSession/GhciProcess"
-            "Tricorder/Effects/GhcPkg"
-            "Tricorder/Effects/Logging"
-            "Tricorder/Effects/SessionStore"
-            "Tricorder/Effects/TestRunner"
-            "Tricorder/Effects/UnixSocket"
-            "Tricorder/Events/FileChanged"
-            "Tricorder/GhcPkg/Types"
-            "Tricorder/Observability"
-            "Tricorder/Runtime"
-            "Tricorder/Session"
-            "Tricorder/Socket/Client"
-            "Tricorder/Socket/Protocol"
-            "Tricorder/Socket/Server"
-            "Tricorder/SourceLookup"
-            "Tricorder/TestOutput"
-            "Tricorder/UI"
-            "Tricorder/UI/Event"
-            "Tricorder/UI/Keys"
-            "Tricorder/UI/Misc"
-            "Tricorder/UI/State"
-            "Tricorder/UI/View"
-            "Tricorder/Version"
-            "Tricorder/Watcher"
-          ];
+          modules = [ "Paths_tricorder" ];
           hsSourceDirs = [ "src" ];
         };
       };
@@ -172,28 +130,12 @@
             (hsPkgs.pkgsBuildBuild.tasty-discover.components.exes.tasty-discover or (pkgs.pkgsBuildBuild.tasty-discover or (errorHandler.buildToolDepError "tasty-discover:tasty-discover")))
           ];
           buildable = true;
-          modules = [
-            "Unit/Tricorder/BuilderSpec"
-            "Unit/Tricorder/BuildStateSpec"
-            "Unit/Tricorder/BuildStoreSpec"
-            "Unit/Tricorder/CLI/RenderSpec"
-            "Unit/Tricorder/Effects/GhciSession/GhciParserSpec"
-            "Unit/Tricorder/Effects/GhciSession/GhciProcessSpec"
-            "Unit/Tricorder/Effects/GhciSessionSpec"
-            "Unit/Tricorder/Effects/SessionStoreSpec"
-            "Unit/Tricorder/GhcPkgSpec"
-            "Unit/Tricorder/SessionSpec"
-            "Unit/Tricorder/SocketSpec"
-            "Unit/Tricorder/SourceLookupSpec"
-            "Unit/Tricorder/SourceSpec"
-            "Unit/Tricorder/TestOutputSpec"
-            "Unit/Tricorder/TestRunnerSpec"
-            "Unit/Tricorder/WatcherSpec"
-            "Paths_tricorder"
-          ];
+          modules = [ "Paths_tricorder" ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Driver.hs" ];
         };
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../tricorder; }
+  } // rec { src = pkgs.lib.mkDefault ../tricorder; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/aarch64-darwin/ghc912/.plan.nix/atelier-core.nix
+++ b/nix/materialized/aarch64-darwin/ghc912/.plan.nix/atelier-core.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -75,54 +75,7 @@
           (hsPkgs."warp" or (errorHandler.buildDepError "warp"))
         ];
         buildable = true;
-        modules = [
-          "Paths_atelier_core"
-          "Atelier/Component"
-          "Atelier/Config"
-          "Atelier/Effects/Arguments"
-          "Atelier/Effects/Await"
-          "Atelier/Effects/Cache"
-          "Atelier/Effects/Cache/Config"
-          "Atelier/Effects/Cache/Singleflight"
-          "Atelier/Effects/Chan"
-          "Atelier/Effects/Clock"
-          "Atelier/Effects/Conc"
-          "Atelier/Effects/Conc/Traced"
-          "Atelier/Effects/Console"
-          "Atelier/Effects/Debounce"
-          "Atelier/Effects/Delay"
-          "Atelier/Effects/Env"
-          "Atelier/Effects/Exit"
-          "Atelier/Effects/File"
-          "Atelier/Effects/FileSystem"
-          "Atelier/Effects/FileWatcher"
-          "Atelier/Effects/Input"
-          "Atelier/Effects/Internal/Coroutine"
-          "Atelier/Effects/Iterator"
-          "Atelier/Effects/Log"
-          "Atelier/Effects/Monitoring/Metrics"
-          "Atelier/Effects/Monitoring/Metrics/Registry"
-          "Atelier/Effects/Monitoring/Metrics/Server"
-          "Atelier/Effects/Monitoring/Tracing"
-          "Atelier/Effects/Monitoring/Tracing/Provider"
-          "Atelier/Effects/Posix/Daemons"
-          "Atelier/Effects/Posix/IO"
-          "Atelier/Effects/Process"
-          "Atelier/Effects/Publishing"
-          "Atelier/Effects/Tally"
-          "Atelier/Effects/Timeout"
-          "Atelier/Effects/UUID"
-          "Atelier/Effects/Yield"
-          "Atelier/Exception"
-          "Atelier/Time"
-          "Atelier/Types/Base64"
-          "Atelier/Types/HttpApiDataReadShow"
-          "Atelier/Types/JsonReadShow"
-          "Atelier/Types/QuietSnake"
-          "Atelier/Types/Semaphore"
-          "Atelier/Types/Semaphore/STM"
-          "Atelier/Types/WithDefaults"
-        ];
+        modules = [ "Paths_atelier_core" ];
         hsSourceDirs = [ "src" ];
       };
       tests = {
@@ -153,32 +106,12 @@
             (hsPkgs.pkgsBuildBuild.tasty-discover.components.exes.tasty-discover or (pkgs.pkgsBuildBuild.tasty-discover or (errorHandler.buildToolDepError "tasty-discover:tasty-discover")))
           ];
           buildable = true;
-          modules = [
-            "Unit/Atelier/ConfigSpec"
-            "Unit/Atelier/Effects/AwaitSpec"
-            "Unit/Atelier/Effects/Cache/SingleflightSpec"
-            "Unit/Atelier/Effects/CacheSpec"
-            "Unit/Atelier/Effects/ChanSpec"
-            "Unit/Atelier/Effects/Conc/TeardownStressSpec"
-            "Unit/Atelier/Effects/Conc/TracedSpec"
-            "Unit/Atelier/Effects/ConcSpec"
-            "Unit/Atelier/Effects/ConsoleSpec"
-            "Unit/Atelier/Effects/DebounceSpec"
-            "Unit/Atelier/Effects/FileSystemSpec"
-            "Unit/Atelier/Effects/FileWatcherSpec"
-            "Unit/Atelier/Effects/IteratorSpec"
-            "Unit/Atelier/Effects/LogSpec"
-            "Unit/Atelier/Effects/PublishingSpec"
-            "Unit/Atelier/Effects/TallySpec"
-            "Unit/Atelier/Effects/YieldSpec"
-            "Unit/Atelier/Types/Semaphore/STMSpec"
-            "Unit/Atelier/Types/SemaphoreSpec"
-            "Unit/Atelier/Types/WithDefaultsSpec"
-            "Paths_atelier_core"
-          ];
+          modules = [ "Paths_atelier_core" ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Driver.hs" ];
         };
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-core; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-core; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/aarch64-darwin/ghc912/.plan.nix/atelier-db.nix
+++ b/nix/materialized/aarch64-darwin/ghc912/.plan.nix/atelier-db.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -52,13 +52,10 @@
           (hsPkgs."time" or (errorHandler.buildDepError "time"))
         ];
         buildable = true;
-        modules = [
-          "Paths_atelier_db"
-          "Atelier/Effects/DB"
-          "Atelier/Effects/DB/Config"
-          "Atelier/Effects/DB/Rel8"
-        ];
+        modules = [ "Paths_atelier_db" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-db; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-db; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/aarch64-darwin/ghc912/.plan.nix/atelier-prelude.nix
+++ b/nix/materialized/aarch64-darwin/ghc912/.plan.nix/atelier-prelude.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "1.18";
@@ -38,8 +38,10 @@
           (hsPkgs."relude" or (errorHandler.buildDepError "relude"))
         ];
         buildable = true;
-        modules = [ "Paths_atelier_prelude" "Prelude" ];
+        modules = [ "Paths_atelier_prelude" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-prelude; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-prelude; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/aarch64-darwin/ghc912/.plan.nix/atelier-testing.nix
+++ b/nix/materialized/aarch64-darwin/ghc912/.plan.nix/atelier-testing.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -50,8 +50,10 @@
           (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
         ];
         buildable = true;
-        modules = [ "Paths_atelier_testing" "Atelier/Testing/Database" ];
+        modules = [ "Paths_atelier_testing" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-testing; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-testing; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/aarch64-darwin/ghc912/.plan.nix/tricorder.nix
+++ b/nix/materialized/aarch64-darwin/ghc912/.plan.nix/tricorder.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -68,49 +68,7 @@
             (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))
           ];
           buildable = true;
-          modules = [
-            "Paths_tricorder"
-            "Tricorder"
-            "Tricorder/Arguments"
-            "Tricorder/Builder"
-            "Tricorder/Builder/Dispatch"
-            "Tricorder/BuildState"
-            "Tricorder/CLI"
-            "Tricorder/CLI/Main"
-            "Tricorder/CLI/Render"
-            "Tricorder/Config"
-            "Tricorder/Daemon"
-            "Tricorder/Daemon/Main"
-            "Tricorder/Effects/Brick"
-            "Tricorder/Effects/BrickChan"
-            "Tricorder/Effects/BuildStore"
-            "Tricorder/Effects/GhciSession"
-            "Tricorder/Effects/GhciSession/GhciParser"
-            "Tricorder/Effects/GhciSession/GhciProcess"
-            "Tricorder/Effects/GhcPkg"
-            "Tricorder/Effects/Logging"
-            "Tricorder/Effects/SessionStore"
-            "Tricorder/Effects/TestRunner"
-            "Tricorder/Effects/UnixSocket"
-            "Tricorder/Events/FileChanged"
-            "Tricorder/GhcPkg/Types"
-            "Tricorder/Observability"
-            "Tricorder/Runtime"
-            "Tricorder/Session"
-            "Tricorder/Socket/Client"
-            "Tricorder/Socket/Protocol"
-            "Tricorder/Socket/Server"
-            "Tricorder/SourceLookup"
-            "Tricorder/TestOutput"
-            "Tricorder/UI"
-            "Tricorder/UI/Event"
-            "Tricorder/UI/Keys"
-            "Tricorder/UI/Misc"
-            "Tricorder/UI/State"
-            "Tricorder/UI/View"
-            "Tricorder/Version"
-            "Tricorder/Watcher"
-          ];
+          modules = [ "Paths_tricorder" ];
           hsSourceDirs = [ "src" ];
         };
       };
@@ -172,28 +130,12 @@
             (hsPkgs.pkgsBuildBuild.tasty-discover.components.exes.tasty-discover or (pkgs.pkgsBuildBuild.tasty-discover or (errorHandler.buildToolDepError "tasty-discover:tasty-discover")))
           ];
           buildable = true;
-          modules = [
-            "Unit/Tricorder/BuilderSpec"
-            "Unit/Tricorder/BuildStateSpec"
-            "Unit/Tricorder/BuildStoreSpec"
-            "Unit/Tricorder/CLI/RenderSpec"
-            "Unit/Tricorder/Effects/GhciSession/GhciParserSpec"
-            "Unit/Tricorder/Effects/GhciSession/GhciProcessSpec"
-            "Unit/Tricorder/Effects/GhciSessionSpec"
-            "Unit/Tricorder/Effects/SessionStoreSpec"
-            "Unit/Tricorder/GhcPkgSpec"
-            "Unit/Tricorder/SessionSpec"
-            "Unit/Tricorder/SocketSpec"
-            "Unit/Tricorder/SourceLookupSpec"
-            "Unit/Tricorder/SourceSpec"
-            "Unit/Tricorder/TestOutputSpec"
-            "Unit/Tricorder/TestRunnerSpec"
-            "Unit/Tricorder/WatcherSpec"
-            "Paths_tricorder"
-          ];
+          modules = [ "Paths_tricorder" ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Driver.hs" ];
         };
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../tricorder; }
+  } // rec { src = pkgs.lib.mkDefault ../tricorder; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/aarch64-darwin/ghc914/.plan.nix/atelier-core.nix
+++ b/nix/materialized/aarch64-darwin/ghc914/.plan.nix/atelier-core.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -75,54 +75,7 @@
           (hsPkgs."warp" or (errorHandler.buildDepError "warp"))
         ];
         buildable = true;
-        modules = [
-          "Paths_atelier_core"
-          "Atelier/Component"
-          "Atelier/Config"
-          "Atelier/Effects/Arguments"
-          "Atelier/Effects/Await"
-          "Atelier/Effects/Cache"
-          "Atelier/Effects/Cache/Config"
-          "Atelier/Effects/Cache/Singleflight"
-          "Atelier/Effects/Chan"
-          "Atelier/Effects/Clock"
-          "Atelier/Effects/Conc"
-          "Atelier/Effects/Conc/Traced"
-          "Atelier/Effects/Console"
-          "Atelier/Effects/Debounce"
-          "Atelier/Effects/Delay"
-          "Atelier/Effects/Env"
-          "Atelier/Effects/Exit"
-          "Atelier/Effects/File"
-          "Atelier/Effects/FileSystem"
-          "Atelier/Effects/FileWatcher"
-          "Atelier/Effects/Input"
-          "Atelier/Effects/Internal/Coroutine"
-          "Atelier/Effects/Iterator"
-          "Atelier/Effects/Log"
-          "Atelier/Effects/Monitoring/Metrics"
-          "Atelier/Effects/Monitoring/Metrics/Registry"
-          "Atelier/Effects/Monitoring/Metrics/Server"
-          "Atelier/Effects/Monitoring/Tracing"
-          "Atelier/Effects/Monitoring/Tracing/Provider"
-          "Atelier/Effects/Posix/Daemons"
-          "Atelier/Effects/Posix/IO"
-          "Atelier/Effects/Process"
-          "Atelier/Effects/Publishing"
-          "Atelier/Effects/Tally"
-          "Atelier/Effects/Timeout"
-          "Atelier/Effects/UUID"
-          "Atelier/Effects/Yield"
-          "Atelier/Exception"
-          "Atelier/Time"
-          "Atelier/Types/Base64"
-          "Atelier/Types/HttpApiDataReadShow"
-          "Atelier/Types/JsonReadShow"
-          "Atelier/Types/QuietSnake"
-          "Atelier/Types/Semaphore"
-          "Atelier/Types/Semaphore/STM"
-          "Atelier/Types/WithDefaults"
-        ];
+        modules = [ "Paths_atelier_core" ];
         hsSourceDirs = [ "src" ];
       };
       tests = {
@@ -153,32 +106,12 @@
             (hsPkgs.pkgsBuildBuild.tasty-discover.components.exes.tasty-discover or (pkgs.pkgsBuildBuild.tasty-discover or (errorHandler.buildToolDepError "tasty-discover:tasty-discover")))
           ];
           buildable = true;
-          modules = [
-            "Unit/Atelier/ConfigSpec"
-            "Unit/Atelier/Effects/AwaitSpec"
-            "Unit/Atelier/Effects/Cache/SingleflightSpec"
-            "Unit/Atelier/Effects/CacheSpec"
-            "Unit/Atelier/Effects/ChanSpec"
-            "Unit/Atelier/Effects/Conc/TeardownStressSpec"
-            "Unit/Atelier/Effects/Conc/TracedSpec"
-            "Unit/Atelier/Effects/ConcSpec"
-            "Unit/Atelier/Effects/ConsoleSpec"
-            "Unit/Atelier/Effects/DebounceSpec"
-            "Unit/Atelier/Effects/FileSystemSpec"
-            "Unit/Atelier/Effects/FileWatcherSpec"
-            "Unit/Atelier/Effects/IteratorSpec"
-            "Unit/Atelier/Effects/LogSpec"
-            "Unit/Atelier/Effects/PublishingSpec"
-            "Unit/Atelier/Effects/TallySpec"
-            "Unit/Atelier/Effects/YieldSpec"
-            "Unit/Atelier/Types/Semaphore/STMSpec"
-            "Unit/Atelier/Types/SemaphoreSpec"
-            "Unit/Atelier/Types/WithDefaultsSpec"
-            "Paths_atelier_core"
-          ];
+          modules = [ "Paths_atelier_core" ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Driver.hs" ];
         };
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-core; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-core; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/aarch64-darwin/ghc914/.plan.nix/atelier-db.nix
+++ b/nix/materialized/aarch64-darwin/ghc914/.plan.nix/atelier-db.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -52,13 +52,10 @@
           (hsPkgs."time" or (errorHandler.buildDepError "time"))
         ];
         buildable = true;
-        modules = [
-          "Paths_atelier_db"
-          "Atelier/Effects/DB"
-          "Atelier/Effects/DB/Config"
-          "Atelier/Effects/DB/Rel8"
-        ];
+        modules = [ "Paths_atelier_db" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-db; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-db; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/aarch64-darwin/ghc914/.plan.nix/atelier-prelude.nix
+++ b/nix/materialized/aarch64-darwin/ghc914/.plan.nix/atelier-prelude.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "1.18";
@@ -38,8 +38,10 @@
           (hsPkgs."relude" or (errorHandler.buildDepError "relude"))
         ];
         buildable = true;
-        modules = [ "Paths_atelier_prelude" "Prelude" ];
+        modules = [ "Paths_atelier_prelude" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-prelude; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-prelude; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/aarch64-darwin/ghc914/.plan.nix/atelier-testing.nix
+++ b/nix/materialized/aarch64-darwin/ghc914/.plan.nix/atelier-testing.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -50,8 +50,10 @@
           (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
         ];
         buildable = true;
-        modules = [ "Paths_atelier_testing" "Atelier/Testing/Database" ];
+        modules = [ "Paths_atelier_testing" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-testing; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-testing; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/aarch64-darwin/ghc914/.plan.nix/tricorder.nix
+++ b/nix/materialized/aarch64-darwin/ghc914/.plan.nix/tricorder.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -68,49 +68,7 @@
             (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))
           ];
           buildable = true;
-          modules = [
-            "Paths_tricorder"
-            "Tricorder"
-            "Tricorder/Arguments"
-            "Tricorder/Builder"
-            "Tricorder/Builder/Dispatch"
-            "Tricorder/BuildState"
-            "Tricorder/CLI"
-            "Tricorder/CLI/Main"
-            "Tricorder/CLI/Render"
-            "Tricorder/Config"
-            "Tricorder/Daemon"
-            "Tricorder/Daemon/Main"
-            "Tricorder/Effects/Brick"
-            "Tricorder/Effects/BrickChan"
-            "Tricorder/Effects/BuildStore"
-            "Tricorder/Effects/GhciSession"
-            "Tricorder/Effects/GhciSession/GhciParser"
-            "Tricorder/Effects/GhciSession/GhciProcess"
-            "Tricorder/Effects/GhcPkg"
-            "Tricorder/Effects/Logging"
-            "Tricorder/Effects/SessionStore"
-            "Tricorder/Effects/TestRunner"
-            "Tricorder/Effects/UnixSocket"
-            "Tricorder/Events/FileChanged"
-            "Tricorder/GhcPkg/Types"
-            "Tricorder/Observability"
-            "Tricorder/Runtime"
-            "Tricorder/Session"
-            "Tricorder/Socket/Client"
-            "Tricorder/Socket/Protocol"
-            "Tricorder/Socket/Server"
-            "Tricorder/SourceLookup"
-            "Tricorder/TestOutput"
-            "Tricorder/UI"
-            "Tricorder/UI/Event"
-            "Tricorder/UI/Keys"
-            "Tricorder/UI/Misc"
-            "Tricorder/UI/State"
-            "Tricorder/UI/View"
-            "Tricorder/Version"
-            "Tricorder/Watcher"
-          ];
+          modules = [ "Paths_tricorder" ];
           hsSourceDirs = [ "src" ];
         };
       };
@@ -172,28 +130,12 @@
             (hsPkgs.pkgsBuildBuild.tasty-discover.components.exes.tasty-discover or (pkgs.pkgsBuildBuild.tasty-discover or (errorHandler.buildToolDepError "tasty-discover:tasty-discover")))
           ];
           buildable = true;
-          modules = [
-            "Unit/Tricorder/BuilderSpec"
-            "Unit/Tricorder/BuildStateSpec"
-            "Unit/Tricorder/BuildStoreSpec"
-            "Unit/Tricorder/CLI/RenderSpec"
-            "Unit/Tricorder/Effects/GhciSession/GhciParserSpec"
-            "Unit/Tricorder/Effects/GhciSession/GhciProcessSpec"
-            "Unit/Tricorder/Effects/GhciSessionSpec"
-            "Unit/Tricorder/Effects/SessionStoreSpec"
-            "Unit/Tricorder/GhcPkgSpec"
-            "Unit/Tricorder/SessionSpec"
-            "Unit/Tricorder/SocketSpec"
-            "Unit/Tricorder/SourceLookupSpec"
-            "Unit/Tricorder/SourceSpec"
-            "Unit/Tricorder/TestOutputSpec"
-            "Unit/Tricorder/TestRunnerSpec"
-            "Unit/Tricorder/WatcherSpec"
-            "Paths_tricorder"
-          ];
+          modules = [ "Paths_tricorder" ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Driver.hs" ];
         };
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../tricorder; }
+  } // rec { src = pkgs.lib.mkDefault ../tricorder; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/aarch64-darwin/ghc98/.plan.nix/atelier-core.nix
+++ b/nix/materialized/aarch64-darwin/ghc98/.plan.nix/atelier-core.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -75,54 +75,7 @@
           (hsPkgs."warp" or (errorHandler.buildDepError "warp"))
         ];
         buildable = true;
-        modules = [
-          "Paths_atelier_core"
-          "Atelier/Component"
-          "Atelier/Config"
-          "Atelier/Effects/Arguments"
-          "Atelier/Effects/Await"
-          "Atelier/Effects/Cache"
-          "Atelier/Effects/Cache/Config"
-          "Atelier/Effects/Cache/Singleflight"
-          "Atelier/Effects/Chan"
-          "Atelier/Effects/Clock"
-          "Atelier/Effects/Conc"
-          "Atelier/Effects/Conc/Traced"
-          "Atelier/Effects/Console"
-          "Atelier/Effects/Debounce"
-          "Atelier/Effects/Delay"
-          "Atelier/Effects/Env"
-          "Atelier/Effects/Exit"
-          "Atelier/Effects/File"
-          "Atelier/Effects/FileSystem"
-          "Atelier/Effects/FileWatcher"
-          "Atelier/Effects/Input"
-          "Atelier/Effects/Internal/Coroutine"
-          "Atelier/Effects/Iterator"
-          "Atelier/Effects/Log"
-          "Atelier/Effects/Monitoring/Metrics"
-          "Atelier/Effects/Monitoring/Metrics/Registry"
-          "Atelier/Effects/Monitoring/Metrics/Server"
-          "Atelier/Effects/Monitoring/Tracing"
-          "Atelier/Effects/Monitoring/Tracing/Provider"
-          "Atelier/Effects/Posix/Daemons"
-          "Atelier/Effects/Posix/IO"
-          "Atelier/Effects/Process"
-          "Atelier/Effects/Publishing"
-          "Atelier/Effects/Tally"
-          "Atelier/Effects/Timeout"
-          "Atelier/Effects/UUID"
-          "Atelier/Effects/Yield"
-          "Atelier/Exception"
-          "Atelier/Time"
-          "Atelier/Types/Base64"
-          "Atelier/Types/HttpApiDataReadShow"
-          "Atelier/Types/JsonReadShow"
-          "Atelier/Types/QuietSnake"
-          "Atelier/Types/Semaphore"
-          "Atelier/Types/Semaphore/STM"
-          "Atelier/Types/WithDefaults"
-        ];
+        modules = [ "Paths_atelier_core" ];
         hsSourceDirs = [ "src" ];
       };
       tests = {
@@ -153,32 +106,12 @@
             (hsPkgs.pkgsBuildBuild.tasty-discover.components.exes.tasty-discover or (pkgs.pkgsBuildBuild.tasty-discover or (errorHandler.buildToolDepError "tasty-discover:tasty-discover")))
           ];
           buildable = true;
-          modules = [
-            "Unit/Atelier/ConfigSpec"
-            "Unit/Atelier/Effects/AwaitSpec"
-            "Unit/Atelier/Effects/Cache/SingleflightSpec"
-            "Unit/Atelier/Effects/CacheSpec"
-            "Unit/Atelier/Effects/ChanSpec"
-            "Unit/Atelier/Effects/Conc/TeardownStressSpec"
-            "Unit/Atelier/Effects/Conc/TracedSpec"
-            "Unit/Atelier/Effects/ConcSpec"
-            "Unit/Atelier/Effects/ConsoleSpec"
-            "Unit/Atelier/Effects/DebounceSpec"
-            "Unit/Atelier/Effects/FileSystemSpec"
-            "Unit/Atelier/Effects/FileWatcherSpec"
-            "Unit/Atelier/Effects/IteratorSpec"
-            "Unit/Atelier/Effects/LogSpec"
-            "Unit/Atelier/Effects/PublishingSpec"
-            "Unit/Atelier/Effects/TallySpec"
-            "Unit/Atelier/Effects/YieldSpec"
-            "Unit/Atelier/Types/Semaphore/STMSpec"
-            "Unit/Atelier/Types/SemaphoreSpec"
-            "Unit/Atelier/Types/WithDefaultsSpec"
-            "Paths_atelier_core"
-          ];
+          modules = [ "Paths_atelier_core" ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Driver.hs" ];
         };
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-core; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-core; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/aarch64-darwin/ghc98/.plan.nix/atelier-db.nix
+++ b/nix/materialized/aarch64-darwin/ghc98/.plan.nix/atelier-db.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -52,13 +52,10 @@
           (hsPkgs."time" or (errorHandler.buildDepError "time"))
         ];
         buildable = true;
-        modules = [
-          "Paths_atelier_db"
-          "Atelier/Effects/DB"
-          "Atelier/Effects/DB/Config"
-          "Atelier/Effects/DB/Rel8"
-        ];
+        modules = [ "Paths_atelier_db" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-db; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-db; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/aarch64-darwin/ghc98/.plan.nix/atelier-prelude.nix
+++ b/nix/materialized/aarch64-darwin/ghc98/.plan.nix/atelier-prelude.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "1.18";
@@ -38,8 +38,10 @@
           (hsPkgs."relude" or (errorHandler.buildDepError "relude"))
         ];
         buildable = true;
-        modules = [ "Paths_atelier_prelude" "Prelude" ];
+        modules = [ "Paths_atelier_prelude" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-prelude; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-prelude; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/aarch64-darwin/ghc98/.plan.nix/atelier-testing.nix
+++ b/nix/materialized/aarch64-darwin/ghc98/.plan.nix/atelier-testing.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -50,8 +50,10 @@
           (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
         ];
         buildable = true;
-        modules = [ "Paths_atelier_testing" "Atelier/Testing/Database" ];
+        modules = [ "Paths_atelier_testing" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-testing; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-testing; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/aarch64-darwin/ghc98/.plan.nix/tricorder.nix
+++ b/nix/materialized/aarch64-darwin/ghc98/.plan.nix/tricorder.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -68,49 +68,7 @@
             (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))
           ];
           buildable = true;
-          modules = [
-            "Paths_tricorder"
-            "Tricorder"
-            "Tricorder/Arguments"
-            "Tricorder/Builder"
-            "Tricorder/Builder/Dispatch"
-            "Tricorder/BuildState"
-            "Tricorder/CLI"
-            "Tricorder/CLI/Main"
-            "Tricorder/CLI/Render"
-            "Tricorder/Config"
-            "Tricorder/Daemon"
-            "Tricorder/Daemon/Main"
-            "Tricorder/Effects/Brick"
-            "Tricorder/Effects/BrickChan"
-            "Tricorder/Effects/BuildStore"
-            "Tricorder/Effects/GhciSession"
-            "Tricorder/Effects/GhciSession/GhciParser"
-            "Tricorder/Effects/GhciSession/GhciProcess"
-            "Tricorder/Effects/GhcPkg"
-            "Tricorder/Effects/Logging"
-            "Tricorder/Effects/SessionStore"
-            "Tricorder/Effects/TestRunner"
-            "Tricorder/Effects/UnixSocket"
-            "Tricorder/Events/FileChanged"
-            "Tricorder/GhcPkg/Types"
-            "Tricorder/Observability"
-            "Tricorder/Runtime"
-            "Tricorder/Session"
-            "Tricorder/Socket/Client"
-            "Tricorder/Socket/Protocol"
-            "Tricorder/Socket/Server"
-            "Tricorder/SourceLookup"
-            "Tricorder/TestOutput"
-            "Tricorder/UI"
-            "Tricorder/UI/Event"
-            "Tricorder/UI/Keys"
-            "Tricorder/UI/Misc"
-            "Tricorder/UI/State"
-            "Tricorder/UI/View"
-            "Tricorder/Version"
-            "Tricorder/Watcher"
-          ];
+          modules = [ "Paths_tricorder" ];
           hsSourceDirs = [ "src" ];
         };
       };
@@ -172,28 +130,12 @@
             (hsPkgs.pkgsBuildBuild.tasty-discover.components.exes.tasty-discover or (pkgs.pkgsBuildBuild.tasty-discover or (errorHandler.buildToolDepError "tasty-discover:tasty-discover")))
           ];
           buildable = true;
-          modules = [
-            "Unit/Tricorder/BuilderSpec"
-            "Unit/Tricorder/BuildStateSpec"
-            "Unit/Tricorder/BuildStoreSpec"
-            "Unit/Tricorder/CLI/RenderSpec"
-            "Unit/Tricorder/Effects/GhciSession/GhciParserSpec"
-            "Unit/Tricorder/Effects/GhciSession/GhciProcessSpec"
-            "Unit/Tricorder/Effects/GhciSessionSpec"
-            "Unit/Tricorder/Effects/SessionStoreSpec"
-            "Unit/Tricorder/GhcPkgSpec"
-            "Unit/Tricorder/SessionSpec"
-            "Unit/Tricorder/SocketSpec"
-            "Unit/Tricorder/SourceLookupSpec"
-            "Unit/Tricorder/SourceSpec"
-            "Unit/Tricorder/TestOutputSpec"
-            "Unit/Tricorder/TestRunnerSpec"
-            "Unit/Tricorder/WatcherSpec"
-            "Paths_tricorder"
-          ];
+          modules = [ "Paths_tricorder" ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Driver.hs" ];
         };
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../tricorder; }
+  } // rec { src = pkgs.lib.mkDefault ../tricorder; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/x86_64-linux/ghc9102/.plan.nix/atelier-core.nix
+++ b/nix/materialized/x86_64-linux/ghc9102/.plan.nix/atelier-core.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -75,54 +75,7 @@
           (hsPkgs."warp" or (errorHandler.buildDepError "warp"))
         ];
         buildable = true;
-        modules = [
-          "Paths_atelier_core"
-          "Atelier/Component"
-          "Atelier/Config"
-          "Atelier/Effects/Arguments"
-          "Atelier/Effects/Await"
-          "Atelier/Effects/Cache"
-          "Atelier/Effects/Cache/Config"
-          "Atelier/Effects/Cache/Singleflight"
-          "Atelier/Effects/Chan"
-          "Atelier/Effects/Clock"
-          "Atelier/Effects/Conc"
-          "Atelier/Effects/Conc/Traced"
-          "Atelier/Effects/Console"
-          "Atelier/Effects/Debounce"
-          "Atelier/Effects/Delay"
-          "Atelier/Effects/Env"
-          "Atelier/Effects/Exit"
-          "Atelier/Effects/File"
-          "Atelier/Effects/FileSystem"
-          "Atelier/Effects/FileWatcher"
-          "Atelier/Effects/Input"
-          "Atelier/Effects/Internal/Coroutine"
-          "Atelier/Effects/Iterator"
-          "Atelier/Effects/Log"
-          "Atelier/Effects/Monitoring/Metrics"
-          "Atelier/Effects/Monitoring/Metrics/Registry"
-          "Atelier/Effects/Monitoring/Metrics/Server"
-          "Atelier/Effects/Monitoring/Tracing"
-          "Atelier/Effects/Monitoring/Tracing/Provider"
-          "Atelier/Effects/Posix/Daemons"
-          "Atelier/Effects/Posix/IO"
-          "Atelier/Effects/Process"
-          "Atelier/Effects/Publishing"
-          "Atelier/Effects/Tally"
-          "Atelier/Effects/Timeout"
-          "Atelier/Effects/UUID"
-          "Atelier/Effects/Yield"
-          "Atelier/Exception"
-          "Atelier/Time"
-          "Atelier/Types/Base64"
-          "Atelier/Types/HttpApiDataReadShow"
-          "Atelier/Types/JsonReadShow"
-          "Atelier/Types/QuietSnake"
-          "Atelier/Types/Semaphore"
-          "Atelier/Types/Semaphore/STM"
-          "Atelier/Types/WithDefaults"
-        ];
+        modules = [ "Paths_atelier_core" ];
         hsSourceDirs = [ "src" ];
       };
       tests = {
@@ -153,32 +106,12 @@
             (hsPkgs.pkgsBuildBuild.tasty-discover.components.exes.tasty-discover or (pkgs.pkgsBuildBuild.tasty-discover or (errorHandler.buildToolDepError "tasty-discover:tasty-discover")))
           ];
           buildable = true;
-          modules = [
-            "Unit/Atelier/ConfigSpec"
-            "Unit/Atelier/Effects/AwaitSpec"
-            "Unit/Atelier/Effects/Cache/SingleflightSpec"
-            "Unit/Atelier/Effects/CacheSpec"
-            "Unit/Atelier/Effects/ChanSpec"
-            "Unit/Atelier/Effects/Conc/TeardownStressSpec"
-            "Unit/Atelier/Effects/Conc/TracedSpec"
-            "Unit/Atelier/Effects/ConcSpec"
-            "Unit/Atelier/Effects/ConsoleSpec"
-            "Unit/Atelier/Effects/DebounceSpec"
-            "Unit/Atelier/Effects/FileSystemSpec"
-            "Unit/Atelier/Effects/FileWatcherSpec"
-            "Unit/Atelier/Effects/IteratorSpec"
-            "Unit/Atelier/Effects/LogSpec"
-            "Unit/Atelier/Effects/PublishingSpec"
-            "Unit/Atelier/Effects/TallySpec"
-            "Unit/Atelier/Effects/YieldSpec"
-            "Unit/Atelier/Types/Semaphore/STMSpec"
-            "Unit/Atelier/Types/SemaphoreSpec"
-            "Unit/Atelier/Types/WithDefaultsSpec"
-            "Paths_atelier_core"
-          ];
+          modules = [ "Paths_atelier_core" ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Driver.hs" ];
         };
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-core; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-core; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/x86_64-linux/ghc9102/.plan.nix/atelier-db.nix
+++ b/nix/materialized/x86_64-linux/ghc9102/.plan.nix/atelier-db.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -52,13 +52,10 @@
           (hsPkgs."time" or (errorHandler.buildDepError "time"))
         ];
         buildable = true;
-        modules = [
-          "Paths_atelier_db"
-          "Atelier/Effects/DB"
-          "Atelier/Effects/DB/Config"
-          "Atelier/Effects/DB/Rel8"
-        ];
+        modules = [ "Paths_atelier_db" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-db; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-db; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/x86_64-linux/ghc9102/.plan.nix/atelier-prelude.nix
+++ b/nix/materialized/x86_64-linux/ghc9102/.plan.nix/atelier-prelude.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "1.18";
@@ -38,8 +38,10 @@
           (hsPkgs."relude" or (errorHandler.buildDepError "relude"))
         ];
         buildable = true;
-        modules = [ "Paths_atelier_prelude" "Prelude" ];
+        modules = [ "Paths_atelier_prelude" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-prelude; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-prelude; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/x86_64-linux/ghc9102/.plan.nix/atelier-testing.nix
+++ b/nix/materialized/x86_64-linux/ghc9102/.plan.nix/atelier-testing.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -50,8 +50,10 @@
           (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
         ];
         buildable = true;
-        modules = [ "Paths_atelier_testing" "Atelier/Testing/Database" ];
+        modules = [ "Paths_atelier_testing" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-testing; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-testing; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/x86_64-linux/ghc9102/.plan.nix/tricorder.nix
+++ b/nix/materialized/x86_64-linux/ghc9102/.plan.nix/tricorder.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -68,49 +68,7 @@
             (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))
           ];
           buildable = true;
-          modules = [
-            "Paths_tricorder"
-            "Tricorder"
-            "Tricorder/Arguments"
-            "Tricorder/Builder"
-            "Tricorder/Builder/Dispatch"
-            "Tricorder/BuildState"
-            "Tricorder/CLI"
-            "Tricorder/CLI/Main"
-            "Tricorder/CLI/Render"
-            "Tricorder/Config"
-            "Tricorder/Daemon"
-            "Tricorder/Daemon/Main"
-            "Tricorder/Effects/Brick"
-            "Tricorder/Effects/BrickChan"
-            "Tricorder/Effects/BuildStore"
-            "Tricorder/Effects/GhciSession"
-            "Tricorder/Effects/GhciSession/GhciParser"
-            "Tricorder/Effects/GhciSession/GhciProcess"
-            "Tricorder/Effects/GhcPkg"
-            "Tricorder/Effects/Logging"
-            "Tricorder/Effects/SessionStore"
-            "Tricorder/Effects/TestRunner"
-            "Tricorder/Effects/UnixSocket"
-            "Tricorder/Events/FileChanged"
-            "Tricorder/GhcPkg/Types"
-            "Tricorder/Observability"
-            "Tricorder/Runtime"
-            "Tricorder/Session"
-            "Tricorder/Socket/Client"
-            "Tricorder/Socket/Protocol"
-            "Tricorder/Socket/Server"
-            "Tricorder/SourceLookup"
-            "Tricorder/TestOutput"
-            "Tricorder/UI"
-            "Tricorder/UI/Event"
-            "Tricorder/UI/Keys"
-            "Tricorder/UI/Misc"
-            "Tricorder/UI/State"
-            "Tricorder/UI/View"
-            "Tricorder/Version"
-            "Tricorder/Watcher"
-          ];
+          modules = [ "Paths_tricorder" ];
           hsSourceDirs = [ "src" ];
         };
       };
@@ -172,28 +130,12 @@
             (hsPkgs.pkgsBuildBuild.tasty-discover.components.exes.tasty-discover or (pkgs.pkgsBuildBuild.tasty-discover or (errorHandler.buildToolDepError "tasty-discover:tasty-discover")))
           ];
           buildable = true;
-          modules = [
-            "Unit/Tricorder/BuilderSpec"
-            "Unit/Tricorder/BuildStateSpec"
-            "Unit/Tricorder/BuildStoreSpec"
-            "Unit/Tricorder/CLI/RenderSpec"
-            "Unit/Tricorder/Effects/GhciSession/GhciParserSpec"
-            "Unit/Tricorder/Effects/GhciSession/GhciProcessSpec"
-            "Unit/Tricorder/Effects/GhciSessionSpec"
-            "Unit/Tricorder/Effects/SessionStoreSpec"
-            "Unit/Tricorder/GhcPkgSpec"
-            "Unit/Tricorder/SessionSpec"
-            "Unit/Tricorder/SocketSpec"
-            "Unit/Tricorder/SourceLookupSpec"
-            "Unit/Tricorder/SourceSpec"
-            "Unit/Tricorder/TestOutputSpec"
-            "Unit/Tricorder/TestRunnerSpec"
-            "Unit/Tricorder/WatcherSpec"
-            "Paths_tricorder"
-          ];
+          modules = [ "Paths_tricorder" ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Driver.hs" ];
         };
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../tricorder; }
+  } // rec { src = pkgs.lib.mkDefault ../tricorder; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/x86_64-linux/ghc912/.plan.nix/atelier-core.nix
+++ b/nix/materialized/x86_64-linux/ghc912/.plan.nix/atelier-core.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -75,54 +75,7 @@
           (hsPkgs."warp" or (errorHandler.buildDepError "warp"))
         ];
         buildable = true;
-        modules = [
-          "Paths_atelier_core"
-          "Atelier/Component"
-          "Atelier/Config"
-          "Atelier/Effects/Arguments"
-          "Atelier/Effects/Await"
-          "Atelier/Effects/Cache"
-          "Atelier/Effects/Cache/Config"
-          "Atelier/Effects/Cache/Singleflight"
-          "Atelier/Effects/Chan"
-          "Atelier/Effects/Clock"
-          "Atelier/Effects/Conc"
-          "Atelier/Effects/Conc/Traced"
-          "Atelier/Effects/Console"
-          "Atelier/Effects/Debounce"
-          "Atelier/Effects/Delay"
-          "Atelier/Effects/Env"
-          "Atelier/Effects/Exit"
-          "Atelier/Effects/File"
-          "Atelier/Effects/FileSystem"
-          "Atelier/Effects/FileWatcher"
-          "Atelier/Effects/Input"
-          "Atelier/Effects/Internal/Coroutine"
-          "Atelier/Effects/Iterator"
-          "Atelier/Effects/Log"
-          "Atelier/Effects/Monitoring/Metrics"
-          "Atelier/Effects/Monitoring/Metrics/Registry"
-          "Atelier/Effects/Monitoring/Metrics/Server"
-          "Atelier/Effects/Monitoring/Tracing"
-          "Atelier/Effects/Monitoring/Tracing/Provider"
-          "Atelier/Effects/Posix/Daemons"
-          "Atelier/Effects/Posix/IO"
-          "Atelier/Effects/Process"
-          "Atelier/Effects/Publishing"
-          "Atelier/Effects/Tally"
-          "Atelier/Effects/Timeout"
-          "Atelier/Effects/UUID"
-          "Atelier/Effects/Yield"
-          "Atelier/Exception"
-          "Atelier/Time"
-          "Atelier/Types/Base64"
-          "Atelier/Types/HttpApiDataReadShow"
-          "Atelier/Types/JsonReadShow"
-          "Atelier/Types/QuietSnake"
-          "Atelier/Types/Semaphore"
-          "Atelier/Types/Semaphore/STM"
-          "Atelier/Types/WithDefaults"
-        ];
+        modules = [ "Paths_atelier_core" ];
         hsSourceDirs = [ "src" ];
       };
       tests = {
@@ -153,32 +106,12 @@
             (hsPkgs.pkgsBuildBuild.tasty-discover.components.exes.tasty-discover or (pkgs.pkgsBuildBuild.tasty-discover or (errorHandler.buildToolDepError "tasty-discover:tasty-discover")))
           ];
           buildable = true;
-          modules = [
-            "Unit/Atelier/ConfigSpec"
-            "Unit/Atelier/Effects/AwaitSpec"
-            "Unit/Atelier/Effects/Cache/SingleflightSpec"
-            "Unit/Atelier/Effects/CacheSpec"
-            "Unit/Atelier/Effects/ChanSpec"
-            "Unit/Atelier/Effects/Conc/TeardownStressSpec"
-            "Unit/Atelier/Effects/Conc/TracedSpec"
-            "Unit/Atelier/Effects/ConcSpec"
-            "Unit/Atelier/Effects/ConsoleSpec"
-            "Unit/Atelier/Effects/DebounceSpec"
-            "Unit/Atelier/Effects/FileSystemSpec"
-            "Unit/Atelier/Effects/FileWatcherSpec"
-            "Unit/Atelier/Effects/IteratorSpec"
-            "Unit/Atelier/Effects/LogSpec"
-            "Unit/Atelier/Effects/PublishingSpec"
-            "Unit/Atelier/Effects/TallySpec"
-            "Unit/Atelier/Effects/YieldSpec"
-            "Unit/Atelier/Types/Semaphore/STMSpec"
-            "Unit/Atelier/Types/SemaphoreSpec"
-            "Unit/Atelier/Types/WithDefaultsSpec"
-            "Paths_atelier_core"
-          ];
+          modules = [ "Paths_atelier_core" ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Driver.hs" ];
         };
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-core; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-core; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/x86_64-linux/ghc912/.plan.nix/atelier-db.nix
+++ b/nix/materialized/x86_64-linux/ghc912/.plan.nix/atelier-db.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -52,13 +52,10 @@
           (hsPkgs."time" or (errorHandler.buildDepError "time"))
         ];
         buildable = true;
-        modules = [
-          "Paths_atelier_db"
-          "Atelier/Effects/DB"
-          "Atelier/Effects/DB/Config"
-          "Atelier/Effects/DB/Rel8"
-        ];
+        modules = [ "Paths_atelier_db" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-db; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-db; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/x86_64-linux/ghc912/.plan.nix/atelier-prelude.nix
+++ b/nix/materialized/x86_64-linux/ghc912/.plan.nix/atelier-prelude.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "1.18";
@@ -38,8 +38,10 @@
           (hsPkgs."relude" or (errorHandler.buildDepError "relude"))
         ];
         buildable = true;
-        modules = [ "Paths_atelier_prelude" "Prelude" ];
+        modules = [ "Paths_atelier_prelude" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-prelude; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-prelude; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/x86_64-linux/ghc912/.plan.nix/atelier-testing.nix
+++ b/nix/materialized/x86_64-linux/ghc912/.plan.nix/atelier-testing.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -50,8 +50,10 @@
           (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
         ];
         buildable = true;
-        modules = [ "Paths_atelier_testing" "Atelier/Testing/Database" ];
+        modules = [ "Paths_atelier_testing" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-testing; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-testing; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/x86_64-linux/ghc912/.plan.nix/tricorder.nix
+++ b/nix/materialized/x86_64-linux/ghc912/.plan.nix/tricorder.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -68,49 +68,7 @@
             (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))
           ];
           buildable = true;
-          modules = [
-            "Paths_tricorder"
-            "Tricorder"
-            "Tricorder/Arguments"
-            "Tricorder/Builder"
-            "Tricorder/Builder/Dispatch"
-            "Tricorder/BuildState"
-            "Tricorder/CLI"
-            "Tricorder/CLI/Main"
-            "Tricorder/CLI/Render"
-            "Tricorder/Config"
-            "Tricorder/Daemon"
-            "Tricorder/Daemon/Main"
-            "Tricorder/Effects/Brick"
-            "Tricorder/Effects/BrickChan"
-            "Tricorder/Effects/BuildStore"
-            "Tricorder/Effects/GhciSession"
-            "Tricorder/Effects/GhciSession/GhciParser"
-            "Tricorder/Effects/GhciSession/GhciProcess"
-            "Tricorder/Effects/GhcPkg"
-            "Tricorder/Effects/Logging"
-            "Tricorder/Effects/SessionStore"
-            "Tricorder/Effects/TestRunner"
-            "Tricorder/Effects/UnixSocket"
-            "Tricorder/Events/FileChanged"
-            "Tricorder/GhcPkg/Types"
-            "Tricorder/Observability"
-            "Tricorder/Runtime"
-            "Tricorder/Session"
-            "Tricorder/Socket/Client"
-            "Tricorder/Socket/Protocol"
-            "Tricorder/Socket/Server"
-            "Tricorder/SourceLookup"
-            "Tricorder/TestOutput"
-            "Tricorder/UI"
-            "Tricorder/UI/Event"
-            "Tricorder/UI/Keys"
-            "Tricorder/UI/Misc"
-            "Tricorder/UI/State"
-            "Tricorder/UI/View"
-            "Tricorder/Version"
-            "Tricorder/Watcher"
-          ];
+          modules = [ "Paths_tricorder" ];
           hsSourceDirs = [ "src" ];
         };
       };
@@ -172,28 +130,12 @@
             (hsPkgs.pkgsBuildBuild.tasty-discover.components.exes.tasty-discover or (pkgs.pkgsBuildBuild.tasty-discover or (errorHandler.buildToolDepError "tasty-discover:tasty-discover")))
           ];
           buildable = true;
-          modules = [
-            "Unit/Tricorder/BuilderSpec"
-            "Unit/Tricorder/BuildStateSpec"
-            "Unit/Tricorder/BuildStoreSpec"
-            "Unit/Tricorder/CLI/RenderSpec"
-            "Unit/Tricorder/Effects/GhciSession/GhciParserSpec"
-            "Unit/Tricorder/Effects/GhciSession/GhciProcessSpec"
-            "Unit/Tricorder/Effects/GhciSessionSpec"
-            "Unit/Tricorder/Effects/SessionStoreSpec"
-            "Unit/Tricorder/GhcPkgSpec"
-            "Unit/Tricorder/SessionSpec"
-            "Unit/Tricorder/SocketSpec"
-            "Unit/Tricorder/SourceLookupSpec"
-            "Unit/Tricorder/SourceSpec"
-            "Unit/Tricorder/TestOutputSpec"
-            "Unit/Tricorder/TestRunnerSpec"
-            "Unit/Tricorder/WatcherSpec"
-            "Paths_tricorder"
-          ];
+          modules = [ "Paths_tricorder" ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Driver.hs" ];
         };
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../tricorder; }
+  } // rec { src = pkgs.lib.mkDefault ../tricorder; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/x86_64-linux/ghc914/.plan.nix/atelier-core.nix
+++ b/nix/materialized/x86_64-linux/ghc914/.plan.nix/atelier-core.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -75,54 +75,7 @@
           (hsPkgs."warp" or (errorHandler.buildDepError "warp"))
         ];
         buildable = true;
-        modules = [
-          "Paths_atelier_core"
-          "Atelier/Component"
-          "Atelier/Config"
-          "Atelier/Effects/Arguments"
-          "Atelier/Effects/Await"
-          "Atelier/Effects/Cache"
-          "Atelier/Effects/Cache/Config"
-          "Atelier/Effects/Cache/Singleflight"
-          "Atelier/Effects/Chan"
-          "Atelier/Effects/Clock"
-          "Atelier/Effects/Conc"
-          "Atelier/Effects/Conc/Traced"
-          "Atelier/Effects/Console"
-          "Atelier/Effects/Debounce"
-          "Atelier/Effects/Delay"
-          "Atelier/Effects/Env"
-          "Atelier/Effects/Exit"
-          "Atelier/Effects/File"
-          "Atelier/Effects/FileSystem"
-          "Atelier/Effects/FileWatcher"
-          "Atelier/Effects/Input"
-          "Atelier/Effects/Internal/Coroutine"
-          "Atelier/Effects/Iterator"
-          "Atelier/Effects/Log"
-          "Atelier/Effects/Monitoring/Metrics"
-          "Atelier/Effects/Monitoring/Metrics/Registry"
-          "Atelier/Effects/Monitoring/Metrics/Server"
-          "Atelier/Effects/Monitoring/Tracing"
-          "Atelier/Effects/Monitoring/Tracing/Provider"
-          "Atelier/Effects/Posix/Daemons"
-          "Atelier/Effects/Posix/IO"
-          "Atelier/Effects/Process"
-          "Atelier/Effects/Publishing"
-          "Atelier/Effects/Tally"
-          "Atelier/Effects/Timeout"
-          "Atelier/Effects/UUID"
-          "Atelier/Effects/Yield"
-          "Atelier/Exception"
-          "Atelier/Time"
-          "Atelier/Types/Base64"
-          "Atelier/Types/HttpApiDataReadShow"
-          "Atelier/Types/JsonReadShow"
-          "Atelier/Types/QuietSnake"
-          "Atelier/Types/Semaphore"
-          "Atelier/Types/Semaphore/STM"
-          "Atelier/Types/WithDefaults"
-        ];
+        modules = [ "Paths_atelier_core" ];
         hsSourceDirs = [ "src" ];
       };
       tests = {
@@ -153,32 +106,12 @@
             (hsPkgs.pkgsBuildBuild.tasty-discover.components.exes.tasty-discover or (pkgs.pkgsBuildBuild.tasty-discover or (errorHandler.buildToolDepError "tasty-discover:tasty-discover")))
           ];
           buildable = true;
-          modules = [
-            "Unit/Atelier/ConfigSpec"
-            "Unit/Atelier/Effects/AwaitSpec"
-            "Unit/Atelier/Effects/Cache/SingleflightSpec"
-            "Unit/Atelier/Effects/CacheSpec"
-            "Unit/Atelier/Effects/ChanSpec"
-            "Unit/Atelier/Effects/Conc/TeardownStressSpec"
-            "Unit/Atelier/Effects/Conc/TracedSpec"
-            "Unit/Atelier/Effects/ConcSpec"
-            "Unit/Atelier/Effects/ConsoleSpec"
-            "Unit/Atelier/Effects/DebounceSpec"
-            "Unit/Atelier/Effects/FileSystemSpec"
-            "Unit/Atelier/Effects/FileWatcherSpec"
-            "Unit/Atelier/Effects/IteratorSpec"
-            "Unit/Atelier/Effects/LogSpec"
-            "Unit/Atelier/Effects/PublishingSpec"
-            "Unit/Atelier/Effects/TallySpec"
-            "Unit/Atelier/Effects/YieldSpec"
-            "Unit/Atelier/Types/Semaphore/STMSpec"
-            "Unit/Atelier/Types/SemaphoreSpec"
-            "Unit/Atelier/Types/WithDefaultsSpec"
-            "Paths_atelier_core"
-          ];
+          modules = [ "Paths_atelier_core" ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Driver.hs" ];
         };
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-core; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-core; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/x86_64-linux/ghc914/.plan.nix/atelier-db.nix
+++ b/nix/materialized/x86_64-linux/ghc914/.plan.nix/atelier-db.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -52,13 +52,10 @@
           (hsPkgs."time" or (errorHandler.buildDepError "time"))
         ];
         buildable = true;
-        modules = [
-          "Paths_atelier_db"
-          "Atelier/Effects/DB"
-          "Atelier/Effects/DB/Config"
-          "Atelier/Effects/DB/Rel8"
-        ];
+        modules = [ "Paths_atelier_db" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-db; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-db; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/x86_64-linux/ghc914/.plan.nix/atelier-prelude.nix
+++ b/nix/materialized/x86_64-linux/ghc914/.plan.nix/atelier-prelude.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "1.18";
@@ -38,8 +38,10 @@
           (hsPkgs."relude" or (errorHandler.buildDepError "relude"))
         ];
         buildable = true;
-        modules = [ "Paths_atelier_prelude" "Prelude" ];
+        modules = [ "Paths_atelier_prelude" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-prelude; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-prelude; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/x86_64-linux/ghc914/.plan.nix/atelier-testing.nix
+++ b/nix/materialized/x86_64-linux/ghc914/.plan.nix/atelier-testing.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -50,8 +50,10 @@
           (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
         ];
         buildable = true;
-        modules = [ "Paths_atelier_testing" "Atelier/Testing/Database" ];
+        modules = [ "Paths_atelier_testing" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-testing; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-testing; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/x86_64-linux/ghc914/.plan.nix/tricorder.nix
+++ b/nix/materialized/x86_64-linux/ghc914/.plan.nix/tricorder.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -68,49 +68,7 @@
             (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))
           ];
           buildable = true;
-          modules = [
-            "Paths_tricorder"
-            "Tricorder"
-            "Tricorder/Arguments"
-            "Tricorder/Builder"
-            "Tricorder/Builder/Dispatch"
-            "Tricorder/BuildState"
-            "Tricorder/CLI"
-            "Tricorder/CLI/Main"
-            "Tricorder/CLI/Render"
-            "Tricorder/Config"
-            "Tricorder/Daemon"
-            "Tricorder/Daemon/Main"
-            "Tricorder/Effects/Brick"
-            "Tricorder/Effects/BrickChan"
-            "Tricorder/Effects/BuildStore"
-            "Tricorder/Effects/GhciSession"
-            "Tricorder/Effects/GhciSession/GhciParser"
-            "Tricorder/Effects/GhciSession/GhciProcess"
-            "Tricorder/Effects/GhcPkg"
-            "Tricorder/Effects/Logging"
-            "Tricorder/Effects/SessionStore"
-            "Tricorder/Effects/TestRunner"
-            "Tricorder/Effects/UnixSocket"
-            "Tricorder/Events/FileChanged"
-            "Tricorder/GhcPkg/Types"
-            "Tricorder/Observability"
-            "Tricorder/Runtime"
-            "Tricorder/Session"
-            "Tricorder/Socket/Client"
-            "Tricorder/Socket/Protocol"
-            "Tricorder/Socket/Server"
-            "Tricorder/SourceLookup"
-            "Tricorder/TestOutput"
-            "Tricorder/UI"
-            "Tricorder/UI/Event"
-            "Tricorder/UI/Keys"
-            "Tricorder/UI/Misc"
-            "Tricorder/UI/State"
-            "Tricorder/UI/View"
-            "Tricorder/Version"
-            "Tricorder/Watcher"
-          ];
+          modules = [ "Paths_tricorder" ];
           hsSourceDirs = [ "src" ];
         };
       };
@@ -172,28 +130,12 @@
             (hsPkgs.pkgsBuildBuild.tasty-discover.components.exes.tasty-discover or (pkgs.pkgsBuildBuild.tasty-discover or (errorHandler.buildToolDepError "tasty-discover:tasty-discover")))
           ];
           buildable = true;
-          modules = [
-            "Unit/Tricorder/BuilderSpec"
-            "Unit/Tricorder/BuildStateSpec"
-            "Unit/Tricorder/BuildStoreSpec"
-            "Unit/Tricorder/CLI/RenderSpec"
-            "Unit/Tricorder/Effects/GhciSession/GhciParserSpec"
-            "Unit/Tricorder/Effects/GhciSession/GhciProcessSpec"
-            "Unit/Tricorder/Effects/GhciSessionSpec"
-            "Unit/Tricorder/Effects/SessionStoreSpec"
-            "Unit/Tricorder/GhcPkgSpec"
-            "Unit/Tricorder/SessionSpec"
-            "Unit/Tricorder/SocketSpec"
-            "Unit/Tricorder/SourceLookupSpec"
-            "Unit/Tricorder/SourceSpec"
-            "Unit/Tricorder/TestOutputSpec"
-            "Unit/Tricorder/TestRunnerSpec"
-            "Unit/Tricorder/WatcherSpec"
-            "Paths_tricorder"
-          ];
+          modules = [ "Paths_tricorder" ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Driver.hs" ];
         };
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../tricorder; }
+  } // rec { src = pkgs.lib.mkDefault ../tricorder; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/x86_64-linux/ghc98/.plan.nix/atelier-core.nix
+++ b/nix/materialized/x86_64-linux/ghc98/.plan.nix/atelier-core.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -75,54 +75,7 @@
           (hsPkgs."warp" or (errorHandler.buildDepError "warp"))
         ];
         buildable = true;
-        modules = [
-          "Paths_atelier_core"
-          "Atelier/Component"
-          "Atelier/Config"
-          "Atelier/Effects/Arguments"
-          "Atelier/Effects/Await"
-          "Atelier/Effects/Cache"
-          "Atelier/Effects/Cache/Config"
-          "Atelier/Effects/Cache/Singleflight"
-          "Atelier/Effects/Chan"
-          "Atelier/Effects/Clock"
-          "Atelier/Effects/Conc"
-          "Atelier/Effects/Conc/Traced"
-          "Atelier/Effects/Console"
-          "Atelier/Effects/Debounce"
-          "Atelier/Effects/Delay"
-          "Atelier/Effects/Env"
-          "Atelier/Effects/Exit"
-          "Atelier/Effects/File"
-          "Atelier/Effects/FileSystem"
-          "Atelier/Effects/FileWatcher"
-          "Atelier/Effects/Input"
-          "Atelier/Effects/Internal/Coroutine"
-          "Atelier/Effects/Iterator"
-          "Atelier/Effects/Log"
-          "Atelier/Effects/Monitoring/Metrics"
-          "Atelier/Effects/Monitoring/Metrics/Registry"
-          "Atelier/Effects/Monitoring/Metrics/Server"
-          "Atelier/Effects/Monitoring/Tracing"
-          "Atelier/Effects/Monitoring/Tracing/Provider"
-          "Atelier/Effects/Posix/Daemons"
-          "Atelier/Effects/Posix/IO"
-          "Atelier/Effects/Process"
-          "Atelier/Effects/Publishing"
-          "Atelier/Effects/Tally"
-          "Atelier/Effects/Timeout"
-          "Atelier/Effects/UUID"
-          "Atelier/Effects/Yield"
-          "Atelier/Exception"
-          "Atelier/Time"
-          "Atelier/Types/Base64"
-          "Atelier/Types/HttpApiDataReadShow"
-          "Atelier/Types/JsonReadShow"
-          "Atelier/Types/QuietSnake"
-          "Atelier/Types/Semaphore"
-          "Atelier/Types/Semaphore/STM"
-          "Atelier/Types/WithDefaults"
-        ];
+        modules = [ "Paths_atelier_core" ];
         hsSourceDirs = [ "src" ];
       };
       tests = {
@@ -153,32 +106,12 @@
             (hsPkgs.pkgsBuildBuild.tasty-discover.components.exes.tasty-discover or (pkgs.pkgsBuildBuild.tasty-discover or (errorHandler.buildToolDepError "tasty-discover:tasty-discover")))
           ];
           buildable = true;
-          modules = [
-            "Unit/Atelier/ConfigSpec"
-            "Unit/Atelier/Effects/AwaitSpec"
-            "Unit/Atelier/Effects/Cache/SingleflightSpec"
-            "Unit/Atelier/Effects/CacheSpec"
-            "Unit/Atelier/Effects/ChanSpec"
-            "Unit/Atelier/Effects/Conc/TeardownStressSpec"
-            "Unit/Atelier/Effects/Conc/TracedSpec"
-            "Unit/Atelier/Effects/ConcSpec"
-            "Unit/Atelier/Effects/ConsoleSpec"
-            "Unit/Atelier/Effects/DebounceSpec"
-            "Unit/Atelier/Effects/FileSystemSpec"
-            "Unit/Atelier/Effects/FileWatcherSpec"
-            "Unit/Atelier/Effects/IteratorSpec"
-            "Unit/Atelier/Effects/LogSpec"
-            "Unit/Atelier/Effects/PublishingSpec"
-            "Unit/Atelier/Effects/TallySpec"
-            "Unit/Atelier/Effects/YieldSpec"
-            "Unit/Atelier/Types/Semaphore/STMSpec"
-            "Unit/Atelier/Types/SemaphoreSpec"
-            "Unit/Atelier/Types/WithDefaultsSpec"
-            "Paths_atelier_core"
-          ];
+          modules = [ "Paths_atelier_core" ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Driver.hs" ];
         };
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-core; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-core; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/x86_64-linux/ghc98/.plan.nix/atelier-db.nix
+++ b/nix/materialized/x86_64-linux/ghc98/.plan.nix/atelier-db.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -52,13 +52,10 @@
           (hsPkgs."time" or (errorHandler.buildDepError "time"))
         ];
         buildable = true;
-        modules = [
-          "Paths_atelier_db"
-          "Atelier/Effects/DB"
-          "Atelier/Effects/DB/Config"
-          "Atelier/Effects/DB/Rel8"
-        ];
+        modules = [ "Paths_atelier_db" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-db; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-db; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/x86_64-linux/ghc98/.plan.nix/atelier-prelude.nix
+++ b/nix/materialized/x86_64-linux/ghc98/.plan.nix/atelier-prelude.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "1.18";
@@ -38,8 +38,10 @@
           (hsPkgs."relude" or (errorHandler.buildDepError "relude"))
         ];
         buildable = true;
-        modules = [ "Paths_atelier_prelude" "Prelude" ];
+        modules = [ "Paths_atelier_prelude" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-prelude; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-prelude; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/x86_64-linux/ghc98/.plan.nix/atelier-testing.nix
+++ b/nix/materialized/x86_64-linux/ghc98/.plan.nix/atelier-testing.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -50,8 +50,10 @@
           (hsPkgs."uuid" or (errorHandler.buildDepError "uuid"))
         ];
         buildable = true;
-        modules = [ "Paths_atelier_testing" "Atelier/Testing/Database" ];
+        modules = [ "Paths_atelier_testing" ];
         hsSourceDirs = [ "src" ];
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../atelier-testing; }
+  } // rec { src = pkgs.lib.mkDefault ../atelier-testing; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/materialized/x86_64-linux/ghc98/.plan.nix/tricorder.nix
+++ b/nix/materialized/x86_64-linux/ghc98/.plan.nix/tricorder.nix
@@ -7,7 +7,7 @@
   , errorHandler
   , config
   , ... }:
-  {
+  ({
     flags = {};
     package = {
       specVersion = "2.0";
@@ -68,49 +68,7 @@
             (hsPkgs."yaml" or (errorHandler.buildDepError "yaml"))
           ];
           buildable = true;
-          modules = [
-            "Paths_tricorder"
-            "Tricorder"
-            "Tricorder/Arguments"
-            "Tricorder/Builder"
-            "Tricorder/Builder/Dispatch"
-            "Tricorder/BuildState"
-            "Tricorder/CLI"
-            "Tricorder/CLI/Main"
-            "Tricorder/CLI/Render"
-            "Tricorder/Config"
-            "Tricorder/Daemon"
-            "Tricorder/Daemon/Main"
-            "Tricorder/Effects/Brick"
-            "Tricorder/Effects/BrickChan"
-            "Tricorder/Effects/BuildStore"
-            "Tricorder/Effects/GhciSession"
-            "Tricorder/Effects/GhciSession/GhciParser"
-            "Tricorder/Effects/GhciSession/GhciProcess"
-            "Tricorder/Effects/GhcPkg"
-            "Tricorder/Effects/Logging"
-            "Tricorder/Effects/SessionStore"
-            "Tricorder/Effects/TestRunner"
-            "Tricorder/Effects/UnixSocket"
-            "Tricorder/Events/FileChanged"
-            "Tricorder/GhcPkg/Types"
-            "Tricorder/Observability"
-            "Tricorder/Runtime"
-            "Tricorder/Session"
-            "Tricorder/Socket/Client"
-            "Tricorder/Socket/Protocol"
-            "Tricorder/Socket/Server"
-            "Tricorder/SourceLookup"
-            "Tricorder/TestOutput"
-            "Tricorder/UI"
-            "Tricorder/UI/Event"
-            "Tricorder/UI/Keys"
-            "Tricorder/UI/Misc"
-            "Tricorder/UI/State"
-            "Tricorder/UI/View"
-            "Tricorder/Version"
-            "Tricorder/Watcher"
-          ];
+          modules = [ "Paths_tricorder" ];
           hsSourceDirs = [ "src" ];
         };
       };
@@ -172,28 +130,12 @@
             (hsPkgs.pkgsBuildBuild.tasty-discover.components.exes.tasty-discover or (pkgs.pkgsBuildBuild.tasty-discover or (errorHandler.buildToolDepError "tasty-discover:tasty-discover")))
           ];
           buildable = true;
-          modules = [
-            "Unit/Tricorder/BuilderSpec"
-            "Unit/Tricorder/BuildStateSpec"
-            "Unit/Tricorder/BuildStoreSpec"
-            "Unit/Tricorder/CLI/RenderSpec"
-            "Unit/Tricorder/Effects/GhciSession/GhciParserSpec"
-            "Unit/Tricorder/Effects/GhciSession/GhciProcessSpec"
-            "Unit/Tricorder/Effects/GhciSessionSpec"
-            "Unit/Tricorder/Effects/SessionStoreSpec"
-            "Unit/Tricorder/GhcPkgSpec"
-            "Unit/Tricorder/SessionSpec"
-            "Unit/Tricorder/SocketSpec"
-            "Unit/Tricorder/SourceLookupSpec"
-            "Unit/Tricorder/SourceSpec"
-            "Unit/Tricorder/TestOutputSpec"
-            "Unit/Tricorder/TestRunnerSpec"
-            "Unit/Tricorder/WatcherSpec"
-            "Paths_tricorder"
-          ];
+          modules = [ "Paths_tricorder" ];
           hsSourceDirs = [ "test" ];
           mainPath = [ "Driver.hs" ];
         };
       };
     };
-  } // rec { src = pkgs.lib.mkDefault ../tricorder; }
+  } // rec { src = pkgs.lib.mkDefault ../tricorder; }) // {
+    cabal-generator = "hpack";
+  }

--- a/nix/package/nix-hpack.nix
+++ b/nix/package/nix-hpack.nix
@@ -21,29 +21,38 @@ writeShellApplication {
     }
 
     usage() {
-      info "Usage: nix-hpack [packages...]"
+      info "Usage: nix-hpack [--keep] [packages...]"
       info "Args:"
+      info "  --keep:    Keep the generated package.yaml file. By default, the generated"
+      info "             package.yaml file is deleted once hpack has generated the .cabal"
+      info "             file."
       info "  packages:  Path to a package directory containing a 'package.nix' to"
       info "             convert."
       info "             Defaults to converting every package under the current working"
       info "             directory."
     }
 
+    packages=()
+    keep_package_yaml=false
     for arg in "$@"; do
       case "$arg" in
         --help|-h)
           usage
           exit 0
           ;;
+        --keep)
+          keep_package_yaml=true
+          ;;
+        *)
+          packages+=("$arg")
+          ;;
       esac
     done
-
-    packages=("$@")
 
     if [ ''${#packages[@]} -eq 0 ]; then
       # If no packages are specified, find all packages in the current
       # directory.
-      mapfile -t packages < <(find . -type f -name "package.nix" -printf "%h\n")
+      mapfile -t packages < <(find "$PWD" -type f -name "package.nix" -printf "%h\n")
     fi
 
     for package in "''${packages[@]}"; do
@@ -60,14 +69,16 @@ writeShellApplication {
       # nix-instantiate tries to initialize /nix/var/nix on startup, which fails
       # in a sandbox. Repackageect to a writable tmpdir for pure --eval use.
       nix_state=$(mktemp -d)
-      export NIX_STATE_package="$nix_state"
-      export NIX_LOG_package="$nix_state/log"
-
+      export NIX_STATE_DIR="$nix_state"
+      export NIX_LOG_DIR="$nix_state/log"
       nix-instantiate --strict --json --eval "$source" \
         | yq --prettyPrint --input-format json --output-format yaml >> "$temp_yaml"
+      rm -rf "$nix_state"
 
       hpack --silent "$temp_yaml" &>/dev/null
-      rm -rf "$temp_yaml" "$nix_state"
+      if test "$keep_package_yaml" = "false"; then
+        rm -rf "$temp_yaml"
+      fi
     done
   '';
 }

--- a/nix/project.nix
+++ b/nix/project.nix
@@ -4,12 +4,28 @@
   compiler-nix-name,
   self,
 }:
+let
+  nix-hpack = pkgs.callPackage ./package/nix-hpack.nix { };
+  # Include the `package.yaml` file for the `haskell-plan-to-nix` step of the
+  # build process. When `haskell-plan-to-nix` uses `package.yaml` instead of
+  # the raw `.cabal` files, it omits the module paths from the materialized
+  # files. By keeping module paths out of our materialized files, we don't have
+  # to update materialization for every module we add or remove, only for
+  # dependencies.
+  src = pkgs.runCommand "src" { } ''
+    mkdir -p src
+    cp -r ${./..}/* src
+    chmod -R +w src
+    ls -la src
+    (cd src && ${nix-hpack}/bin/nix-hpack --keep)
+    mv src $out
+  '';
+in
 pkgs.haskell-nix.cabalProject' {
-  src = ../.;
-  inherit compiler-nix-name;
+  inherit src compiler-nix-name;
 
   # Enable materialization for deterministic builds and better CI caching
-  materialized = ./materialized + "/${pkgs.stdenv.hostPlatform.system}/${compiler-nix-name}";
+  materialized = ./materialized/${pkgs.stdenv.hostPlatform.system}/${compiler-nix-name};
   checkMaterialization = true;
 
   # Add tmp-postgres from flake input


### PR DESCRIPTION
Provide `package.yaml` files for the `haskell-plan-to-nix` stage of the builds so that the materialization uses `.cabal` files generated from `package.yaml` files in isolation, whereby `hpack` does not find any source modules to populate the `exposed-modules` list with.

This simplifies materialization quite a bit, since adding a module will no longer cause every set of materialized files to have to be re-materialized. Materialization is a bit cumbersome since we have it for multiple architectures, and multiple GHC versions.

Depends on https://github.com/atelier-hub/tricorder/pull/201