### PR TITLE
refactor: use newtypes for Session properties

### DIFF
--- a/tricorder/src/Tricorder/BuildState.hs
+++ b/tricorder/src/Tricorder/BuildState.hs
@@ -38,7 +38,7 @@ import System.FilePath (makeRelative)
 
 import Tricorder.Effects.SessionStore (SessionStore)
 import Tricorder.Runtime (LogPath (..), ProjectRoot (..), SocketPath (..))
-import Tricorder.Session (Session (..))
+import Tricorder.Session (Session (..), Targets (..), WatchDirs (..))
 
 import Tricorder.Effects.SessionStore qualified as SessionStore
 import Tricorder.Observability qualified as Observability
@@ -77,8 +77,8 @@ loadDaemonInfo = do
     LogPath logFile <- ask
     pure
         $ DaemonInfo
-            { targets = session.targets
-            , watchDirs = map (makeRelative projectRoot) session.watchDirs
+            { targets = session.targets.getTargets
+            , watchDirs = map (makeRelative projectRoot) session.watchDirs.getWatchDirs
             , sockPath
             , logFile
             , metricsPort = if obsCfg.metrics.enabled then Just obsCfg.metrics.port else Nothing

--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -66,7 +66,7 @@ import Tricorder.Effects.GhciSession.GhciProcess (GhciProcessError (..))
 import Tricorder.Effects.SessionStore (SessionStore)
 import Tricorder.Effects.TestRunner (TestRunner)
 import Tricorder.Runtime (ProjectRoot (..))
-import Tricorder.Session (Session (..))
+import Tricorder.Session (Command (..), Session (..), Targets, TestTargets (..), WatchDirs)
 
 import Tricorder.Effects.BuildStore qualified as BuildStore
 import Tricorder.Effects.GhciSession qualified as GhciSession
@@ -103,10 +103,10 @@ component =
 
 -- | A subset of 'Session' with just the properties that 'Builder' cares about.
 data BuildConfig = BuildConfig
-    { command :: Text
-    , targets :: [Text]
-    , testTargets :: [Text]
-    , watchDirs :: [FilePath]
+    { command :: Command
+    , targets :: Targets
+    , testTargets :: TestTargets
+    , watchDirs :: WatchDirs
     }
     deriving stock (Eq)
 
@@ -187,7 +187,7 @@ loadBuildConfig = do
                 , testTargets = session.testTargets
                 , watchDirs = session.watchDirs
                 }
-    Log.info $ "Builder.component: resolved command = " <> config.command
+    Log.info $ "Builder.component: resolved command = " <> coerce config.command
     pure config
 
 
@@ -278,7 +278,7 @@ runGhciSessions hooks config = forever do
     hooks.onStart
     root@(ProjectRoot rootPath) <- ask
     BuildId n <- get
-    Log.info $ "Starting GHCi session #" <> show n <> ": " <> config.command
+    Log.info $ "Starting GHCi session #" <> show n <> ": " <> coerce config.command
 
     startTime <- Clock.currentTime
     result <- trySync $ GhciSession.withGhci config.command root \initialLoad controls -> do
@@ -546,17 +546,17 @@ runTestsIfClean
     -> BuildResult
     -> Eff es (Maybe [TestRun])
 runTestsIfClean (BuildConfig {testTargets}) bid partialResult
-    | null testTargets || any (\d -> d.severity == SError) partialResult.diagnostics = pure (Just [])
+    | null testTargets.getTestTargets || any (\d -> d.severity == SError) partialResult.diagnostics = pure (Just [])
     | otherwise = do
         TestRunner.resetAbort
         setNewPhase
             $ EnteringNewPhase bid
-            $ Testing partialResult {testRuns = map (`TestRunning` Nothing) testTargets}
+            $ Testing partialResult {testRuns = map (`TestRunning` Nothing) testTargets.getTestTargets}
 
-        Log.info $ "Running " <> show (length testTargets) <> " test suite(s)"
+        Log.info $ "Running " <> show (length testTargets.getTestTargets) <> " test suite(s)"
 
-        let initial = (\t -> (t, TestRunning t Nothing)) <$> testTargets
-        runLoop initial testTargets
+        let initial = (\t -> (t, TestRunning t Nothing)) <$> testTargets.getTestTargets
+        runLoop initial testTargets.getTestTargets
   where
     runLoop acc [] = pure (Just (snd <$> acc))
     runLoop acc (target : rest) = do

--- a/tricorder/src/Tricorder/Builder/Dispatch.hs
+++ b/tricorder/src/Tricorder/Builder/Dispatch.hs
@@ -26,6 +26,7 @@ import Tricorder.Effects.GhciSession.GhciParser
     , pathSuffixesAsModuleName
     , unattributedFailure
     )
+import Tricorder.Session (WatchDirs (..))
 
 
 -- | The Builder's per-GHCi-session cache: what it last saw from GHCi plus its
@@ -159,9 +160,9 @@ dispatch knownTargets known fp event = case known of
 -- failures (e.g. a home-unit GHC plugin that can't load under
 -- @--enable-multi-repl@) that must not be dropped, or the build would silently
 -- read as clean.
-filterToWatchDirs :: FilePath -> [FilePath] -> [Diagnostic] -> [Diagnostic]
-filterToWatchDirs _ [] diags = diags
-filterToWatchDirs projectRoot watchDirs diags =
+filterToWatchDirs :: FilePath -> WatchDirs -> [Diagnostic] -> [Diagnostic]
+filterToWatchDirs _ (WatchDirs []) diags = diags
+filterToWatchDirs projectRoot (WatchDirs watchDirs) diags =
     filter (\d -> isLocationLess d.file || isUnderAnyWatchDir d.file) diags
   where
     absWatchDirs = map toAbsWd watchDirs

--- a/tricorder/src/Tricorder/Effects/GhciSession.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession.hs
@@ -47,6 +47,7 @@ import Tricorder.Effects.GhciSession.GhciParser
     )
 import Tricorder.Effects.GhciSession.GhciProcess (addGhci, collectGhciResult, interruptGhci, reloadGhci, unaddGhci, withGhciProcess)
 import Tricorder.Runtime (ProjectRoot (..))
