### PR TITLE
chore: add tagref pre-commit hook and dev shell tool

### DIFF
--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -70,6 +70,12 @@ let
             entry = "${nix-hpack}/bin/nix-hpack";
             pass_filenames = false;
           };
+          # Validate tagref cross-references (no dangling refs / duplicate tags).
+          tagref = {
+            enable = true;
+            entry = "${pkgs.tagref}/bin/tagref check";
+            pass_filenames = false;
+          };
         }
       )
     ];

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -14,6 +14,7 @@ let
       nixfmt
       postgresql
       pre-commit
+      tagref
     ]);
 in
 project.shellFor {


### PR DESCRIPTION
- Add a `tagref check` git-hook to validate cross-references (no dangling refs / duplicate tags)
- Expose the `tagref` binary in the dev shell for local use