### PR TITLE
refactor: read `cabal.project` and `.cabal` files only once

### DIFF
--- a/nix/package/dependencies.nix
+++ b/nix/package/dependencies.nix
@@ -6,6 +6,7 @@ let
   depList = map dep;
   constraints = {
     base = ">=4.18 && < 4.23";
+    Cabal = ">=3.12 && <3.17";
     Cabal-syntax = ">=3.12 && <3.17";
     aeson = ">=2.2 && <2.3";
     ansi-terminal = ">=1.1 && <1.2";

--- a/tricorder/package.nix
+++ b/tricorder/package.nix
@@ -45,6 +45,7 @@ in
       ++ depList [
         "atelier-prelude"
         "atelier-core"
+        "Cabal"
         "Cabal-syntax"
         "aeson"
         "ansi-terminal"

--- a/tricorder/src/Tricorder/Daemon/Main.hs
+++ b/tricorder/src/Tricorder/Daemon/Main.hs
@@ -36,6 +36,7 @@ import Tricorder.Effects.SessionStore (runSessionStore)
 import Tricorder.Effects.TestRunner (runTestRunnerIO)
 import Tricorder.Effects.UnixSocket (runUnixSocketIO)
 import Tricorder.Runtime (runLogPath, runProjectRoot, runRuntimeDir, runSocketPath)
+import Tricorder.Session (runCabalFiles)
 
 import Tricorder.BuildState qualified as BuildState
 import Tricorder.Builder qualified as Builder
@@ -77,6 +78,7 @@ main =
         . runTracingFromConfig
         . runChan
         . runPubSub @SessionStore.SessionStoreReloaded
+        . runCabalFiles
         . runSessionStore
         . runReader @CacheConfig.Config def
         . runPubSub @Watcher.WatchedFile

--- a/tricorder/src/Tricorder/Effects/SessionStore.hs
+++ b/tricorder/src/Tricorder/Effects/SessionStore.hs
@@ -30,7 +30,7 @@ import Atelier.Effects.Publishing qualified as Sub
 import Effectful.State.Static.Shared qualified as State
 
 import Tricorder.Runtime (ProjectRoot)
-import Tricorder.Session (Session, loadSession)
+import Tricorder.Session (CabalFile, Session, loadSession)
 
 
 data SessionStore :: Effect where
@@ -103,6 +103,7 @@ runSessionStore
        , Pub SessionStoreReloaded :> es
        , Reader LoadedConfig :> es
        , Reader ProjectRoot :> es
+       , Reader [CabalFile] :> es
        )
     => Eff (SessionStore : es) a -> Eff es a
 runSessionStore act = do

--- a/tricorder/src/Tricorder/Session.hs
+++ b/tricorder/src/Tricorder/Session.hs
@@ -15,6 +15,8 @@ module Tricorder.Session
     , TestTimeout (..)
     , Pattern
     , loadSession
+    , CabalFile (..)
+    , runCabalFiles
     , resolveCommand
     , resolveTargets
     , discoverCabalFiles
@@ -33,6 +35,7 @@ import Atelier.Types.WithDefaults (WithDefaults (..))
 import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Default (Default (..))
 import Data.List (nub)
+import Data.Traversable (for)
 import Distribution.Compat.Lens (view)
 import Distribution.Fields (Field (..), FieldLine (..), Name (..), readFields)
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescriptionMaybe)
@@ -52,10 +55,8 @@ import Distribution.Types.PackageId (pkgName)
 import Distribution.Types.PackageName (unPackageName)
 import Distribution.Types.UnqualComponentName (mkUnqualComponentName, unUnqualComponentName)
 import Distribution.Utils.Path (getSymbolicPath)
-import Effectful.Exception (throwIO)
-import Effectful.Reader.Static (Reader, ask)
+import Effectful.Reader.Static (Reader, ask, runReader)
 import System.FilePath (normalise, takeDirectory, takeExtension, (</>))
-import System.IO.Error (userError)
 import Text.Regex.TDFA.ReadRegex (parseRegex)
 
 import Atelier.Effects.Log qualified as Log
