### PR TITLE
chore: update-materialization clobbers itself

### DIFF
--- a/.github/workflows/update-materialization.yml
+++ b/.github/workflows/update-materialization.yml
@@ -93,7 +93,11 @@ jobs:
         if: ${{ steps.check-for-change.outputs.upload == 'true' }}
         with:
           name: materialization-${{ matrix.system }}-${{ matrix.ghc-version }}
-          path: nix/materialized
+          # Include the README.md to make `upload-artifact` base the artifact
+          # in the root of the repo.
+          path: |
+            nix/materialized/${{ matrix.system }}/${{ matrix.ghc-version }}
+            README.md
           include-hidden-files: true
 
   commit:


### PR DESCRIPTION
Since each full materialization directory is uploaded as artifacts, they end up overwriting each other with old materialization files.

Example:
- GHC 9.14 re-materializes. It uploads `nix/materialization`, which contains both GHC 9.14's new, re-materialized files, as well as old materialized files for other versions.
- GHC 9.8 re-materializes. It also uploads the full `nix/materialization` directory.
- The `commit` job downloads both artifacts, and applies them to the same directory. First it applies GHC 9.14's materialized files, with its new re-materialized files for GHC 9.14. Then it applies GHC 9.8's materialized files, with the new re-materialized files for GHC 9.8, but _also the old_ materialized files for GHC 9.14.

And thus, only a single GHC version of materialized files per system are updated in the subsequent PR.

This fixes that by moving the directories with new materialized files to a separate directory tree, and uploading that as an artifact. This preserves the directory structure, and ensures only changed materialization files are uploaded.