### PR TITLE
chore: remove redundant dependency hs-opentelemetry-exporter-otlp

### DIFF
--- a/atelier-core/atelier-core.cabal
+++ b/atelier-core/atelier-core.cabal
@@ -118,7 +118,6 @@ library
     , filepath >=1.4 && <1.6
     , fsnotify ==0.4.*
     , hs-opentelemetry-api ==0.3.*
-    , hs-opentelemetry-exporter-otlp ==0.1.*
     , hs-opentelemetry-sdk ==0.1.*
     , http-api-data ==0.7.*
     , http-types ==0.12.*

--- a/atelier-core/package.nix
+++ b/atelier-core/package.nix
@@ -56,7 +56,6 @@ in
       "filepath"
       "fsnotify"
       "hs-opentelemetry-api"
-      "hs-opentelemetry-exporter-otlp"
       "hs-opentelemetry-sdk"
       "http-api-data"
       "http-types"

--- a/nix/package/dependencies.nix
+++ b/nix/package/dependencies.nix
@@ -34,7 +34,6 @@ let
     hasql-transaction = ">=1.2 && <1.3";
     hedgehog = ">=1.7 && <1.8";
     hs-opentelemetry-api = ">=0.3 && <0.4";
-    hs-opentelemetry-exporter-otlp = ">=0.1 && <0.2";
     hs-opentelemetry-sdk = ">=0.1 && <0.2";
     hspec = ">=2.11 && <2.12";
     hspec-hedgehog = ">=0.3 && <0.4";


### PR DESCRIPTION
Depends on https://github.com/atelier-hub/tricorder/pull/217