@@ -291,30 +292,30 @@ detectCommand targets (TestTargets testTargets) replBuildDir (ProjectRoot projec
 -- 1. @watch_dirs@ from config, if non-empty (used as-is relative to project root)
 -- 2. @hs-source-dirs@ inferred from cabal targets, if targets are set
 -- 3. Falls back to @["."]@ (project root) if neither is available
-resolveWatchDirs :: (FileSystem :> es) => ProjectRoot -> [FilePath] -> Config -> [Target] -> Eff es WatchDirs
-resolveWatchDirs projectRoot cabalFiles cfg targets =
+resolveWatchDirs :: ProjectRoot -> [CabalFile] -> Config -> [Target] -> WatchDirs
+resolveWatchDirs projectRoot projectFiles cfg targets =
     case cfg.watchDirs of
-        dirs@(_ : _) -> pure $ WatchDirs $ map (coerce projectRoot </>) dirs
-        [] -> resolveWatchDirsFromTargets cabalFiles targets
+        dirs@(_ : _) -> WatchDirs $ map (coerce projectRoot </>) dirs
+        [] -> resolveWatchDirsFromTargets projectFiles targets
 
 
-resolveWatchDirsFromTargets :: (FileSystem :> es) => [FilePath] -> [Target] -> Eff es WatchDirs
-resolveWatchDirsFromTargets _ [] = pure $ WatchDirs ["."]
-resolveWatchDirsFromTargets cabalFiles targets = do
-    dirs <- nub . concat <$> traverse watchDirsForCabal cabalFiles
-    pure $ WatchDirs $ if null dirs then ["."] else dirs
+resolveWatchDirsFromTargets :: [CabalFile] -> [Target] -> WatchDirs
+resolveWatchDirsFromTargets _ [] = WatchDirs ["."]
+resolveWatchDirsFromTargets projectFiles targets =
+    WatchDirs $ case dirs of
+        [] -> ["."]
+        _ -> dirs
   where
+    dirs = nub . concat $ watchDirsForCabal <$> projectFiles
     -- @hs-source-dirs@ are relative to the package's own directory, so scope
     -- them to the directory holding that package's @.cabal@. In a
     -- single-package project that directory is the project root; in a
     -- multi-package project it's the per-package subdirectory. Targets that
     -- don't belong to this package yield no dirs.
-    watchDirsForCabal cabalFile = do
-        contents <- readFileBs cabalFile
-        let pkgDir = takeDirectory cabalFile
-        pure $ case parseGenericPackageDescriptionMaybe contents of
-            Nothing -> []
-            Just gpd -> map (pkgDir </>) (concatMap (sourceDirsForTarget gpd) targets)
+    watchDirsForCabal projectFile =
+        let pkgDir = takeDirectory projectFile.projectFilePath
+            sourceDirs = sourceDirsForTarget projectFile.projectPackageDescription
+        in  (pkgDir </>) <$> concatMap sourceDirs targets
 
 
 sourceDirsForTarget :: GenericPackageDescription -> Target -> [FilePath]
@@ -391,14 +392,11 @@ sourceDirsForTarget gpd target =
 -- discovered package are auto-detected when no targets are configured. Either
 -- way the result is sorted with 'compareTargets' so libraries come last
 -- [ref:lib_sort_order].
-resolveTargets :: (FileSystem :> es) => [FilePath] -> [Text] -> Eff es [Target]
-resolveTargets _ targets@(_ : _) = pure $ sortBy compareTargets $ map parseTarget targets
+resolveTargets :: [CabalFile] -> [Text] -> [Target]
+resolveTargets _ targets@(_ : _) = sortBy compareTargets $ parseTarget <$> targets
 resolveTargets cabalFiles [] =
-    sortBy compareTargets . concat <$> traverse targetsFromCabal cabalFiles
-  where
-    targetsFromCabal path = do
-        contents <- readFileBs path
-        pure $ maybe [] allComponentTargets (parseGenericPackageDescriptionMaybe contents)
+    sortBy compareTargets
+        $ foldMap (allComponentTargets . (.projectPackageDescription)) cabalFiles
 
 
 -- | [tag:lib_sort_order] When running @cabal repl <package defining custom
@@ -472,7 +470,7 @@ projectPackageEntries :: ByteString -> [FilePath]
 projectPackageEntries contents =
     case readFields contents of
         Left _ -> []
-        Right fields -> filter (notElem '*') (concatMap fromField fields)
+        Right fields -> filter (notElem '*') $ concatMap fromField fields
   where
     fromField (Field (Name _ name) fieldLines)
         | name == "packages" = concatMap fromLine fieldLines
@@ -509,14 +507,39 @@ resolveTestTargets cfg targets = case cfg.testTargets of
     Nothing -> projectTestTargets targets
 
 
-resolveWatchExclusionPatterns :: [Text] -> Eff es WatchExclusionPatterns
+resolveWatchExclusionPatterns :: [Text] -> Either Text WatchExclusionPatterns
 resolveWatchExclusionPatterns rawPatterns = do
-    either (throwIO . userError . show) (pure . WatchExclusionPatterns)
-        $ traverse
-            ( parseRegex
-                . toString
-            )
-            rawPatterns
+    bimap show WatchExclusionPatterns
+        $ traverse (parseRegex . toString) rawPatterns
+
+
+data CabalFile = CabalFile
+    { projectFilePath :: FilePath
+    , projectPackageDescription :: GenericPackageDescription
+    }
+    deriving stock (Show)
+
+
+runCabalFiles
+    :: ( FileSystem :> es
+       , Log :> es
+       , Reader ProjectRoot :> es
+       )
+    => Eff (Reader [CabalFile] : es) a -> Eff es a
+runCabalFiles act = do
+    projectRoot <- ask
+    projectFilePaths <- discoverCabalFiles projectRoot
+    (faileds, packageDescriptions) <-
+        partitionEithers <$> for projectFilePaths \p -> do
+            contents <- readFileBs p
+            case parseGenericPackageDescriptionMaybe contents of
+                Nothing -> pure $ Left p
+                Just gpd -> pure $ Right $ CabalFile p gpd
+    unless (null faileds) do
+        Log.warn
+            $ "Failed to parse .cabal files for the following packages: "
+                <> T.intercalate ", " (toText <$> faileds)
+    runReader packageDescriptions act
 
 
 loadSession
@@ -524,18 +547,34 @@ loadSession
        , Log :> es
        , Reader LoadedConfig :> es
        , Reader ProjectRoot :> es
+       , Reader [CabalFile] :> es
        )
     => Eff es Session
 loadSession = do
     projectRoot <- ask @ProjectRoot
     loadedCfg <- ask