+import Tricorder.Session (Command)
 
 
 data GhciSession :: Effect where
@@ -54,7 +55,7 @@ data GhciSession :: Effect where
     -- The handler is also provided an action to reload the GHCi session,
     -- returning new messages with module counts. The GHCi session is closed
     -- when the handler returns.
-    WithGhci :: Text -> ProjectRoot -> (LoadResult -> Controls m -> m a) -> GhciSession m a
+    WithGhci :: Command -> ProjectRoot -> (LoadResult -> Controls m -> m a) -> GhciSession m a
 
 
 data Controls m = Controls

--- a/tricorder/src/Tricorder/Effects/GhciSession/GhciProcess.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession/GhciProcess.hs
@@ -57,6 +57,7 @@ import Tricorder.Effects.GhciSession.GhciParser
     , stripAnsi
     , unattributedFailure
     )
+import Tricorder.Session (Command (..))
 
 
 -- | Configuration for GHCi process management.
@@ -142,7 +143,7 @@ startGhciProcess
        , Timeout :> es
        )
     => Config
-    -> Text
+    -> Command
     -> FilePath
     -> (GhciLoading -> Eff es ())
     -- ^ Called as each @[N of M] Compiling …@ line is streamed during the
@@ -162,7 +163,7 @@ startGhciProcess config cmd dir onProgress onReady = do
             $ setStderr createPipe
             $ setCreateGroup True
             $ setWorkingDir dir
-            $ shell (toString cmd)
+            $ shell (toString cmd.getCommand)
     let inp = getStdin p
         out = getStdout p
         err = getStderr p
@@ -237,7 +238,7 @@ startGhciProcess config cmd dir onProgress onReady = do
 withGhciProcess
     :: (Conc :> es, Concurrent :> es, File :> es, Process :> es, Timeout :> es)
     => Config
-    -> Text
+    -> Command
     -> FilePath
     -> (GhciLoading -> Eff es ())
     -> (GhciProcess -> Eff es ())

--- a/tricorder/src/Tricorder/Effects/TestRunner.hs
+++ b/tricorder/src/Tricorder/Effects/TestRunner.hs
@@ -55,7 +55,7 @@ import Tricorder.Effects.GhciSession.GhciParser (GhciLoading (..))
 import Tricorder.Effects.GhciSession.GhciProcess (GhciProcess, execGhci, terminateGhciProcess, withGhciProcess)
 import Tricorder.Effects.SessionStore (SessionStore)
 import Tricorder.Runtime (ProjectRoot (..))
-import Tricorder.Session (Session (..))
+import Tricorder.Session (Command (..), Session (..), TestTimeout (..))
 import Tricorder.TestOutput (parseHspecDuration, parseHspecOutput)
 
 import Tricorder.Effects.SessionStore qualified as SessionStore
@@ -136,7 +136,7 @@ runTestRunnerIO act = do
                     $ bracket_
                         (pure ())
                         (atomically (writeTVar currentProcRef Nothing))
-                    $ withGhciProcess def ("cabal repl " <> target) projectRoot onProgress onReady \ghci _ ->
+                    $ withGhciProcess def (Command $ "cabal repl " <> target) projectRoot onProgress onReady \ghci _ ->
                         atomically (readTVar abortedRef) >>= \case
                             -- An interrupt may have landed during the
                             -- @cabal repl@ load. The returned value is
@@ -144,8 +144,8 @@ runTestRunnerIO act = do
                             -- 'abortedRef'.
                             True -> pure (Right [])
                             False -> case testTimeout of
-                                secs | secs <= 0 -> Right <$> execGhci ghci ":main" noProgress
-                                secs ->
+                                TestTimeout secs | secs <= 0 -> Right <$> execGhci ghci ":main" noProgress
+                                TestTimeout secs ->
                                     timeout (fromIntegral secs :: Second) (execGhci ghci ":main" noProgress) >>= \case
                                         Nothing -> pure (Left secs)
                                         Just ls -> pure (Right ls)