+    projectFiles <- ask
+
     let cfgFile = extractConfig @"session" @Config loadedCfg
-    cabalFiles <- discoverCabalFiles projectRoot
-    effectiveTargets <- resolveTargets cabalFiles cfgFile.targets
-    let testTargets = resolveTestTargets cfgFile effectiveTargets
+        effectiveTargets = resolveTargets projectFiles cfgFile.targets
+        testTargets = resolveTestTargets cfgFile effectiveTargets
+        watchDirs = resolveWatchDirs projectRoot projectFiles cfgFile effectiveTargets
+
+    watchExclusionPatterns <-
+        case resolveWatchExclusionPatterns cfgFile.watchExclusionPatterns of
+            Left err -> do
+                Log.err
+                    $ T.intercalate
+                        "\n"
+                        [ "Failed to parse watch exclusion patterns:"
+                        , err
+                        , "Defaulting to no exclusion patterns."
+                        ]
+                pure $ WatchExclusionPatterns []
+            Right pts -> pure pts
+
     command <- resolveCommand projectRoot cfgFile effectiveTargets testTargets
-    watchDirs <- resolveWatchDirs projectRoot cabalFiles cfgFile effectiveTargets
-    watchExclusionPatterns <- resolveWatchExclusionPatterns cfgFile.watchExclusionPatterns
+
     pure
         $ Session
             { targets = effectiveTargets

--- a/tricorder/test/Unit/Tricorder/SessionSpec.hs
+++ b/tricorder/test/Unit/Tricorder/SessionSpec.hs
@@ -13,7 +13,24 @@ import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 
 import Tricorder.Runtime (ProjectRoot (..))
-import Tricorder.Session (Command (..), ComponentKind (..), Config (..), Target (..), WatchDirs (..), allComponentTargets, compareTargets, discoverCabalFiles, parseTarget, parseTestTargets, resolveCommand, resolveTargets, resolveTestTargets, resolveWatchDirs, sourceDirsForTarget)
+import Tricorder.Session
+    ( CabalFile (..)
+    , Command (..)
+    , ComponentKind (..)
+    , Config (..)
+    , Target (..)
+    , WatchDirs (..)
+    , allComponentTargets
+    , compareTargets
+    , discoverCabalFiles
+    , parseTarget
+    , parseTestTargets
+    , resolveCommand
+    , resolveTargets
+    , resolveTestTargets
+    , resolveWatchDirs
+    , sourceDirsForTarget
+    )
 
 
 spec_Session :: Spec
@@ -136,33 +153,24 @@ testSourceDirsForTarget = do
 
 testAllComponentTargets :: Spec
 testAllComponentTargets = do
-    it "includes the main library as a named Qualified Lib" do
-        allComponentTargets gpd `shouldContain` [Qualified Lib "myapp"]
-
-    it "includes sub-libraries" do
-        allComponentTargets gpd `shouldContain` [Qualified Lib "myapp-utils"]
-
-    it "includes foreign libraries" do
-        allComponentTargets gpd `shouldContain` [Qualified FLib "myapp-flib"]
-
-    it "includes executables" do
-        allComponentTargets gpd `shouldContain` [Qualified Exe "myapp-exe"]
-
-    it "includes test suites" do
-        allComponentTargets gpd `shouldContain` [Qualified Test "myapp-test"]
-
-    it "includes benchmarks" do
-        allComponentTargets gpd `shouldContain` [Qualified Bench "myapp-bench"]
-
     it "returns every component for the fixture" do
         allComponentTargets gpd
-            `shouldBe` [ Qualified Lib "myapp"
-                       , Qualified Lib "myapp-utils"
-                       , Qualified FLib "myapp-flib"
-                       , Qualified Exe "myapp-exe"
-                       , Qualified Test "myapp-test"
-                       , Qualified Bench "myapp-bench"
-                       ]
+            `shouldMatchList` [ Qualified Lib "myapp"
+                              , Qualified Lib "myapp-utils"
+                              , Qualified FLib "myapp-flib"
+                              , Qualified Exe "myapp-exe"
+                              , Qualified Test "myapp-test"
+                              , Qualified Bench "myapp-bench"
+                              ]
+    -- This test ensures `allComponentTargets`' part of the aggregate test.
+    -- [ref:test_resolve_targest_aggregate]
+    it "returns every component for test fixures" do
+        let actual =
+                allComponentTargets
+                    $ fromMaybe (error "failed to parse cabal")
+                    $ parseGenericPackageDescriptionMaybe
+                    $ libTestCabal "pkg-a"
+        actual `shouldMatchList` [Qualified Lib "pkg-a", Qualified Test "pkg-a-test"]
 
 
 -- | Pins the discovery contract: a @cabal.project@ selects per-package
@@ -194,22 +202,12 @@ testResolveTargets :: Spec
 testResolveTargets = do
     describe "when targets are configured" do
         it "returns configured targets as-is without reading any cabal file" do
-            -- The cabal file is absent from the mock FS, so any attempt to read
-            -- it would error; passing the test proves the early return.
-            let actual =
-                    runPureEff
-                        . evalState mempty
-                        . runFileSystemState
-                        $ resolveTargets ["/myapp.cabal"] ["lib:foo", "test:foo-test"]
+            let actual = resolveTargets [] ["lib:foo", "test:foo-test"]
             actual `shouldBe` [Qualified Test "foo-test", Qualified Lib "foo"]
 
     describe "when no targets are configured" do
         it "auto-detects all components from the cabal file" do
-            let actual =
-                    runPureEff
-                        . evalState (Map.singleton "/myapp.cabal" cabalFixture)
-                        . runFileSystemState
-                        $ resolveTargets ["/myapp.cabal"] []
+            let actual = resolveTargets singleCabalFile []
             actual
                 `shouldBe` [ Qualified Bench "myapp-bench"
                            , Qualified Exe "myapp-exe"
@@ -220,31 +218,22 @@ testResolveTargets = do
                            ]
 
         it "surfaces test-suite components so they can be run after a build" do
-            let actual =
-                    runPureEff
-                        . evalState (Map.singleton "/myapp.cabal" cabalFixture)
-                        . runFileSystemState
-                        $ resolveTargets ["/myapp.cabal"] []
+            let actual = resolveTargets singleCabalFile []
             actual `shouldContain` [Qualified Test "myapp-test"]
 
         it "returns no targets when there are no cabal files" do
-            let actual =
-                    runPureEff
-                        . evalState mempty
-                        . runFileSystemState
-                        $ resolveTargets [] []
+            let actual = resolveTargets [] []
             actual `shouldBe` []
 
+        -- [tag: test_resolve_targest_aggregate]
         it "aggregates components across every package (regression: was 0)" do
-            let actual =
-                    runPureEff
-                        . evalState multiPackageFs
-                        . runFileSystemState
-                        $ resolveTargets ["/pkg-a/pkg-a.cabal", "/pkg-b/pkg-b.cabal"] []
-            actual `shouldContain` [Qualified Lib "pkg-a"]
-            actual `shouldContain` [Qualified Lib "pkg-b"]
-            [t | t@(Qualified Test _) <- actual]
-                `shouldBe` [Qualified Test "pkg-a-test", Qualified Test "pkg-b-test"]
+            let actual = resolveTargets multiCabalFiles []
+            actual
+                `shouldMatchList` [ Qualified Test "pkg-a-test"
+                                  , Qualified Test "pkg-b-test"
+                                  , Qualified Lib "pkg-a"
+                                  , Qualified Lib "pkg-b"
+                                  ]
 
 
 testResolveWatchDirs :: Spec
@@ -252,72 +241,46 @@ testResolveWatchDirs = do
     describe "when watch_dirs is set in config" do
         it "uses config dirs relative to project root" do
             let WatchDirs actual =
-                    runPureEff
-                        . evalState mempty
-                        . runFileSystemState
-                        $ resolveWatchDirs pr [] def {watchDirs = ["src", "test"]} []
+                    resolveWatchDirs pr [] def {watchDirs = ["src", "test"]} []
             actual `shouldBe` ["/src", "/test"]
 
     describe "when watch_dirs is not set" do
         it "falls back to [\".\"] when targets list is empty" do
-            let WatchDirs actual =
-                    runPureEff
-                        . evalState mempty
-                        . runFileSystemState
-                        $ resolveWatchDirs pr [] def []
+            let WatchDirs actual = resolveWatchDirs pr [] def []
             actual `shouldBe` ["."]
 
         it "infers source dirs from resolved targets" do
             let WatchDirs actual =
-                    runPureEff
-                        . evalState (Map.singleton "/myapp.cabal" cabalFixture)
-                        . runFileSystemState
-                        $ resolveWatchDirs pr ["/myapp.cabal"] def (mkTargets ["lib:myapp", "test:myapp-test"])
+                    resolveWatchDirs pr singleCabalFile def (mkTargets ["lib:myapp", "test:myapp-test"])
             actual `shouldBe` ["/src", "/test"]
 
         it "falls back to [\".\"] when there are no cabal files" do
             let WatchDirs actual =
-                    runPureEff
-                        . evalState mempty
-                        . runFileSystemState
-                        $ resolveWatchDirs pr [] def (mkTargets ["lib:myapp"])
+                    resolveWatchDirs pr [] def (mkTargets ["lib:myapp"])
             actual `shouldBe` ["."]
 
         -- Sharp edge: an unparseable .cabal yields no source dirs, so resolution
         -- falls back to watching the whole project root. This pins the current
         -- behavior; if it ever changes to something narrower, update this test.
-        it "falls back to [\".\"] when the cabal file cannot be parsed" do
+        it "falls back to [\".\"] when no cabal files are found or parsed" do
             let WatchDirs actual =
-                    runPureEff
-                        . evalState (Map.singleton "/myapp.cabal" malformedCabal)
-                        . runFileSystemState
-                        $ resolveWatchDirs pr ["/myapp.cabal"] def (mkTargets ["lib:myapp"])
+                    resolveWatchDirs pr [] def (mkTargets ["lib:myapp"])
             actual `shouldBe` ["."]
 
     describe "when the project is a multi-package cabal.project" do
         it "infers per-package source dirs, scoped to each package's directory" do
             let WatchDirs actual =
-                    runPureEff
-                        . evalState multiPackageFs
-                        . runFileSystemState
-                        $ resolveWatchDirs
-                            pr
-                            ["/pkg-a/pkg-a.cabal", "/pkg-b/pkg-b.cabal"]
-                            def
-                            (mkTargets ["lib:pkg-a", "test:pkg-a-test", "lib:pkg-b", "test:pkg-b-test"])
+                    resolveWatchDirs
+                        pr
+                        multiCabalFiles
+                        def
+                        (mkTargets ["lib:pkg-a", "test:pkg-a-test", "lib:pkg-b", "test:pkg-b-test"])
             actual
                 `shouldBe` ["/pkg-a/src", "/pkg-a/test", "/pkg-b/src", "/pkg-b/test"]
 
         it "scopes a bare package-name target to that package, ignoring siblings" do
             let WatchDirs actual =
-                    runPureEff
-                        . evalState multiPackageFs
-                        . runFileSystemState
-                        $ resolveWatchDirs
-                            pr
-                            ["/pkg-a/pkg-a.cabal", "/pkg-b/pkg-b.cabal"]
-                            def
-                            (mkTargets ["pkg-a"])
+                    resolveWatchDirs pr multiCabalFiles def (mkTargets ["pkg-a"])
             actual `shouldBe` ["/pkg-a/src", "/pkg-a/test"]
   where
     pr = ProjectRoot "/"
@@ -483,13 +446,30 @@ mkTargets :: [Text] -> [Target]
 mkTargets = map parseTarget
 
 
+multiCabalFiles :: [CabalFile]
+multiCabalFiles =
+    uncurry CabalFile
+        . second
+            ( fromMaybe (error "multiCabalFiles failed to parse")
+                . parseGenericPackageDescriptionMaybe
+            )
+        <$> Map.toList multiPackageCabalFs
+
+
 -- | An in-memory project root with a @cabal.project@ listing two packages,
 -- each in its own subdirectory with a library and a test suite.
 multiPackageFs :: Map FilePath ByteString
 multiPackageFs =
     Map.fromList
         [ ("/cabal.project", "packages:\n  pkg-a\n  pkg-b\n\ntests: True\n")
-        , ("/pkg-a/pkg-a.cabal", libTestCabal "pkg-a")
+        ]
+        `Map.union` multiPackageCabalFs
+
+
+multiPackageCabalFs :: Map FilePath ByteString
+multiPackageCabalFs =
+    Map.fromList
+        [ ("/pkg-a/pkg-a.cabal", libTestCabal "pkg-a")
         , ("/pkg-b/pkg-b.cabal", libTestCabal "pkg-b")
         ]
 
@@ -519,10 +499,12 @@ libTestCabal name =
             ]
 
 