--- a/tricorder/src/Tricorder/Session.hs
+++ b/tricorder/src/Tricorder/Session.hs
@@ -1,6 +1,12 @@
 module Tricorder.Session
     ( Session (..)
     , Config (..)
+    , Command (..)
+    , Targets (..)
+    , TestTargets (..)
+    , WatchDirs (..)
+    , ReplBuildDir (..)
+    , TestTimeout (..)
     , loadSession
     , resolveCommand
     , resolveTargets
@@ -16,7 +22,7 @@ import Atelier.Effects.FileSystem (FileSystem, doesFileExist, listDirectory, rea
 import Atelier.Effects.Log (Log)
 import Atelier.Types.QuietSnake (QuietSnake (..))
 import Atelier.Types.WithDefaults (WithDefaults (..))
-import Data.Aeson (FromJSON)
+import Data.Aeson (FromJSON, ToJSON)
 import Data.Default (Default (..))
 import Data.List (nub)
 import Distribution.Fields (Field (..), FieldLine (..), Name (..), readFields)
@@ -50,24 +56,24 @@ import Tricorder.Runtime (ProjectRoot (..))
 
 
 data Session = Session
-    { command :: Text
-    , targets :: [Text]
-    , testTargets :: [Text]
-    , watchDirs :: [FilePath]
-    , replBuildDir :: FilePath
-    , testTimeout :: Int
+    { command :: Command
+    , targets :: Targets
+    , testTargets :: TestTargets
+    , watchDirs :: WatchDirs
+    , replBuildDir :: ReplBuildDir
+    , testTimeout :: TestTimeout
     }
 
 
 instance Default Session where
     def =
         Session
-            { command = ""
-            , targets = []
-            , testTargets = []
-            , watchDirs = []
-            , replBuildDir = "/tmp"
-            , testTimeout = 10
+            { command = Command ""
+            , targets = Targets []
+            , testTargets = TestTargets []
+            , watchDirs = WatchDirs []
+            , replBuildDir = ReplBuildDir "/tmp"
+            , testTimeout = TestTimeout 10
             }
 
 
@@ -95,15 +101,45 @@ instance Default Config where
             }
 
 
+newtype Command = Command {getCommand :: Text}
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via Text
+
+
+newtype Targets = Targets {getTargets :: [Text]}
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via [Text]
+
+
+newtype TestTargets = TestTargets {getTestTargets :: [Text]}
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via [Text]
+
+
+newtype WatchDirs = WatchDirs {getWatchDirs :: [FilePath]}
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via [FilePath]
+
+
+newtype ReplBuildDir = ReplBuildDir {getReplBuildDir :: FilePath}
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via FilePath
+
+
+newtype TestTimeout = TestTimeout {getTestTimeout :: Int}
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via Int
+
+
 -- | Resolve the GHCi command, using config if set or autodetecting otherwise.
 --
 -- The @testTargets@ are the discovered @test:@ components; they are appended to
 -- the auto-detected @all@ target (see 'detectCommand'). They are ignored when
 -- the user has pinned an explicit @command@ or explicit @targets@ in config.
-resolveCommand :: (FileSystem :> es) => ProjectRoot -> Config -> [Text] -> [Text] -> Eff es Text
+resolveCommand :: (FileSystem :> es) => ProjectRoot -> Config -> Targets -> TestTargets -> Eff es Command
 resolveCommand projectRoot cfg targets testTargets =
     case cfg.command of
-        Just cmd -> pure cmd
+        Just cmd -> pure $ Command cmd
         Nothing -> detectCommand targets testTargets cfg.replBuildDir projectRoot
 
 
@@ -120,8 +156,8 @@ resolveCommand projectRoot cfg targets testTargets =
 -- "not loaded" and the session dies — which a naive discovery-order enumeration
 -- triggers but @all@ avoids. Appending already-included test targets is a no-op
 -- (cabal deduplicates).
-detectCommand :: (FileSystem :> es) => [Text] -> [Text] -> FilePath -> ProjectRoot -> Eff es Text
-detectCommand targets testTargets replBuildDir (ProjectRoot projectRoot) = do
+detectCommand :: (FileSystem :> es) => Targets -> TestTargets -> FilePath -> ProjectRoot -> Eff es Command
+detectCommand (Targets targets) (TestTargets testTargets) replBuildDir (ProjectRoot projectRoot) = do
     hasCabalProject <- doesFileExist (projectRoot </> "cabal.project")
     cabalFiles <- filter (\f -> takeExtension f == ".cabal") <$> listDirectory projectRoot
     hasStack <- doesFileExist (projectRoot </> "stack.yaml")
@@ -132,9 +168,9 @@ detectCommand targets testTargets replBuildDir (ProjectRoot projectRoot) = do
     pure
         if
             | hasCabalProject || not (null cabalFiles) ->
-                "cabal repl --enable-multi-repl " <> buildDirFlag <> targetStr
-            | hasStack -> "stack ghci " <> targetStr
-            | otherwise -> "cabal repl " <> buildDirFlag <> targetStr
+                Command $ "cabal repl --enable-multi-repl " <> buildDirFlag <> targetStr
+            | hasStack -> Command $ "stack ghci " <> targetStr
+            | otherwise -> Command $ "cabal repl " <> buildDirFlag <> targetStr
 
 
 -- | Resolve the directories to watch.
@@ -143,18 +179,18 @@ detectCommand targets testTargets replBuildDir (ProjectRoot projectRoot) = do
 -- 1. @watch_dirs@ from config, if non-empty (used as-is relative to project root)
 -- 2. @hs-source-dirs@ inferred from cabal targets, if targets are set
 -- 3. Falls back to @["."]@ (project root) if neither is available
-resolveWatchDirs :: (FileSystem :> es) => ProjectRoot -> [FilePath] -> Config -> [Text] -> Eff es [FilePath]
+resolveWatchDirs :: (FileSystem :> es) => ProjectRoot -> [FilePath] -> Config -> Targets -> Eff es WatchDirs
 resolveWatchDirs projectRoot cabalFiles cfg targets =
     case cfg.watchDirs of
-        dirs@(_ : _) -> pure $ map (coerce projectRoot </>) dirs
+        dirs@(_ : _) -> pure $ WatchDirs $ map (coerce projectRoot </>) dirs
         [] -> resolveWatchDirsFromTargets cabalFiles targets
 
 
-resolveWatchDirsFromTargets :: (FileSystem :> es) => [FilePath] -> [Text] -> Eff es [FilePath]
-resolveWatchDirsFromTargets _ [] = pure ["."]
-resolveWatchDirsFromTargets cabalFiles targets = do
+resolveWatchDirsFromTargets :: (FileSystem :> es) => [FilePath] -> Targets -> Eff es WatchDirs
+resolveWatchDirsFromTargets _ (Targets []) = pure $ WatchDirs ["."]
+resolveWatchDirsFromTargets cabalFiles (Targets targets) = do
     dirs <- nub . concat <$> traverse watchDirsForCabal cabalFiles
-    pure $ if null dirs then ["."] else dirs
+    pure $ WatchDirs $ if null dirs then ["."] else dirs
   where
     -- @hs-source-dirs@ are relative to the package's own directory, so scope
     -- them to the directory holding that package's @.cabal@. In a
@@ -197,10 +233,10 @@ sourceDirsForTarget gpd target =
 -- | Infer the effective targets to build and watch.
 -- Returns the configured targets as-is, or auto-detects all components across
 -- every discovered package when no targets are configured.
-resolveTargets :: (FileSystem :> es) => [FilePath] -> [Text] -> Eff es [Text]
-resolveTargets _ targets@(_ : _) = pure targets
+resolveTargets :: (FileSystem :> es) => [FilePath] -> [Text] -> Eff es Targets
+resolveTargets _ targets@(_ : _) = pure $ Targets targets
 resolveTargets cabalFiles [] =
-    concat <$> traverse targetsFromCabal cabalFiles
+    Targets . concat <$> traverse targetsFromCabal cabalFiles
   where
     targetsFromCabal path = do
         contents <- readFileBs path
@@ -283,10 +319,10 @@ allComponentTargets gpd =
 --
 -- When 'testTargets' is set in config, those suites are used directly.
 -- Otherwise, all @test:@ components in 'targets' are inferred.
-resolveTestTargets :: Config -> [Text] -> [Text]
+resolveTestTargets :: Config -> Targets -> TestTargets
 resolveTestTargets cfg targets = case cfg.testTargets of
-    Just explicit -> explicit
-    Nothing -> filter ("test:" `T.isPrefixOf`) targets
+    Just explicit -> TestTargets explicit
+    Nothing -> TestTargets $ filter ("test:" `T.isPrefixOf`) targets.getTargets
 
 
 loadSession
@@ -311,6 +347,6 @@ loadSession = do
             , command
             , watchDirs
             , testTargets
-            , replBuildDir = cfgFile.replBuildDir
-            , testTimeout = cfgFile.testTimeout
+            , replBuildDir = ReplBuildDir cfgFile.replBuildDir
+            , testTimeout = TestTimeout cfgFile.testTimeout
             }

--- a/tricorder/src/Tricorder/Watcher.hs
+++ b/tricorder/src/Tricorder/Watcher.hs
@@ -34,7 +34,7 @@ import Tricorder.BuildState
 import Tricorder.Effects.BuildStore (BuildStore)
 import Tricorder.Effects.SessionStore (SessionStore, SessionStoreReloaded)
 import Tricorder.Runtime (ProjectRoot (..))
-import Tricorder.Session (Session (..))
+import Tricorder.Session (Session (..), WatchDirs (..))
 
 import Tricorder.Effects.BuildStore qualified as BuildStore
 import Tricorder.Effects.SessionStore qualified as SessionStore
@@ -106,7 +106,7 @@ withWatcherSession
     -> (SessionStore.Reloader es -> WatcherSession -> Eff es Void)
     -> Eff es Void
 withWatcherSession =
-    SessionStore.withSubSession $ WatcherSession . (.watchDirs)
+    SessionStore.withSubSession $ WatcherSession . (.watchDirs.getWatchDirs)
 
 
 watchFiles

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -68,6 +68,7 @@ import Tricorder.Effects.GhciSession (Controls (..), LoadResult (..), LoadedModu
 import Tricorder.Effects.GhciSession.GhciParser (collectResult, extractTitle, resolveKnownTargets)
 import Tricorder.Effects.TestRunner (TestRunner (..), runTestRunnerScripted)
 import Tricorder.Runtime (ProjectRoot (..))
+import Tricorder.Session (Command (..), Targets (..), TestTargets (..), WatchDirs (..))
 
 import Tricorder.BuildState qualified as BuildState
 import Tricorder.Builder qualified as Builder
@@ -447,27 +448,27 @@ testCompileLoadResultsIntoBuildResults = do
                 runPureEff
                     . runReader (ProjectRoot "/")
                     . runState (emptyBuilderState {diagnosticMap = acc})
-                    $ compileLoadResultsIntoBuildResults (def {Builder.watchDirs = ["/src"]}) nlr
+                    $ compileLoadResultsIntoBuildResults (def {Builder.watchDirs = WatchDirs ["/src"]}) nlr
         in  (builderState.diagnosticMap, buildResult)
 
 
 testRequestTestRunsForNewBuildResults :: Spec
 testRequestTestRunsForNewBuildResults = do
     describe "when there are no test targets" $ it "should skip testing" do
-        phases <- runTest [] [] expected
+        phases <- runTest (TestTargets []) [] expected
         length phases `shouldBe` 1
         phases `shouldMatchList` [EnteringNewPhase (BuildId 1) $ Done expected]
 
     describe "when there are errors" $ it "should skip testing" do
         let expected' = expected {BuildState.diagnostics = [errMsg]}
-        phases <- runTest ["test:foo"] [] expected'
+        phases <- runTest (TestTargets ["test:foo"]) [] expected'
         length phases `shouldBe` 1
         phases `shouldMatchList` [EnteringNewPhase (BuildId 1) $ Done expected']
 
     it "should emit EnteringNewPhase events for each test target" do
         phases <-
             runTest
-                ["test:foo", "test:bar"]
+                (TestTargets ["test:foo", "test:bar"])
                 [ Right $ mkTestRun "test:foo"
                 , Right $ mkTestRun "test:bar"
                 ]
@@ -510,10 +511,10 @@ testRequestTestRunsForNewBuildResults = do
                 . runTestRunnerAbortAfterFirst (mkTestRun "test:foo")
                 $ requestTestRunsForNewBuildResults
                     BuildConfig
-                        { command = ""
-                        , targets = []
-                        , testTargets = ["test:foo", "test:bar"]
-                        , watchDirs = []
+                        { command = Command ""
+                        , targets = Targets []
+                        , testTargets = TestTargets ["test:foo", "test:bar"]
+                        , watchDirs = WatchDirs []
                         }
                     expected
         -- The critical assertion: no Done phase, because the run was
@@ -535,7 +536,12 @@ testRequestTestRunsForNewBuildResults = do
             . runBuildStoreCapture
             . runTestRunnerScripted script
             $ requestTestRunsForNewBuildResults
-                BuildConfig {command = "", targets = [], testTargets, watchDirs = []}
+                BuildConfig
+                    { command = Command ""
+                    , targets = Targets []
+                    , testTargets
+                    , watchDirs = WatchDirs []
+                    }
                 partial
 
     mkPhase = EnteringNewPhase (BuildId 1)
@@ -793,7 +799,7 @@ testMergeDiagnostics = do
 testFilterToWatchDirs :: Spec
 testFilterToWatchDirs = do
     let root = "/project"
-        watchDirs = ["/project/src"]
+        watchDirs = WatchDirs ["/project/src"]
 
     it "keeps diagnostics under a watched directory" do
         -- ./src/Foo.hs is what toRelative produces for an absolute project file
@@ -815,16 +821,16 @@ testFilterToWatchDirs = do
         -- A mangled path joined onto projectRoot would incorrectly start with
         -- projectRoot+"/", so this case requires an explicit guard.
         let d = errMsg {file = "In file included from src/Foo.hs"}
-        filterToWatchDirs root ["."] [d] `shouldBe` []
+        filterToWatchDirs root (WatchDirs ["."]) [d] `shouldBe` []
 
     it "passes everything through when watchDirs is empty" do
         let d = errMsg {file = "/nix/store/abc123/ghcautoconf.h"}
-        filterToWatchDirs root [] [d] `shouldBe` [d]
+        filterToWatchDirs root (WatchDirs []) [d] `shouldBe` [d]
 
     it "works with the '.' fallback watch dir (whole project root)" do
         let d = errMsg {file = "./src/Foo.hs"}
             nixD = errMsg {file = "/nix/store/abc123/ghcautoconf.h"}
-        filterToWatchDirs root ["."] [d, nixD] `shouldBe` [d]
+        filterToWatchDirs root (WatchDirs ["."]) [d, nixD] `shouldBe` [d]
 
     describe "when diagnostic has no path it" $ it "keeps location-less <no location info> errors" do
         -- A home-unit GHC plugin that can't load under --enable-multi-repl

--- a/tricorder/test/Unit/Tricorder/Effects/GhciSessionSpec.hs
+++ b/tricorder/test/Unit/Tricorder/Effects/GhciSessionSpec.hs
@@ -11,6 +11,7 @@ import Data.Set qualified as Set
 import Tricorder.BuildState (Diagnostic (..), Severity (..))
 import Tricorder.Effects.GhciSession (Controls (..), GhciSession, LoadResult (..), runGhciSessionScripted, withGhci)
 import Tricorder.Runtime (ProjectRoot (..))
+import Tricorder.Session (Command (..))
 
 
 spec_GhciSession :: Spec
@@ -29,40 +30,40 @@ testScripted = do
             it "returns scripted messages" do
                 LoadResult {diagnostics = msgs} <-
                     runScripted [simpleResult [errMsg]]
-                        $ withGhci "cabal repl" (ProjectRoot "/") \initial _ -> pure initial
+                        $ withGhci (Command "cabal repl") (ProjectRoot "/") \initial _ -> pure initial
                 msgs `shouldBe` [errMsg]
 
             it "returns empty list when scripted result has no messages" do
                 LoadResult {diagnostics = msgs} <-
                     runScripted [simpleResult []]
-                        $ withGhci "cabal repl" (ProjectRoot "/") \initial _ -> pure initial
+                        $ withGhci (Command "cabal repl") (ProjectRoot "/") \initial _ -> pure initial
                 msgs `shouldBe` []
 
             it "throws when scripted result is Left" do
                 result <-
                     runScripted [Left (toException boom)]
                         $ try @ErrorCall
-                        $ withGhci "cabal repl" (ProjectRoot "/") \initial _ -> pure initial
+                        $ withGhci (Command "cabal repl") (ProjectRoot "/") \initial _ -> pure initial
                 result `shouldBe` Left boom
 
         describe "reloading" do
             it "returns scripted messages" do
                 LoadResult {diagnostics = msgs} <-
                     runScripted [simpleResult [warnMsg], simpleResult [errMsg]]
-                        $ withGhci "cabal repl" (ProjectRoot "/") \_ controls -> controls.reload
+                        $ withGhci (Command "cabal repl") (ProjectRoot "/") \_ controls -> controls.reload
                 msgs `shouldBe` [errMsg]
 
             it "throws when scripted result is Left" do
                 result <-
                     runScripted [Left (toException boom)]
                         $ try @ErrorCall
-                        $ withGhci "cabal repl" (ProjectRoot "/") \_ controls -> controls.reload
+                        $ withGhci (Command "cabal repl") (ProjectRoot "/") \_ controls -> controls.reload
                 result `shouldBe` Left boom
 
     describe "sequencing" do
         it "consumes results in order across mixed operations" do
             (a, b) <- runScripted [simpleResult [errMsg], simpleResult [warnMsg]] do
-                withGhci "cabal repl" (ProjectRoot "/") \LoadResult {diagnostics = a} controls -> do
+                withGhci (Command "cabal repl") (ProjectRoot "/") \LoadResult {diagnostics = a} controls -> do
                     LoadResult {diagnostics = b} <- controls.reload
                     pure (a, b)
             a `shouldBe` [errMsg]
@@ -70,8 +71,8 @@ testScripted = do
 
         it "recover scenario: error then success" do
             result <- runScripted [Left (toException boom), simpleResult []] do
-                r1 <- try @ErrorCall $ withGhci "cabal repl" (ProjectRoot "/") \i _ -> pure i
-                LoadResult {diagnostics = r2} <- withGhci "cabal repl" (ProjectRoot "/") \i _ -> pure i
+                r1 <- try @ErrorCall $ withGhci (Command "cabal repl") (ProjectRoot "/") \i _ -> pure i
+                LoadResult {diagnostics = r2} <- withGhci (Command "cabal repl") (ProjectRoot "/") \i _ -> pure i
                 pure (r1, r2)
             fst result `shouldSatisfy` isLeft
             snd result `shouldBe` []

--- a/tricorder/test/Unit/Tricorder/Effects/SessionStoreSpec.hs
+++ b/tricorder/test/Unit/Tricorder/Effects/SessionStoreSpec.hs
@@ -24,7 +24,7 @@ import Tricorder.Effects.SessionStore
     , runSessionStoreConst
     , withSession
     )
-import Tricorder.Session (Session (..))
+import Tricorder.Session (Command (..), Session (..))
 
 import Tricorder.Effects.SessionStore qualified as SessionStore
 
@@ -151,11 +151,11 @@ runSessionStoreMutable ref = interpret_ \case
 --------------------------------------------------------------------------------
 
 session1 :: Session
-session1 = def {command = "session-1"}
+session1 = def {command = Command "session-1"}
 
 
 session2 :: Session
-session2 = def {command = "session-2"}
+session2 = def {command = Command "session-2"}
 
 
 epoch :: UTCTime

--- a/tricorder/test/Unit/Tricorder/SessionSpec.hs
+++ b/tricorder/test/Unit/Tricorder/SessionSpec.hs
@@ -13,16 +13,7 @@ import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 
 import Tricorder.Runtime (ProjectRoot (..))
-import Tricorder.Session
-    ( Config (..)
-    , allComponentTargets
-    , discoverCabalFiles
-    , resolveCommand
-    , resolveTargets
-    , resolveTestTargets
-    , resolveWatchDirs
-    , sourceDirsForTarget
-    )
+import Tricorder.Session (Command (..), Config (..), Targets (..), TestTargets (..), WatchDirs (..), allComponentTargets, discoverCabalFiles, resolveCommand, resolveTargets, resolveTestTargets, resolveWatchDirs, sourceDirsForTarget)
 
 
 spec_Session :: Spec
@@ -116,7 +107,7 @@ testResolveTargets = do
         it "returns configured targets as-is without reading any cabal file" do
             -- The cabal file is absent from the mock FS, so any attempt to read
             -- it would error; passing the test proves the early return.
-            let actual =
+            let Targets actual =
                     runPureEff
                         . evalState mempty
                         . runFileSystemState
@@ -125,7 +116,7 @@ testResolveTargets = do
 
     describe "when no targets are configured" do
         it "auto-detects all components from the cabal file" do
-            let actual =
+            let Targets actual =
                     runPureEff
                         . evalState (Map.singleton "/myapp.cabal" cabalFixture)
                         . runFileSystemState
@@ -134,7 +125,7 @@ testResolveTargets = do
                 `shouldBe` ["lib:myapp", "lib:myapp-utils", "exe:myapp-exe", "test:myapp-test"]
 
         it "surfaces test-suite components so they can be run after a build" do
-            let actual =
+            let Targets actual =
                     runPureEff
                         . evalState (Map.singleton "/myapp.cabal" cabalFixture)
                         . runFileSystemState
@@ -142,7 +133,7 @@ testResolveTargets = do
             actual `shouldContain` ["test:myapp-test"]
 
         it "returns no targets when there are no cabal files" do
-            let actual =
+            let Targets actual =
                     runPureEff
                         . evalState mempty
                         . runFileSystemState
@@ -150,7 +141,7 @@ testResolveTargets = do
             actual `shouldBe` []
 
         it "aggregates components across every package (regression: was 0)" do
-            let actual =
+            let Targets actual =
                     runPureEff
                         . evalState multiPackageFs
                         . runFileSystemState
@@ -165,41 +156,41 @@ testResolveWatchDirs :: Spec
 testResolveWatchDirs = do
     describe "when watch_dirs is set in config" do
         it "uses config dirs relative to project root" do
-            let actual =
+            let WatchDirs actual =
                     runPureEff
                         . evalState mempty
                         . runFileSystemState
-                        $ resolveWatchDirs pr [] def {watchDirs = ["src", "test"]} []
+                        $ resolveWatchDirs pr [] def {watchDirs = ["src", "test"]} (Targets [])
             actual `shouldBe` ["/src", "/test"]
 
     describe "when watch_dirs is not set" do
         it "falls back to [\".\"] when targets list is empty" do
-            let actual =
+            let WatchDirs actual =
                     runPureEff
                         . evalState mempty
                         . runFileSystemState
-                        $ resolveWatchDirs pr [] def []
+                        $ resolveWatchDirs pr [] def (Targets [])
             actual `shouldBe` ["."]
 
         it "infers source dirs from resolved targets" do
-            let actual =
+            let WatchDirs actual =
                     runPureEff
                         . evalState (Map.singleton "/myapp.cabal" cabalFixture)
                         . runFileSystemState
-                        $ resolveWatchDirs pr ["/myapp.cabal"] def ["lib:myapp", "test:myapp-test"]
+                        $ resolveWatchDirs pr ["/myapp.cabal"] def (Targets ["lib:myapp", "test:myapp-test"])
             actual `shouldBe` ["/src", "/test"]
 
         it "falls back to [\".\"] when there are no cabal files" do
-            let actual =
+            let WatchDirs actual =
                     runPureEff
                         . evalState mempty
                         . runFileSystemState
-                        $ resolveWatchDirs pr [] def ["lib:myapp"]
+                        $ resolveWatchDirs pr [] def (Targets ["lib:myapp"])
             actual `shouldBe` ["."]
 
     describe "when the project is a multi-package cabal.project" do
         it "infers per-package source dirs, scoped to each package's directory" do
-            let actual =
+            let WatchDirs actual =
                     runPureEff
                         . evalState multiPackageFs
                         . runFileSystemState
@@ -207,7 +198,7 @@ testResolveWatchDirs = do
                             pr
                             ["/pkg-a/pkg-a.cabal", "/pkg-b/pkg-b.cabal"]
                             def
-                            ["lib:pkg-a", "test:pkg-a-test", "lib:pkg-b", "test:pkg-b-test"]
+                            (Targets ["lib:pkg-a", "test:pkg-a-test", "lib:pkg-b", "test:pkg-b-test"])
             actual
                 `shouldBe` ["/pkg-a/src", "/pkg-a/test", "/pkg-b/src", "/pkg-b/test"]
   where
@@ -218,96 +209,96 @@ testResolveTestTargets :: Spec
 testResolveTestTargets = do
     it "infers test: components from targets when testTargets is absent" do
         let cfg = def :: Config
-        resolveTestTargets cfg ["lib:mylib", "test:mylib-test"] `shouldBe` ["test:mylib-test"]
+        resolveTestTargets cfg (Targets ["lib:mylib", "test:mylib-test"]) `shouldBe` TestTargets ["test:mylib-test"]
 
     it "returns empty list when no test: components in targets" do
         let cfg = def :: Config
-        resolveTestTargets cfg ["lib:mylib", "exe:myapp"] `shouldBe` []
+        resolveTestTargets cfg (Targets ["lib:mylib", "exe:myapp"]) `shouldBe` TestTargets []
 
     it "uses explicit testTargets list when set" do
         let cfg = def {testTargets = Just ["test:b-test"]} :: Config
-        resolveTestTargets cfg ["lib:a", "test:a-test", "test:b-test"] `shouldBe` ["test:b-test"]
+        resolveTestTargets cfg (Targets ["lib:a", "test:a-test", "test:b-test"]) `shouldBe` TestTargets ["test:b-test"]
 
     it "returns empty list when testTargets is explicitly empty" do
         let cfg = def {testTargets = Just []} :: Config
-        resolveTestTargets cfg ["lib:a", "test:a-test"] `shouldBe` []
+        resolveTestTargets cfg (Targets ["lib:a", "test:a-test"]) `shouldBe` TestTargets []
 
     it "infers multiple test: components" do
         let cfg = def :: Config
-        resolveTestTargets cfg ["lib:a", "test:a-test", "test:b-test"] `shouldBe` ["test:a-test", "test:b-test"]
+        resolveTestTargets cfg (Targets ["lib:a", "test:a-test", "test:b-test"]) `shouldBe` TestTargets ["test:a-test", "test:b-test"]
 
 
 testResolveCommand :: Spec
 testResolveCommand = do
     describe "when config has a command" do
         it "should use specified command" do
-            let actual =
+            let Command actual =
                     runPureEff
                         . evalState mempty
                         . runFileSystemState
-                        $ resolveCommand pr def {command = Just "foo"} [] testTargets
+                        $ resolveCommand pr def {command = Just "foo"} (Targets []) testTargets
             actual `shouldBe` "foo"
 
     describe "when config has explicit targets" do
         it "should spell them out verbatim, ignoring discovered test targets" do
-            let actual =
+            let Command actual =
                     runPureEff
                         . evalState (Map.singleton "/cabal.project" "")
                         . runFileSystemState
-                        $ resolveCommand pr cfg ["lib:foo"] testTargets
+                        $ resolveCommand pr cfg (Targets ["lib:foo"]) testTargets
             actual `shouldBe` "cabal repl --enable-multi-repl --builddir /replbuild lib:foo"
 
     describe "when config does not have a command or targets" do
         describe "and there is a cabal.project file" do
             it "should use cabal 'all' plus the discovered test targets" do
-                let actual =
+                let Command actual =
                         runPureEff
                             . evalState (Map.singleton "/cabal.project" "")
                             . runFileSystemState
-                            $ resolveCommand pr cfg [] testTargets
+                            $ resolveCommand pr cfg (Targets []) testTargets
                 actual
                     `shouldBe` "cabal repl --enable-multi-repl --builddir /replbuild all test:foo"
 
         describe "and there is at least one *.cabal file" do
             it "should use cabal 'all' plus the discovered test targets" do
-                let actual =
+                let Command actual =
                         runPureEff
                             . evalState (Map.singleton "/foo.cabal" "")
                             . runFileSystemState
-                            $ resolveCommand pr cfg [] testTargets
+                            $ resolveCommand pr cfg (Targets []) testTargets
                 actual
                     `shouldBe` "cabal repl --enable-multi-repl --builddir /replbuild all test:foo"
 
         describe "and there is a stack.yaml file" do
             it "should use stack ghci with 'all' plus test targets" do
-                let actual =
+                let Command actual =
                         runPureEff
                             . evalState (Map.singleton "/stack.yaml" "")
                             . runFileSystemState
-                            $ resolveCommand pr cfg [] testTargets
+                            $ resolveCommand pr cfg (Targets []) testTargets
                 actual `shouldBe` "stack ghci all test:foo"
 
         describe "but there are no project files" do
             it "should use default cabal repl with 'all' plus test targets" do
-                let actual =
+                let Command actual =
                         runPureEff
                             . evalState mempty
                             . runFileSystemState
-                            $ resolveCommand pr cfg [] testTargets
+                            $ resolveCommand pr cfg (Targets []) testTargets
                 actual `shouldBe` "cabal repl --builddir /replbuild all test:foo"
 
         describe "and no test targets are discovered" do
             it "should fall back to plain 'all'" do
-                let actual =
+                let Command actual =
                         runPureEff
                             . evalState (Map.singleton "/cabal.project" "")
                             . runFileSystemState
-                            $ resolveCommand pr cfg [] []
+                            $ resolveCommand pr cfg (Targets []) (TestTargets [])
                 actual `shouldBe` "cabal repl --enable-multi-repl --builddir /replbuild all"
   where
     pr = ProjectRoot "/"
     cfg = def {replBuildDir = "/replbuild"}
-    testTargets = ["test:foo"]
+    testTargets = TestTargets ["test:foo"]
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
One of the causes of the problem fixed by #209 was type blindness. In the spirit of [Parse, don't validate](https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/), this PR introduces proper `newtype`s for each of the `Session` properties to better ensure they are indeed parsed/resolved properly where they should be.

The drawback to this is of course the verbosity of having to `coerce` or otherwise pattern-match on the `newtype`d value to use it, but that is a minor drawback at best.

Depends on https://github.com/atelier-hub/tricorder/pull/217