--- | Not a valid @.cabal@ file: @parseGenericPackageDescriptionMaybe@ returns
--- 'Nothing' for it.
-malformedCabal :: ByteString
-malformedCabal = "this is not a cabal file {{{ <<< @@@\n"
+singleCabalFile :: [CabalFile]
+singleCabalFile = [CabalFile "/myapp.cabal" gpdFixture]
+
+
+gpdFixture :: GenericPackageDescription
+gpdFixture = fromMaybe (error "gpdFixture failed to parse") $ parseGenericPackageDescriptionMaybe cabalFixture
 
 
 cabalFixture :: ByteString

--- a/tricorder/tricorder.cabal
+++ b/tricorder/tricorder.cabal
@@ -92,7 +92,8 @@ library tricorder-internal
       TypeFamilies
   ghc-options: -Weverything -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-missing-local-signatures -Wno-missing-import-lists -Wno-implicit-prelude -Wno-unticked-promoted-constructors -Wno-unused-packages -Wno-all-missed-specialisations -Wno-missed-specialisations -fplugin=Effectful.Plugin -threaded
   build-depends:
-      Cabal-syntax >=3.12 && <3.17
+      Cabal >=3.12 && <3.17
+    , Cabal-syntax >=3.12 && <3.17
     , aeson ==2.2.*
     , ansi-terminal ==1.1.*
     , atelier-core ==0.2.*


### PR DESCRIPTION
Depends on https://github.com/atelier-hub/tricorder/pull/233