### PR TITLE
fix: watch-dir scoping for bare package-name targets

### DIFF
--- a/tricorder/src/Tricorder/BuildState.hs
+++ b/tricorder/src/Tricorder/BuildState.hs
@@ -38,7 +38,7 @@ import System.FilePath (makeRelative)
 
 import Tricorder.Effects.SessionStore (SessionStore)
 import Tricorder.Runtime (LogPath (..), ProjectRoot (..), SocketPath (..))
-import Tricorder.Session (Session (..), Targets (..), WatchDirs (..))
+import Tricorder.Session (Session (..), Target, WatchDirs (..))
 
 import Tricorder.Effects.SessionStore qualified as SessionStore
 import Tricorder.Observability qualified as Observability
@@ -51,7 +51,7 @@ newtype BuildId = BuildId Int
 
 
 data DaemonInfo = DaemonInfo
-    { targets :: [Text]
+    { targets :: [Target]
     , watchDirs :: [FilePath]
     , sockPath :: FilePath
     , logFile :: FilePath
@@ -77,7 +77,7 @@ loadDaemonInfo = do
     LogPath logFile <- ask
     pure
         $ DaemonInfo
-            { targets = session.targets.getTargets
+            { targets = session.targets
             , watchDirs = map (makeRelative projectRoot) session.watchDirs.getWatchDirs
             , sockPath
             , logFile

--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -66,7 +66,7 @@ import Tricorder.Effects.GhciSession.GhciProcess (GhciProcessError (..))
 import Tricorder.Effects.SessionStore (SessionStore)
 import Tricorder.Effects.TestRunner (TestRunner)
 import Tricorder.Runtime (ProjectRoot (..))
-import Tricorder.Session (Command (..), Session (..), Targets, TestTargets (..), WatchDirs)
+import Tricorder.Session (Command (..), Session (..), Target, TestTargets, WatchDirs, getTestTargets, renderTarget)
 
 import Tricorder.Effects.BuildStore qualified as BuildStore
 import Tricorder.Effects.GhciSession qualified as GhciSession
@@ -104,7 +104,7 @@ component =
 -- | A subset of 'Session' with just the properties that 'Builder' cares about.
 data BuildConfig = BuildConfig
     { command :: Command
-    , targets :: Targets
+    , targets :: [Target]
     , testTargets :: TestTargets
     , watchDirs :: WatchDirs
     }
@@ -546,18 +546,21 @@ runTestsIfClean
     -> BuildResult
     -> Eff es (Maybe [TestRun])
 runTestsIfClean (BuildConfig {testTargets}) bid partialResult
-    | null testTargets.getTestTargets || any (\d -> d.severity == SError) partialResult.diagnostics = pure (Just [])
+    | null targetNames || any (\d -> d.severity == SError) partialResult.diagnostics = pure (Just [])
     | otherwise = do
         TestRunner.resetAbort
         setNewPhase
             $ EnteringNewPhase bid
-            $ Testing partialResult {testRuns = map (`TestRunning` Nothing) testTargets.getTestTargets}
+            $ Testing partialResult {testRuns = map (`TestRunning` Nothing) targetNames}
 
-        Log.info $ "Running " <> show (length testTargets.getTestTargets) <> " test suite(s)"
+        Log.info $ "Running " <> show (length targetNames) <> " test suite(s)"
 
-        let initial = (\t -> (t, TestRunning t Nothing)) <$> testTargets.getTestTargets
-        runLoop initial testTargets.getTestTargets
+        let initial = (\t -> (t, TestRunning t Nothing)) <$> targetNames
+        runLoop initial targetNames
   where
+    -- The runner consumes the @test:@ targets as cabal/ghci arguments, so
+    -- render the structured targets to their textual form at this boundary.
+    targetNames = map renderTarget testTargets.getTestTargets
     runLoop acc [] = pure (Just (snd <$> acc))
     runLoop acc (target : rest) = do
         Log.info $ "Running tests: " <> target

--- a/tricorder/src/Tricorder/Session.hs
+++ b/tricorder/src/Tricorder/Session.hs
@@ -33,13 +33,10 @@ import Atelier.Types.WithDefaults (WithDefaults (..))
 import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Default (Default (..))
 import Data.List (nub)
+import Distribution.Compat.Lens (view)
 import Distribution.Fields (Field (..), FieldLine (..), Name (..), readFields)
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescriptionMaybe)
-import Distribution.Types.Benchmark (benchmarkBuildInfo)
-import Distribution.Types.BuildInfo (hsSourceDirs)
 import Distribution.Types.CondTree (condTreeData)
-import Distribution.Types.Executable (buildInfo)
-import Distribution.Types.ForeignLib (foreignLibBuildInfo)
 import Distribution.Types.GenericPackageDescription
     ( GenericPackageDescription
     , condBenchmarks
@@ -50,11 +47,9 @@ import Distribution.Types.GenericPackageDescription
     , condTestSuites
     , packageDescription
     )
-import Distribution.Types.Library (libBuildInfo)
 import Distribution.Types.PackageDescription (package)
 import Distribution.Types.PackageId (pkgName)
 import Distribution.Types.PackageName (unPackageName)
-import Distribution.Types.TestSuite (testBuildInfo)
 import Distribution.Types.UnqualComponentName (mkUnqualComponentName, unUnqualComponentName)
 import Distribution.Utils.Path (getSymbolicPath)
 import Effectful.Exception (throwIO)
@@ -66,6 +61,7 @@ import Text.Regex.TDFA.ReadRegex (parseRegex)
 import Atelier.Effects.Log qualified as Log
 import Data.ByteString.Char8 qualified as BC
 import Data.Text qualified as T
+import Distribution.Types.BuildInfo.Lens qualified as Lens
 import Text.Regex.TDFA.Pattern qualified as Regex
 
 import Tricorder.Runtime (ProjectRoot (..))
@@ -348,18 +344,18 @@ sourceDirsForTarget gpd target =
         Unrecognized raw -> componentSourceDirsByName (T.takeWhileEnd (/= ':') raw)
   where
     mainPkgName = unPackageName . pkgName . package . packageDescription $ gpd
-    libDirs = hsSourceDirs . libBuildInfo
-    flibDirs = hsSourceDirs . foreignLibBuildInfo
-    testDirs = hsSourceDirs . testBuildInfo
-    exeDirs = hsSourceDirs . buildInfo
-    benchDirs = hsSourceDirs . benchmarkBuildInfo
 
-    mainLibSourceDirs = maybe [] (libDirs . condTreeData) (condLibrary gpd)
-    subLibSourceDirs name = dirsForComponent libDirs (condSubLibraries gpd) name
-    flibSourceDirs name = dirsForComponent flibDirs (condForeignLibs gpd) name
-    exeSourceDirs name = dirsForComponent exeDirs (condExecutables gpd) name
-    testSourceDirs name = dirsForComponent testDirs (condTestSuites gpd) name
-    benchSourceDirs name = dirsForComponent benchDirs (condBenchmarks gpd) name
+    -- @hs-source-dirs@ of any component, via the @HasBuildInfo@ lens — one
+    -- accessor that works uniformly across libraries, foreign libs, exes,
+    -- tests, and benchmarks, so we don't repeat a per-kind @buildInfo@ getter.
+    componentDirs component = view Lens.hsSourceDirs component
+
+    mainLibSourceDirs = maybe [] (componentDirs . condTreeData) (condLibrary gpd)
+    subLibSourceDirs name = dirsForComponent (condSubLibraries gpd) name
+    flibSourceDirs name = dirsForComponent (condForeignLibs gpd) name
+    exeSourceDirs name = dirsForComponent (condExecutables gpd) name
+    testSourceDirs name = dirsForComponent (condTestSuites gpd) name
+    benchSourceDirs name = dirsForComponent (condBenchmarks gpd) name
 
     -- Match a component name across every kind. The main library is keyed by
     -- the package name rather than an unqualified component name, so it joins
@@ -378,15 +374,15 @@ sourceDirsForTarget gpd target =
 
     allComponentSourceDirs =
         mainLibSourceDirs
-            <> concatMap (libDirs . condTreeData . snd) (condSubLibraries gpd)
-            <> concatMap (flibDirs . condTreeData . snd) (condForeignLibs gpd)
-            <> concatMap (exeDirs . condTreeData . snd) (condExecutables gpd)
-            <> concatMap (testDirs . condTreeData . snd) (condTestSuites gpd)
-            <> concatMap (benchDirs . condTreeData . snd) (condBenchmarks gpd)
+            <> concatMap (componentDirs . condTreeData . snd) (condSubLibraries gpd)
+            <> concatMap (componentDirs . condTreeData . snd) (condForeignLibs gpd)
+            <> concatMap (componentDirs . condTreeData . snd) (condExecutables gpd)
+            <> concatMap (componentDirs . condTreeData . snd) (condTestSuites gpd)
+            <> concatMap (componentDirs . condTreeData . snd) (condBenchmarks gpd)
 
-    dirsForComponent dirs components name =
+    dirsForComponent components name =
         let ucn = mkUnqualComponentName (toString name)
-        in  concatMap (dirs . condTreeData . snd) $ filter ((== ucn) . fst) components
+        in  concatMap (componentDirs . condTreeData . snd) $ filter ((== ucn) . fst) components
 
 
 -- | Infer the effective targets to build and watch. This is the boundary where

--- a/tricorder/src/Tricorder/Session.hs
+++ b/tricorder/src/Tricorder/Session.hs
@@ -181,8 +181,9 @@ data ComponentKind = Lib | FLib | Exe | Test | Bench
 -- We deliberately model only these canonical prefixes, not cabal's full set of
 -- aliases (@executable@, @test-suite@, …) or its case-folding. Those would mean
 -- hand-mirroring an unexported, internally-inconsistent cabal table; instead an
--- aliased spelling falls to 'Unrecognized' and is passed to cabal verbatim (so
--- the build still works), only forgoing precise watch-dir scoping.
+-- aliased spelling falls to 'Unrecognized', which is still handed to cabal
+-- verbatim for the build and still resolves watch dirs by matching its trailing
+-- component name [ref:alias_name_match].
 kindPrefix :: ComponentKind -> Text
 kindPrefix = \case
     Lib -> "lib"
@@ -336,13 +337,15 @@ sourceDirsForTarget gpd target =
         -- single component by name across the kinds.
         Bare name
             | toString name == mainPkgName -> allComponentSourceDirs
-            | otherwise ->
-                subLibSourceDirs name
-                    <> flibSourceDirs name
-                    <> exeSourceDirs name
-                    <> testSourceDirs name
-                    <> benchSourceDirs name
-        Unrecognized _ -> []
+            | otherwise -> componentSourceDirsByName name
+        -- [tag:alias_name_match] A form we couldn't parse into a kind — a cabal
+        -- alias (@executable:@) or a case variant (@Lib:@). The kind is
+        -- untrustworthy, but cabal component names are unique within a package,
+        -- so we match the trailing name across every kind. This recovers precise
+        -- watch dirs for aliased spellings; worst case we over-match a
+        -- same-named component, never miss one. (The raw string is still handed
+        -- to cabal verbatim for the build.)
+        Unrecognized raw -> componentSourceDirsByName (T.takeWhileEnd (/= ':') raw)
   where
     mainPkgName = unPackageName . pkgName . package . packageDescription $ gpd
     libDirs = hsSourceDirs . libBuildInfo
@@ -357,6 +360,21 @@ sourceDirsForTarget gpd target =
     exeSourceDirs name = dirsForComponent exeDirs (condExecutables gpd) name
     testSourceDirs name = dirsForComponent testDirs (condTestSuites gpd) name
     benchSourceDirs name = dirsForComponent benchDirs (condBenchmarks gpd) name
+
+    -- Match a component name across every kind. The main library is keyed by
+    -- the package name rather than an unqualified component name, so it joins
+    -- in only when @name@ is the package name.
+    componentSourceDirsByName name =
+        mainLibForName name
+            <> subLibSourceDirs name
+            <> flibSourceDirs name
+            <> exeSourceDirs name
+            <> testSourceDirs name
+            <> benchSourceDirs name
+
+    mainLibForName name
+        | toString name == mainPkgName = mainLibSourceDirs
+        | otherwise = []
 
     allComponentSourceDirs =
         mainLibSourceDirs

--- a/tricorder/src/Tricorder/Session.hs
+++ b/tricorder/src/Tricorder/Session.hs
@@ -128,14 +128,15 @@ newtype Command = Command {getCommand :: Text}
 -- | The test suites to run after a clean build. Built only by projecting a
 -- target list onto its @test:@ components via 'projectTestTargets'; the data
 -- constructor is not exported, so a 'TestTargets' can never hold a non-test
--- target.
+-- target [ref:test_targets_invariant].
 newtype TestTargets = TestTargets {getTestTargets :: [Target]}
     deriving stock (Eq, Generic, Show)
     deriving (FromJSON, ToJSON) via [Target]
 
 
--- | Project a target list onto its test suites — the only way to build a
--- 'TestTargets', so the @test:@-only invariant holds by construction.
+-- | [tag:test_targets_invariant] Project a target list onto its test suites —
+-- the only way to build a 'TestTargets', so the @test:@-only invariant holds by
+-- construction.
 projectTestTargets :: [Target] -> TestTargets
 projectTestTargets = TestTargets . filter isTestTarget
   where
@@ -168,9 +169,9 @@ data ComponentKind = Lib | Exe | Test
     deriving stock (Bounded, Enum, Eq, Show)
 
 
--- | The textual prefix cabal uses for each component kind. Single source of
--- truth shared by 'parseTarget' and 'renderTarget' — keep this the only place
--- the prefix strings appear.
+-- | [tag:kind_prefix_sole_source] The textual prefix cabal uses for each
+-- component kind. Single source of truth shared by 'parseTarget' and
+-- 'renderTarget' — keep this the only place the prefix strings appear.
 kindPrefix :: ComponentKind -> Text
 kindPrefix = \case
     Lib -> "lib"
@@ -179,7 +180,7 @@ kindPrefix = \case
 
 
 -- | Parse a kind prefix, derived as the inverse of 'kindPrefix' so the two
--- never drift apart.
+-- never drift apart [ref:kind_prefix_sole_source].
 parseKind :: Text -> Maybe ComponentKind
 parseKind = inverseMap kindPrefix
 
@@ -195,7 +196,8 @@ parseTarget target = case T.splitOn ":" target of
 
 
 -- | Render a 'Target' back to the textual form cabal understands. Inverse of
--- 'parseTarget' (lossless: @parseTarget . renderTarget == id@).
+-- 'parseTarget' (lossless: @parseTarget . renderTarget == id@). Builds prefixes
+-- via 'kindPrefix' rather than hardcoding them [ref:kind_prefix_sole_source].
 renderTarget :: Target -> Text
 renderTarget = \case
     Qualified kind name -> kindPrefix kind <> ":" <> name
@@ -346,7 +348,8 @@ sourceDirsForTarget gpd target =
 -- raw target strings (from config) are parsed into structured 'Target's: the
 -- configured targets are parsed as-is, or all components across every
 -- discovered package are auto-detected when no targets are configured. Either
--- way the result is sorted with 'compareTargets' so libraries come last.
+-- way the result is sorted with 'compareTargets' so libraries come last
+-- [ref:lib_sort_order].
 resolveTargets :: (FileSystem :> es) => [FilePath] -> [Text] -> Eff es [Target]
 resolveTargets _ targets@(_ : _) = pure $ sortBy compareTargets $ map parseTarget targets
 resolveTargets cabalFiles [] =
@@ -357,10 +360,11 @@ resolveTargets cabalFiles [] =
         pure $ maybe [] allComponentTargets (parseGenericPackageDescriptionMaybe contents)
 
 
--- | When running @cabal repl <package defining custom prelude> <other
--- packages...>@, GHCi fails because it attempts to load the provided @Prelude@
--- module before loading the package itself. This is not a problem if the
--- package defining the prelude module is not the first component listed.
+-- | [tag:lib_sort_order] When running @cabal repl <package defining custom
+-- prelude> <other packages...>@, GHCi fails because it attempts to load the
+-- provided @Prelude@ module before loading the package itself. This is not a
+-- problem if the package defining the prelude module is not the first component
+-- listed.
 --
 -- Because of this GHCi quirk, we sort all packages beginning with @lib:@ last.
 -- This is based on the assumption that components defining custom preludes
@@ -453,7 +457,7 @@ allComponentTargets gpd =
 -- | Resolve which test suites to run after a clean build. Either source — the
 -- explicit @test_targets@ config or the build 'targets' — is projected onto its
 -- @test:@ components (see 'projectTestTargets'), so non-test entries are
--- dropped and the result only ever names test suites.
+-- dropped and the result only ever names test suites [ref:test_targets_invariant].
 resolveTestTargets :: Config -> [Target] -> TestTargets
 resolveTestTargets cfg targets = case cfg.testTargets of
     Just explicit -> parseTestTargets explicit

--- a/tricorder/src/Tricorder/Session.hs
+++ b/tricorder/src/Tricorder/Session.hs
@@ -2,8 +2,13 @@ module Tricorder.Session
     ( Session (..)
     , Config (..)
     , Command (..)
-    , Targets (..)
-    , TestTargets (..)
+    , TestTargets
+    , getTestTargets
+    , parseTestTargets
+    , Target (..)
+    , ComponentKind (..)
+    , parseTarget
+    , renderTarget
     , WatchDirs (..)
     , WatchExclusionPatterns (..)
     , ReplBuildDir (..)
@@ -25,7 +30,7 @@ import Atelier.Effects.FileSystem (FileSystem, doesFileExist, listDirectory, rea
 import Atelier.Effects.Log (Log)
 import Atelier.Types.QuietSnake (QuietSnake (..))
 import Atelier.Types.WithDefaults (WithDefaults (..))
-import Data.Aeson (FromJSON, ToJSON)
+import Data.Aeson (FromJSON (..), ToJSON (..))
 import Data.Default (Default (..))
 import Data.List (nub)
 import Distribution.Fields (Field (..), FieldLine (..), Name (..), readFields)
@@ -64,7 +69,7 @@ import Tricorder.Runtime (ProjectRoot (..))
 
 data Session = Session
     { command :: Command
-    , targets :: Targets
+    , targets :: [Target]
     , testTargets :: TestTargets
     , watchDirs :: WatchDirs
     , watchExclusionPatterns :: WatchExclusionPatterns
@@ -80,8 +85,8 @@ instance Default Session where
     def =
         Session
             { command = Command ""
-            , targets = Targets []
-            , testTargets = TestTargets []
+            , targets = []
+            , testTargets = projectTestTargets []
             , watchDirs = WatchDirs []
             , watchExclusionPatterns = WatchExclusionPatterns []
             , replBuildDir = ReplBuildDir "/tmp"
@@ -120,14 +125,90 @@ newtype Command = Command {getCommand :: Text}
     deriving (FromJSON, ToJSON) via Text
 
 
-newtype Targets = Targets {getTargets :: [Text]}
+-- | The test suites to run after a clean build. Built only by projecting a
+-- target list onto its @test:@ components via 'projectTestTargets'; the data
+-- constructor is not exported, so a 'TestTargets' can never hold a non-test
+-- target.
+newtype TestTargets = TestTargets {getTestTargets :: [Target]}
     deriving stock (Eq, Generic, Show)
-    deriving (FromJSON, ToJSON) via [Text]
+    deriving (FromJSON, ToJSON) via [Target]
 
 
-newtype TestTargets = TestTargets {getTestTargets :: [Text]}
-    deriving stock (Eq, Generic, Show)
-    deriving (FromJSON, ToJSON) via [Text]
+-- | Project a target list onto its test suites — the only way to build a
+-- 'TestTargets', so the @test:@-only invariant holds by construction.
+projectTestTargets :: [Target] -> TestTargets
+projectTestTargets = TestTargets . filter isTestTarget
+  where
+    isTestTarget (Qualified Test _) = True
+    isTestTarget _ = False
+
+
+-- | Parse raw target strings (e.g. the @test_targets@ config) and project them
+-- onto their test suites — non-test entries are dropped.
+parseTestTargets :: [Text] -> TestTargets
+parseTestTargets = projectTestTargets . map parseTarget
+
+
+-- | A cabal build target, parsed from its textual @[kind:]name@ form. Used to
+-- resolve which source directories belong to a target.
+data Target
+    = -- | A @kind:name@ reference, e.g. @lib:foo@, @exe:foo@, @test:foo@. An
+      -- empty name with 'Lib' (i.e. @lib:@) denotes the package's main library.
+      Qualified ComponentKind Text
+    | -- | A name with no @kind:@ prefix. Refers either to a package (all of its
+      -- components) or to a single component matched by name.
+      Bare Text
+    | -- | A form we don't recognize: an unknown kind, or extra colons.
+      Unrecognized Text
+    deriving stock (Eq, Show)
+
+
+-- | The kind of cabal component a 'Qualified' target names.
+data ComponentKind = Lib | Exe | Test
+    deriving stock (Bounded, Enum, Eq, Show)
+
+
+-- | The textual prefix cabal uses for each component kind. Single source of
+-- truth shared by 'parseTarget' and 'renderTarget' — keep this the only place
+-- the prefix strings appear.
+kindPrefix :: ComponentKind -> Text
+kindPrefix = \case
+    Lib -> "lib"
+    Exe -> "exe"
+    Test -> "test"
+
+
+-- | Parse a kind prefix, derived as the inverse of 'kindPrefix' so the two
+-- never drift apart.
+parseKind :: Text -> Maybe ComponentKind
+parseKind = inverseMap kindPrefix
+
+
+-- | Classify a target's textual form. The grammar is @[kind:]name@ where
+-- @kind@ is one of @lib@, @exe@, or @test@; anything else (an unknown kind, or
+-- extra colons) is 'Unrecognized'.
+parseTarget :: Text -> Target
+parseTarget target = case T.splitOn ":" target of
+    [prefix, name] | Just kind <- parseKind prefix -> Qualified kind name
+    [name] -> Bare name
+    _ -> Unrecognized target
+
+
+-- | Render a 'Target' back to the textual form cabal understands. Inverse of
+-- 'parseTarget' (lossless: @parseTarget . renderTarget == id@).
+renderTarget :: Target -> Text
+renderTarget = \case
+    Qualified kind name -> kindPrefix kind <> ":" <> name
+    Bare name -> name
+    Unrecognized raw -> raw
+
+
+instance ToJSON Target where
+    toJSON = toJSON . renderTarget
+
+
+instance FromJSON Target where
+    parseJSON = fmap parseTarget . parseJSON
 
 
 newtype WatchDirs = WatchDirs {getWatchDirs :: [FilePath]}
@@ -154,7 +235,7 @@ newtype TestTimeout = TestTimeout {getTestTimeout :: Int}
 -- The @testTargets@ are the discovered @test:@ components; they are appended to
 -- the auto-detected @all@ target (see 'detectCommand'). They are ignored when
 -- the user has pinned an explicit @command@ or explicit @targets@ in config.
-resolveCommand :: (FileSystem :> es) => ProjectRoot -> Config -> Targets -> TestTargets -> Eff es Command
+resolveCommand :: (FileSystem :> es) => ProjectRoot -> Config -> [Target] -> TestTargets -> Eff es Command
 resolveCommand projectRoot cfg targets testTargets =
     case cfg.command of
         Just cmd -> pure $ Command cmd
@@ -174,14 +255,14 @@ resolveCommand projectRoot cfg targets testTargets =
 -- "not loaded" and the session dies — which a naive discovery-order enumeration
 -- triggers but @all@ avoids. Appending already-included test targets is a no-op
 -- (cabal deduplicates).
-detectCommand :: (FileSystem :> es) => Targets -> TestTargets -> FilePath -> ProjectRoot -> Eff es Command
-detectCommand (Targets targets) (TestTargets testTargets) replBuildDir (ProjectRoot projectRoot) = do
+detectCommand :: (FileSystem :> es) => [Target] -> TestTargets -> FilePath -> ProjectRoot -> Eff es Command
+detectCommand targets (TestTargets testTargets) replBuildDir (ProjectRoot projectRoot) = do
     hasCabalProject <- doesFileExist (projectRoot </> "cabal.project")
     cabalFiles <- filter (\f -> takeExtension f == ".cabal") <$> listDirectory projectRoot
     hasStack <- doesFileExist (projectRoot </> "stack.yaml")
     let targetStr
-            | not (null targets) = unwords targets
-            | otherwise = unwords ("all" : testTargets)
+            | not (null targets) = unwords (map renderTarget targets)
+            | otherwise = unwords ("all" : map renderTarget testTargets)
         buildDirFlag = "--builddir " <> toText replBuildDir <> " "
     pure
         if
@@ -197,16 +278,16 @@ detectCommand (Targets targets) (TestTargets testTargets) replBuildDir (ProjectR
 -- 1. @watch_dirs@ from config, if non-empty (used as-is relative to project root)
 -- 2. @hs-source-dirs@ inferred from cabal targets, if targets are set
 -- 3. Falls back to @["."]@ (project root) if neither is available
-resolveWatchDirs :: (FileSystem :> es) => ProjectRoot -> [FilePath] -> Config -> Targets -> Eff es WatchDirs
+resolveWatchDirs :: (FileSystem :> es) => ProjectRoot -> [FilePath] -> Config -> [Target] -> Eff es WatchDirs
 resolveWatchDirs projectRoot cabalFiles cfg targets =
     case cfg.watchDirs of
         dirs@(_ : _) -> pure $ WatchDirs $ map (coerce projectRoot </>) dirs
         [] -> resolveWatchDirsFromTargets cabalFiles targets
 
 
-resolveWatchDirsFromTargets :: (FileSystem :> es) => [FilePath] -> Targets -> Eff es WatchDirs
-resolveWatchDirsFromTargets _ (Targets []) = pure $ WatchDirs ["."]
-resolveWatchDirsFromTargets cabalFiles (Targets targets) = do
+resolveWatchDirsFromTargets :: (FileSystem :> es) => [FilePath] -> [Target] -> Eff es WatchDirs
+resolveWatchDirsFromTargets _ [] = pure $ WatchDirs ["."]
+resolveWatchDirsFromTargets cabalFiles targets = do
     dirs <- nub . concat <$> traverse watchDirsForCabal cabalFiles
     pure $ WatchDirs $ if null dirs then ["."] else dirs
   where
@@ -223,22 +304,22 @@ resolveWatchDirsFromTargets cabalFiles (Targets targets) = do
             Just gpd -> map (pkgDir </>) (concatMap (sourceDirsForTarget gpd) targets)
 
 
-sourceDirsForTarget :: GenericPackageDescription -> Text -> [FilePath]
+sourceDirsForTarget :: GenericPackageDescription -> Target -> [FilePath]
 sourceDirsForTarget gpd target =
-    map getSymbolicPath $ case T.splitOn ":" target of
-        ["lib", ""] -> mainLibSourceDirs
-        ["lib", name]
+    map getSymbolicPath $ case target of
+        Qualified Lib "" -> mainLibSourceDirs
+        Qualified Lib name
             | toString name == mainPkgName -> mainLibSourceDirs
             | otherwise -> subLibSourceDirs name
-        ["test", name] -> testSourceDirs name
-        ["exe", name] -> exeSourceDirs name
+        Qualified Exe name -> exeSourceDirs name
+        Qualified Test name -> testSourceDirs name
         -- A bare target (no @kind:@ prefix) is a package name or a component
         -- name. A package name covers every component; otherwise match a
         -- single component by name across the kinds.
-        [name]
+        Bare name
             | toString name == mainPkgName -> allComponentSourceDirs
             | otherwise -> subLibSourceDirs name <> exeSourceDirs name <> testSourceDirs name
-        _ -> []
+        Unrecognized _ -> []
   where
     mainPkgName = unPackageName . pkgName . package . packageDescription $ gpd
     libDirs = hsSourceDirs . libBuildInfo
@@ -261,13 +342,15 @@ sourceDirsForTarget gpd target =
         in  concatMap (dirs . condTreeData . snd) $ filter ((== ucn) . fst) components
 
 
--- | Infer the effective targets to build and watch.
--- Returns the configured targets as-is, or auto-detects all components across
--- every discovered package when no targets are configured.
-resolveTargets :: (FileSystem :> es) => [FilePath] -> [Text] -> Eff es Targets
-resolveTargets _ targets@(_ : _) = pure $ Targets $ sortBy compareTargets targets
+-- | Infer the effective targets to build and watch. This is the boundary where
+-- raw target strings (from config) are parsed into structured 'Target's: the
+-- configured targets are parsed as-is, or all components across every
+-- discovered package are auto-detected when no targets are configured. Either
+-- way the result is sorted with 'compareTargets' so libraries come last.
+resolveTargets :: (FileSystem :> es) => [FilePath] -> [Text] -> Eff es [Target]
+resolveTargets _ targets@(_ : _) = pure $ sortBy compareTargets $ map parseTarget targets
 resolveTargets cabalFiles [] =
-    Targets . sortBy compareTargets . concat <$> traverse targetsFromCabal cabalFiles
+    sortBy compareTargets . concat <$> traverse targetsFromCabal cabalFiles
   where
     targetsFromCabal path = do
         contents <- readFileBs path
@@ -284,13 +367,14 @@ resolveTargets cabalFiles [] =
 -- usually reside in libraries. If we can then place at least one target that
 -- does not specify a custom prelude a before targets that do, we will prevent
 -- the user from being hit with this rather obscure error message.
-compareTargets :: Text -> Text -> Ordering
+compareTargets :: Target -> Target -> Ordering
 compareTargets a b
     | isLib a && not (isLib b) = GT
     | not (isLib a) && isLib b = LT
-    | otherwise = compare a b
+    | otherwise = compare (renderTarget a) (renderTarget b)
   where
-    isLib = ("lib:" `T.isPrefixOf`)
+    isLib (Qualified Lib _) = True
+    isLib _ = False
 
 
 -- | Locate every package's @.cabal@ file, logging what drove the result. In a
@@ -351,7 +435,7 @@ projectPackageEntries contents =
     fromLine (FieldLine _ bs) = map BC.unpack (BC.words bs)
 
 
-allComponentTargets :: GenericPackageDescription -> [Text]
+allComponentTargets :: GenericPackageDescription -> [Target]
 allComponentTargets gpd =
     mainLibTargets
         ++ subLibTargets
@@ -359,20 +443,21 @@ allComponentTargets gpd =
         ++ testTargets
   where
     mainPkgName = toText $ unPackageName . pkgName . package . packageDescription $ gpd
-    mainLibTargets = maybe [] (const ["lib:" <> mainPkgName]) (condLibrary gpd)
-    subLibTargets = map (\(n, _) -> "lib:" <> toText (unUnqualComponentName n)) (condSubLibraries gpd)
-    exeTargets = map (\(n, _) -> "exe:" <> toText (unUnqualComponentName n)) (condExecutables gpd)
-    testTargets = map (\(n, _) -> "test:" <> toText (unUnqualComponentName n)) (condTestSuites gpd)
+    mainLibTargets = maybe [] (const [Qualified Lib mainPkgName]) (condLibrary gpd)
+    subLibTargets = map (\(n, _) -> Qualified Lib (componentName n)) (condSubLibraries gpd)
+    exeTargets = map (\(n, _) -> Qualified Exe (componentName n)) (condExecutables gpd)
+    testTargets = map (\(n, _) -> Qualified Test (componentName n)) (condTestSuites gpd)
+    componentName = toText . unUnqualComponentName
 
 
--- | Resolve which test suites to run after a clean build.
---
--- When 'testTargets' is set in config, those suites are used directly.
--- Otherwise, all @test:@ components in 'targets' are inferred.
-resolveTestTargets :: Config -> Targets -> TestTargets
+-- | Resolve which test suites to run after a clean build. Either source — the
+-- explicit @test_targets@ config or the build 'targets' — is projected onto its
+-- @test:@ components (see 'projectTestTargets'), so non-test entries are
+-- dropped and the result only ever names test suites.
+resolveTestTargets :: Config -> [Target] -> TestTargets
 resolveTestTargets cfg targets = case cfg.testTargets of
-    Just explicit -> TestTargets explicit
-    Nothing -> TestTargets $ filter ("test:" `T.isPrefixOf`) targets.getTargets
+    Just explicit -> parseTestTargets explicit
+    Nothing -> projectTestTargets targets
 
 
 resolveWatchExclusionPatterns :: [Text] -> Eff es WatchExclusionPatterns

--- a/tricorder/src/Tricorder/Session.hs
+++ b/tricorder/src/Tricorder/Session.hs
@@ -226,26 +226,39 @@ resolveWatchDirsFromTargets cabalFiles (Targets targets) = do
 sourceDirsForTarget :: GenericPackageDescription -> Text -> [FilePath]
 sourceDirsForTarget gpd target =
     map getSymbolicPath $ case T.splitOn ":" target of
-        ["lib", ""] ->
-            maybe [] (libDirs . condTreeData) (condLibrary gpd)
-        ["lib", name] ->
-            let ucn = mkUnqualComponentName (toString name)
-                mainLibName = unPackageName . pkgName . package . packageDescription $ gpd
-            in  if toString name == mainLibName then
-                    maybe [] (libDirs . condTreeData) (condLibrary gpd)
-                else
-                    concatMap (libDirs . condTreeData . snd) $ filter ((== ucn) . fst) (condSubLibraries gpd)
-        ["test", name] ->
-            let ucn = mkUnqualComponentName (toString name)
-            in  concatMap (testDirs . condTreeData . snd) $ filter ((== ucn) . fst) (condTestSuites gpd)
-        ["exe", name] ->
-            let ucn = mkUnqualComponentName (toString name)
-            in  concatMap (exeDirs . condTreeData . snd) $ filter ((== ucn) . fst) (condExecutables gpd)
+        ["lib", ""] -> mainLibSourceDirs
+        ["lib", name]
+            | toString name == mainPkgName -> mainLibSourceDirs
+            | otherwise -> subLibSourceDirs name
+        ["test", name] -> testSourceDirs name
+        ["exe", name] -> exeSourceDirs name
+        -- A bare target (no @kind:@ prefix) is a package name or a component
+        -- name. A package name covers every component; otherwise match a
+        -- single component by name across the kinds.
+        [name]
+            | toString name == mainPkgName -> allComponentSourceDirs
+            | otherwise -> subLibSourceDirs name <> exeSourceDirs name <> testSourceDirs name
         _ -> []
   where
+    mainPkgName = unPackageName . pkgName . package . packageDescription $ gpd
     libDirs = hsSourceDirs . libBuildInfo
     testDirs = hsSourceDirs . testBuildInfo
     exeDirs = hsSourceDirs . buildInfo
+
+    mainLibSourceDirs = maybe [] (libDirs . condTreeData) (condLibrary gpd)
+    subLibSourceDirs name = dirsForComponent libDirs (condSubLibraries gpd) name
+    exeSourceDirs name = dirsForComponent exeDirs (condExecutables gpd) name
+    testSourceDirs name = dirsForComponent testDirs (condTestSuites gpd) name
+
+    allComponentSourceDirs =
+        mainLibSourceDirs
+            <> concatMap (libDirs . condTreeData . snd) (condSubLibraries gpd)
+            <> concatMap (exeDirs . condTreeData . snd) (condExecutables gpd)
+            <> concatMap (testDirs . condTreeData . snd) (condTestSuites gpd)
+
+    dirsForComponent dirs components name =
+        let ucn = mkUnqualComponentName (toString name)
+        in  concatMap (dirs . condTreeData . snd) $ filter ((== ucn) . fst) components
 
 
 -- | Infer the effective targets to build and watch.

--- a/tricorder/src/Tricorder/Session.hs
+++ b/tricorder/src/Tricorder/Session.hs
@@ -35,12 +35,16 @@ import Data.Default (Default (..))
 import Data.List (nub)
 import Distribution.Fields (Field (..), FieldLine (..), Name (..), readFields)
 import Distribution.PackageDescription.Parsec (parseGenericPackageDescriptionMaybe)
+import Distribution.Types.Benchmark (benchmarkBuildInfo)
 import Distribution.Types.BuildInfo (hsSourceDirs)
 import Distribution.Types.CondTree (condTreeData)
 import Distribution.Types.Executable (buildInfo)
+import Distribution.Types.ForeignLib (foreignLibBuildInfo)
 import Distribution.Types.GenericPackageDescription
     ( GenericPackageDescription
+    , condBenchmarks
     , condExecutables
+    , condForeignLibs
     , condLibrary
     , condSubLibraries
     , condTestSuites
@@ -164,19 +168,28 @@ data Target
     deriving stock (Eq, Show)
 
 
--- | The kind of cabal component a 'Qualified' target names.
-data ComponentKind = Lib | Exe | Test
+-- | The kind of cabal component a 'Qualified' target names. Covers every
+-- component kind cabal models (matching @Distribution.Types.ComponentName@).
+data ComponentKind = Lib | FLib | Exe | Test | Bench
     deriving stock (Bounded, Enum, Eq, Show)
 
 
--- | [tag:kind_prefix_sole_source] The textual prefix cabal uses for each
+-- | [tag:kind_prefix_sole_source] The canonical prefix cabal uses for each
 -- component kind. Single source of truth shared by 'parseTarget' and
 -- 'renderTarget' — keep this the only place the prefix strings appear.
+--
+-- We deliberately model only these canonical prefixes, not cabal's full set of
+-- aliases (@executable@, @test-suite@, …) or its case-folding. Those would mean
+-- hand-mirroring an unexported, internally-inconsistent cabal table; instead an
+-- aliased spelling falls to 'Unrecognized' and is passed to cabal verbatim (so
+-- the build still works), only forgoing precise watch-dir scoping.
 kindPrefix :: ComponentKind -> Text
 kindPrefix = \case
     Lib -> "lib"
+    FLib -> "flib"
     Exe -> "exe"
     Test -> "test"
+    Bench -> "bench"
 
 
 -- | Parse a kind prefix, derived as the inverse of 'kindPrefix' so the two
@@ -186,8 +199,9 @@ parseKind = inverseMap kindPrefix
 
 
 -- | Classify a target's textual form. The grammar is @[kind:]name@ where
--- @kind@ is one of @lib@, @exe@, or @test@; anything else (an unknown kind, or
--- extra colons) is 'Unrecognized'.
+-- @kind@ is one of @lib@, @flib@, @exe@, @test@, or @bench@; anything else (an
+-- unknown kind, a cabal alias such as @executable@, or extra colons) is
+-- 'Unrecognized'.
 parseTarget :: Text -> Target
 parseTarget target = case T.splitOn ":" target of
     [prefix, name] | Just kind <- parseKind prefix -> Qualified kind name
@@ -313,31 +327,44 @@ sourceDirsForTarget gpd target =
         Qualified Lib name
             | toString name == mainPkgName -> mainLibSourceDirs
             | otherwise -> subLibSourceDirs name
+        Qualified FLib name -> flibSourceDirs name
         Qualified Exe name -> exeSourceDirs name
         Qualified Test name -> testSourceDirs name
+        Qualified Bench name -> benchSourceDirs name
         -- A bare target (no @kind:@ prefix) is a package name or a component
         -- name. A package name covers every component; otherwise match a
         -- single component by name across the kinds.
         Bare name
             | toString name == mainPkgName -> allComponentSourceDirs
-            | otherwise -> subLibSourceDirs name <> exeSourceDirs name <> testSourceDirs name
+            | otherwise ->
+                subLibSourceDirs name
+                    <> flibSourceDirs name
+                    <> exeSourceDirs name
+                    <> testSourceDirs name
+                    <> benchSourceDirs name
         Unrecognized _ -> []
   where
     mainPkgName = unPackageName . pkgName . package . packageDescription $ gpd
     libDirs = hsSourceDirs . libBuildInfo
+    flibDirs = hsSourceDirs . foreignLibBuildInfo
     testDirs = hsSourceDirs . testBuildInfo
     exeDirs = hsSourceDirs . buildInfo
+    benchDirs = hsSourceDirs . benchmarkBuildInfo
 
     mainLibSourceDirs = maybe [] (libDirs . condTreeData) (condLibrary gpd)
     subLibSourceDirs name = dirsForComponent libDirs (condSubLibraries gpd) name
+    flibSourceDirs name = dirsForComponent flibDirs (condForeignLibs gpd) name
     exeSourceDirs name = dirsForComponent exeDirs (condExecutables gpd) name
     testSourceDirs name = dirsForComponent testDirs (condTestSuites gpd) name
+    benchSourceDirs name = dirsForComponent benchDirs (condBenchmarks gpd) name
 
     allComponentSourceDirs =
         mainLibSourceDirs
             <> concatMap (libDirs . condTreeData . snd) (condSubLibraries gpd)
+            <> concatMap (flibDirs . condTreeData . snd) (condForeignLibs gpd)
             <> concatMap (exeDirs . condTreeData . snd) (condExecutables gpd)
             <> concatMap (testDirs . condTreeData . snd) (condTestSuites gpd)
+            <> concatMap (benchDirs . condTreeData . snd) (condBenchmarks gpd)
 
     dirsForComponent dirs components name =
         let ucn = mkUnqualComponentName (toString name)
@@ -443,14 +470,18 @@ allComponentTargets :: GenericPackageDescription -> [Target]
 allComponentTargets gpd =
     mainLibTargets
         ++ subLibTargets
+        ++ flibTargets
         ++ exeTargets
         ++ testTargets
+        ++ benchTargets
   where
     mainPkgName = toText $ unPackageName . pkgName . package . packageDescription $ gpd
     mainLibTargets = maybe [] (const [Qualified Lib mainPkgName]) (condLibrary gpd)
     subLibTargets = map (\(n, _) -> Qualified Lib (componentName n)) (condSubLibraries gpd)
+    flibTargets = map (\(n, _) -> Qualified FLib (componentName n)) (condForeignLibs gpd)
     exeTargets = map (\(n, _) -> Qualified Exe (componentName n)) (condExecutables gpd)
     testTargets = map (\(n, _) -> Qualified Test (componentName n)) (condTestSuites gpd)
+    benchTargets = map (\(n, _) -> Qualified Bench (componentName n)) (condBenchmarks gpd)
     componentName = toText . unUnqualComponentName
 
 

--- a/tricorder/src/Tricorder/UI/View.hs
+++ b/tricorder/src/Tricorder/UI/View.hs
@@ -47,6 +47,7 @@ import Tricorder.BuildState
     , TestRunCompletion (..)
     , TestRunError (..)
     )
+import Tricorder.Session (Target, renderTarget)
 import Tricorder.TestOutput (stripGhciNoise)
 import Tricorder.UI.Keys (KeyEvent, keybindForRoute, viewKeybindings)
 import Tricorder.UI.Misc (emphasis, err, hBoxSpaced, ok, subtle, vBoxSpaced, warn)
@@ -196,7 +197,7 @@ viewVersion =
         ]
 
 
-viewTargets :: [Text] -> Widget n
+viewTargets :: [Target] -> Widget n
 viewTargets targets =
     hBoxSpaced
         1
@@ -204,7 +205,7 @@ viewTargets targets =
         , if null targets then
             txt "(all)"
           else
-            txtWrap (T.intercalate " " targets)
+            txtWrap (T.intercalate " " (map renderTarget targets))
         ]
 
 

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -68,7 +68,7 @@ import Tricorder.Effects.GhciSession (Controls (..), LoadResult (..), LoadedModu
 import Tricorder.Effects.GhciSession.GhciParser (collectResult, extractTitle, resolveKnownTargets)
 import Tricorder.Effects.TestRunner (TestRunner (..), runTestRunnerScripted)
 import Tricorder.Runtime (ProjectRoot (..))
-import Tricorder.Session (Command (..), Targets (..), TestTargets (..), WatchDirs (..))
+import Tricorder.Session (Command (..), WatchDirs (..), parseTestTargets)
 
 import Tricorder.BuildState qualified as BuildState
 import Tricorder.Builder qualified as Builder
@@ -455,20 +455,20 @@ testCompileLoadResultsIntoBuildResults = do
 testRequestTestRunsForNewBuildResults :: Spec
 testRequestTestRunsForNewBuildResults = do
     describe "when there are no test targets" $ it "should skip testing" do
-        phases <- runTest (TestTargets []) [] expected
+        phases <- runTest (parseTestTargets []) [] expected
         length phases `shouldBe` 1
         phases `shouldMatchList` [EnteringNewPhase (BuildId 1) $ Done expected]
 
     describe "when there are errors" $ it "should skip testing" do
         let expected' = expected {BuildState.diagnostics = [errMsg]}
-        phases <- runTest (TestTargets ["test:foo"]) [] expected'
+        phases <- runTest (parseTestTargets ["test:foo"]) [] expected'
         length phases `shouldBe` 1
         phases `shouldMatchList` [EnteringNewPhase (BuildId 1) $ Done expected']
 
     it "should emit EnteringNewPhase events for each test target" do
         phases <-
             runTest
-                (TestTargets ["test:foo", "test:bar"])
+                (parseTestTargets ["test:foo", "test:bar"])
                 [ Right $ mkTestRun "test:foo"
                 , Right $ mkTestRun "test:bar"
                 ]
@@ -512,8 +512,8 @@ testRequestTestRunsForNewBuildResults = do
                 $ requestTestRunsForNewBuildResults
                     BuildConfig
                         { command = Command ""
-                        , targets = Targets []
-                        , testTargets = TestTargets ["test:foo", "test:bar"]
+                        , targets = []
+                        , testTargets = parseTestTargets ["test:foo", "test:bar"]
                         , watchDirs = WatchDirs []
                         }
                     expected
@@ -538,7 +538,7 @@ testRequestTestRunsForNewBuildResults = do
             $ requestTestRunsForNewBuildResults
                 BuildConfig
                     { command = Command ""
-                    , targets = Targets []
+                    , targets = []
                     , testTargets
                     , watchDirs = WatchDirs []
                     }

--- a/tricorder/test/Unit/Tricorder/SessionSpec.hs
+++ b/tricorder/test/Unit/Tricorder/SessionSpec.hs
@@ -121,7 +121,16 @@ testSourceDirsForTarget = do
                 sourceDirsForTarget gpd (Bare "unknown") `shouldBe` []
 
     describe "Unrecognized" do
-        it "returns an empty list" do
+        it "matches an aliased kind prefix by trailing name" do
+            sourceDirsForTarget gpd (Unrecognized "executable:myapp-exe") `shouldBe` ["app"]
+
+        it "matches a case-variant kind prefix by trailing name" do
+            sourceDirsForTarget gpd (Unrecognized "Test-Suite:myapp-test") `shouldBe` ["test"]
+
+        it "matches the main library when the trailing name is the package name" do
+            sourceDirsForTarget gpd (Unrecognized "library:myapp") `shouldBe` ["src"]
+
+        it "returns an empty list when the trailing name matches no component" do
             sourceDirsForTarget gpd (Unrecognized "bogus:x") `shouldBe` []
 
 

--- a/tricorder/test/Unit/Tricorder/SessionSpec.hs
+++ b/tricorder/test/Unit/Tricorder/SessionSpec.hs
@@ -50,8 +50,8 @@ testParseTarget = do
         it "parses a bench: target" do
             parseTarget "bench:myapp-bench" `shouldBe` Qualified Bench "myapp-bench"
 
-    describe "bare targets" do
-        it "parses a name with no kind prefix as bare" do
+    describe "a name with no kind prefix" do
+        it "parses as bare" do
             parseTarget "myapp" `shouldBe` Bare "myapp"
 
     describe "unrecognized targets" do

--- a/tricorder/test/Unit/Tricorder/SessionSpec.hs
+++ b/tricorder/test/Unit/Tricorder/SessionSpec.hs
@@ -13,21 +13,7 @@ import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 
 import Tricorder.Runtime (ProjectRoot (..))
-import Tricorder.Session
-    ( Command (..)
-    , Config (..)
-    , Targets (..)
-    , TestTargets (..)
-    , WatchDirs (..)
-    , allComponentTargets
-    , compareTargets
-    , discoverCabalFiles
-    , resolveCommand
-    , resolveTargets
-    , resolveTestTargets
-    , resolveWatchDirs
-    , sourceDirsForTarget
-    )
+import Tricorder.Session (Command (..), ComponentKind (..), Config (..), Target (..), WatchDirs (..), allComponentTargets, compareTargets, discoverCabalFiles, parseTarget, parseTestTargets, resolveCommand, resolveTargets, resolveTestTargets, resolveWatchDirs, sourceDirsForTarget)
 
 
 spec_Session :: Spec
@@ -37,72 +23,111 @@ spec_Session = do
     describe "resolveTargets" testResolveTargets
     describe "resolveWatchDirs" testResolveWatchDirs
     describe "resolveTestTargets" testResolveTestTargets
+    describe "parseTarget" testParseTarget
     describe "sourceDirsForTarget" testSourceDirsForTarget
     describe "allComponentTargets" testAllComponentTargets
     describe "compareTargets" testCompareTargets
 
 
+testParseTarget :: Spec
+testParseTarget = do
+    describe "qualified targets" do
+        it "parses lib: as the main library (empty name)" do
+            parseTarget "lib:" `shouldBe` Qualified Lib ""
+
+        it "parses a named lib: target" do
+            parseTarget "lib:myapp-utils" `shouldBe` Qualified Lib "myapp-utils"
+
+        it "parses an exe: target" do
+            parseTarget "exe:myapp-exe" `shouldBe` Qualified Exe "myapp-exe"
+
+        it "parses a test: target" do
+            parseTarget "test:myapp-test" `shouldBe` Qualified Test "myapp-test"
+
+    describe "bare targets" do
+        it "parses a name with no kind prefix as bare" do
+            parseTarget "myapp" `shouldBe` Bare "myapp"
+
+    describe "unrecognized targets" do
+        it "rejects an unknown kind" do
+            parseTarget "bench:myapp-bench" `shouldBe` Unrecognized "bench:myapp-bench"
+
+        it "rejects a form with extra colons" do
+            parseTarget "lib:a:b" `shouldBe` Unrecognized "lib:a:b"
+
+
+-- | These exercise the 'Target' -> dirs resolution directly with constructed
+-- 'Target' values; the string -> 'Target' parsing is covered by 'testParseTarget'.
 testSourceDirsForTarget :: Spec
 testSourceDirsForTarget = do
-    describe "lib:" do
-        it "returns main library source dirs" do
-            sourceDirsForTarget gpd "lib:" `shouldBe` ["src"]
+    describe "Qualified Lib" do
+        context "when the name is empty" do
+            it "returns the main library source dirs" do
+                sourceDirsForTarget gpd (Qualified Lib "") `shouldBe` ["src"]
 
-    describe "lib:<package-name>" do
-        it "returns main library source dirs when name matches package name" do
-            sourceDirsForTarget gpd "lib:myapp" `shouldBe` ["src"]
+        context "when the name matches the package name" do
+            it "returns the main library source dirs" do
+                sourceDirsForTarget gpd (Qualified Lib "myapp") `shouldBe` ["src"]
 
-    describe "lib:<sub-library>" do
-        it "returns sub-library source dirs" do
-            sourceDirsForTarget gpd "lib:myapp-utils" `shouldBe` ["utils"]
+        context "when the name matches a sub-library" do
+            it "returns the sub-library source dirs" do
+                sourceDirsForTarget gpd (Qualified Lib "myapp-utils") `shouldBe` ["utils"]
 
-        it "returns empty list for unknown sub-library" do
-            sourceDirsForTarget gpd "lib:nonexistent" `shouldBe` []
+        context "when the sub-library is unknown" do
+            it "returns an empty list" do
+                sourceDirsForTarget gpd (Qualified Lib "nonexistent") `shouldBe` []
 
-    describe "exe:<name>" do
-        it "returns executable source dirs" do
-            sourceDirsForTarget gpd "exe:myapp-exe" `shouldBe` ["app"]
+    describe "Qualified Exe" do
+        it "returns the executable source dirs" do
+            sourceDirsForTarget gpd (Qualified Exe "myapp-exe") `shouldBe` ["app"]
 
-    describe "test:<name>" do
-        it "returns test suite source dirs" do
-            sourceDirsForTarget gpd "test:myapp-test" `shouldBe` ["test"]
+    describe "Qualified Test" do
+        it "returns the test suite source dirs" do
+            sourceDirsForTarget gpd (Qualified Test "myapp-test") `shouldBe` ["test"]
 
-    describe "bare package name" do
+    describe "Bare (package name)" do
         it "returns every component's source dirs" do
-            sourceDirsForTarget gpd "myapp" `shouldBe` ["src", "utils", "app", "test"]
+            sourceDirsForTarget gpd (Bare "myapp") `shouldBe` ["src", "utils", "app", "test"]
 
-    describe "bare component name" do
-        it "resolves a sub-library by its bare name" do
-            sourceDirsForTarget gpd "myapp-utils" `shouldBe` ["utils"]
+    describe "Bare (component name)" do
+        context "when it names a sub-library" do
+            it "returns the sub-library source dirs" do
+                sourceDirsForTarget gpd (Bare "myapp-utils") `shouldBe` ["utils"]
 
-        it "resolves an executable by its bare name" do
-            sourceDirsForTarget gpd "myapp-exe" `shouldBe` ["app"]
+        context "when it names an executable" do
+            it "returns the executable source dirs" do
+                sourceDirsForTarget gpd (Bare "myapp-exe") `shouldBe` ["app"]
 
-        it "resolves a test suite by its bare name" do
-            sourceDirsForTarget gpd "myapp-test" `shouldBe` ["test"]
+        context "when it names a test suite" do
+            it "returns the test suite source dirs" do
+                sourceDirsForTarget gpd (Bare "myapp-test") `shouldBe` ["test"]
 
-    describe "unknown target" do
-        it "returns empty list" do
-            sourceDirsForTarget gpd "unknown" `shouldBe` []
+        context "when it matches no component" do
+            it "returns an empty list" do
+                sourceDirsForTarget gpd (Bare "unknown") `shouldBe` []
+
+    describe "Unrecognized" do
+        it "returns an empty list" do
+            sourceDirsForTarget gpd (Unrecognized "bench:x") `shouldBe` []
 
 
 testAllComponentTargets :: Spec
 testAllComponentTargets = do
-    it "includes the main library as lib:<package-name>" do
-        allComponentTargets gpd `shouldContain` ["lib:myapp"]
+    it "includes the main library as a named Qualified Lib" do
+        allComponentTargets gpd `shouldContain` [Qualified Lib "myapp"]
 
     it "includes sub-libraries" do
-        allComponentTargets gpd `shouldContain` ["lib:myapp-utils"]
+        allComponentTargets gpd `shouldContain` [Qualified Lib "myapp-utils"]
 
     it "includes executables" do
-        allComponentTargets gpd `shouldContain` ["exe:myapp-exe"]
+        allComponentTargets gpd `shouldContain` [Qualified Exe "myapp-exe"]
 
     it "includes test suites" do
-        allComponentTargets gpd `shouldContain` ["test:myapp-test"]
+        allComponentTargets gpd `shouldContain` [Qualified Test "myapp-test"]
 
     it "returns all four components for the fixture" do
         allComponentTargets gpd
-            `shouldBe` ["lib:myapp", "lib:myapp-utils", "exe:myapp-exe", "test:myapp-test"]
+            `shouldBe` [Qualified Lib "myapp", Qualified Lib "myapp-utils", Qualified Exe "myapp-exe", Qualified Test "myapp-test"]
 
 
 -- | Pins the discovery contract: a @cabal.project@ selects per-package
@@ -136,33 +161,33 @@ testResolveTargets = do
         it "returns configured targets as-is without reading any cabal file" do
             -- The cabal file is absent from the mock FS, so any attempt to read
             -- it would error; passing the test proves the early return.
-            let Targets actual =
+            let actual =
                     runPureEff
                         . evalState mempty
                         . runFileSystemState
                         $ resolveTargets ["/myapp.cabal"] ["lib:foo", "test:foo-test"]
-            actual `shouldBe` ["test:foo-test", "lib:foo"]
+            actual `shouldBe` [Qualified Test "foo-test", Qualified Lib "foo"]
 
     describe "when no targets are configured" do
         it "auto-detects all components from the cabal file" do
-            let Targets actual =
+            let actual =
                     runPureEff
                         . evalState (Map.singleton "/myapp.cabal" cabalFixture)
                         . runFileSystemState
                         $ resolveTargets ["/myapp.cabal"] []
             actual
-                `shouldBe` ["exe:myapp-exe", "test:myapp-test", "lib:myapp", "lib:myapp-utils"]
+                `shouldBe` [Qualified Exe "myapp-exe", Qualified Test "myapp-test", Qualified Lib "myapp", Qualified Lib "myapp-utils"]
 
         it "surfaces test-suite components so they can be run after a build" do
-            let Targets actual =
+            let actual =
                     runPureEff
                         . evalState (Map.singleton "/myapp.cabal" cabalFixture)
                         . runFileSystemState
                         $ resolveTargets ["/myapp.cabal"] []
-            actual `shouldContain` ["test:myapp-test"]
+            actual `shouldContain` [Qualified Test "myapp-test"]
 
         it "returns no targets when there are no cabal files" do
-            let Targets actual =
+            let actual =
                     runPureEff
                         . evalState mempty
                         . runFileSystemState
@@ -170,15 +195,15 @@ testResolveTargets = do
             actual `shouldBe` []
 
         it "aggregates components across every package (regression: was 0)" do
-            let Targets actual =
+            let actual =
                     runPureEff
                         . evalState multiPackageFs
                         . runFileSystemState
                         $ resolveTargets ["/pkg-a/pkg-a.cabal", "/pkg-b/pkg-b.cabal"] []
-            actual `shouldContain` ["lib:pkg-a"]
-            actual `shouldContain` ["lib:pkg-b"]
-            filter ("test:" `T.isPrefixOf`) actual
-                `shouldBe` ["test:pkg-a-test", "test:pkg-b-test"]
+            actual `shouldContain` [Qualified Lib "pkg-a"]
+            actual `shouldContain` [Qualified Lib "pkg-b"]
+            [t | t@(Qualified Test _) <- actual]
+                `shouldBe` [Qualified Test "pkg-a-test", Qualified Test "pkg-b-test"]
 
 
 testResolveWatchDirs :: Spec
@@ -189,7 +214,7 @@ testResolveWatchDirs = do
                     runPureEff
                         . evalState mempty
                         . runFileSystemState
-                        $ resolveWatchDirs pr [] def {watchDirs = ["src", "test"]} (Targets [])
+                        $ resolveWatchDirs pr [] def {watchDirs = ["src", "test"]} []
             actual `shouldBe` ["/src", "/test"]
 
     describe "when watch_dirs is not set" do
@@ -198,7 +223,7 @@ testResolveWatchDirs = do
                     runPureEff
                         . evalState mempty
                         . runFileSystemState
-                        $ resolveWatchDirs pr [] def (Targets [])
+                        $ resolveWatchDirs pr [] def []
             actual `shouldBe` ["."]
 
         it "infers source dirs from resolved targets" do
@@ -206,7 +231,7 @@ testResolveWatchDirs = do
                     runPureEff
                         . evalState (Map.singleton "/myapp.cabal" cabalFixture)
                         . runFileSystemState
-                        $ resolveWatchDirs pr ["/myapp.cabal"] def (Targets ["lib:myapp", "test:myapp-test"])
+                        $ resolveWatchDirs pr ["/myapp.cabal"] def (mkTargets ["lib:myapp", "test:myapp-test"])
             actual `shouldBe` ["/src", "/test"]
 
         it "falls back to [\".\"] when there are no cabal files" do
@@ -214,7 +239,7 @@ testResolveWatchDirs = do
                     runPureEff
                         . evalState mempty
                         . runFileSystemState
-                        $ resolveWatchDirs pr [] def (Targets ["lib:myapp"])
+                        $ resolveWatchDirs pr [] def (mkTargets ["lib:myapp"])
             actual `shouldBe` ["."]
 
         -- Sharp edge: an unparseable .cabal yields no source dirs, so resolution
@@ -225,7 +250,7 @@ testResolveWatchDirs = do
                     runPureEff
                         . evalState (Map.singleton "/myapp.cabal" malformedCabal)
                         . runFileSystemState
-                        $ resolveWatchDirs pr ["/myapp.cabal"] def (Targets ["lib:myapp"])
+                        $ resolveWatchDirs pr ["/myapp.cabal"] def (mkTargets ["lib:myapp"])
             actual `shouldBe` ["."]
 
     describe "when the project is a multi-package cabal.project" do
@@ -238,7 +263,7 @@ testResolveWatchDirs = do
                             pr
                             ["/pkg-a/pkg-a.cabal", "/pkg-b/pkg-b.cabal"]
                             def
-                            (Targets ["lib:pkg-a", "test:pkg-a-test", "lib:pkg-b", "test:pkg-b-test"])
+                            (mkTargets ["lib:pkg-a", "test:pkg-a-test", "lib:pkg-b", "test:pkg-b-test"])
             actual
                 `shouldBe` ["/pkg-a/src", "/pkg-a/test", "/pkg-b/src", "/pkg-b/test"]
 
@@ -251,7 +276,7 @@ testResolveWatchDirs = do
                             pr
                             ["/pkg-a/pkg-a.cabal", "/pkg-b/pkg-b.cabal"]
                             def
-                            (Targets ["pkg-a"])
+                            (mkTargets ["pkg-a"])
             actual `shouldBe` ["/pkg-a/src", "/pkg-a/test"]
   where
     pr = ProjectRoot "/"
@@ -261,23 +286,23 @@ testResolveTestTargets :: Spec
 testResolveTestTargets = do
     it "infers test: components from targets when testTargets is absent" do
         let cfg = def :: Config
-        resolveTestTargets cfg (Targets ["lib:mylib", "test:mylib-test"]) `shouldBe` TestTargets ["test:mylib-test"]
+        resolveTestTargets cfg (mkTargets ["lib:mylib", "test:mylib-test"]) `shouldBe` parseTestTargets ["test:mylib-test"]
 
     it "returns empty list when no test: components in targets" do
         let cfg = def :: Config
-        resolveTestTargets cfg (Targets ["lib:mylib", "exe:myapp"]) `shouldBe` TestTargets []
+        resolveTestTargets cfg (mkTargets ["lib:mylib", "exe:myapp"]) `shouldBe` parseTestTargets []
 
     it "uses explicit testTargets list when set" do
         let cfg = def {testTargets = Just ["test:b-test"]} :: Config
-        resolveTestTargets cfg (Targets ["lib:a", "test:a-test", "test:b-test"]) `shouldBe` TestTargets ["test:b-test"]
+        resolveTestTargets cfg (mkTargets ["lib:a", "test:a-test", "test:b-test"]) `shouldBe` parseTestTargets ["test:b-test"]
 
     it "returns empty list when testTargets is explicitly empty" do
         let cfg = def {testTargets = Just []} :: Config
-        resolveTestTargets cfg (Targets ["lib:a", "test:a-test"]) `shouldBe` TestTargets []
+        resolveTestTargets cfg (mkTargets ["lib:a", "test:a-test"]) `shouldBe` parseTestTargets []
 
     it "infers multiple test: components" do
         let cfg = def :: Config
-        resolveTestTargets cfg (Targets ["lib:a", "test:a-test", "test:b-test"]) `shouldBe` TestTargets ["test:a-test", "test:b-test"]
+        resolveTestTargets cfg (mkTargets ["lib:a", "test:a-test", "test:b-test"]) `shouldBe` parseTestTargets ["test:a-test", "test:b-test"]
 
 
 testResolveCommand :: Spec
@@ -288,7 +313,7 @@ testResolveCommand = do
                     runPureEff
                         . evalState mempty
                         . runFileSystemState
-                        $ resolveCommand pr def {command = Just "foo"} (Targets []) testTargets
+                        $ resolveCommand pr def {command = Just "foo"} [] testTargets
             actual `shouldBe` "foo"
 
     describe "when config has explicit targets" do
@@ -297,7 +322,7 @@ testResolveCommand = do
                     runPureEff
                         . evalState (Map.singleton "/cabal.project" "")
                         . runFileSystemState
-                        $ resolveCommand pr cfg (Targets ["lib:foo"]) testTargets
+                        $ resolveCommand pr cfg (mkTargets ["lib:foo"]) testTargets
             actual `shouldBe` "cabal repl --enable-multi-repl --builddir /replbuild lib:foo"
 
     describe "when config does not have a command or targets" do
@@ -307,7 +332,7 @@ testResolveCommand = do
                         runPureEff
                             . evalState (Map.singleton "/cabal.project" "")
                             . runFileSystemState
-                            $ resolveCommand pr cfg (Targets []) testTargets
+                            $ resolveCommand pr cfg [] testTargets
                 actual
                     `shouldBe` "cabal repl --enable-multi-repl --builddir /replbuild all test:foo"
 
@@ -317,7 +342,7 @@ testResolveCommand = do
                         runPureEff
                             . evalState (Map.singleton "/foo.cabal" "")
                             . runFileSystemState
-                            $ resolveCommand pr cfg (Targets []) testTargets
+                            $ resolveCommand pr cfg [] testTargets
                 actual
                     `shouldBe` "cabal repl --enable-multi-repl --builddir /replbuild all test:foo"
 
@@ -327,7 +352,7 @@ testResolveCommand = do
                         runPureEff
                             . evalState (Map.singleton "/stack.yaml" "")
                             . runFileSystemState
-                            $ resolveCommand pr cfg (Targets []) testTargets
+                            $ resolveCommand pr cfg [] testTargets
                 actual `shouldBe` "stack ghci all test:foo"
 
         describe "but there are no project files" do
@@ -336,7 +361,7 @@ testResolveCommand = do
                         runPureEff
                             . evalState mempty
                             . runFileSystemState
-                            $ resolveCommand pr cfg (Targets []) testTargets
+                            $ resolveCommand pr cfg [] testTargets
                 actual `shouldBe` "cabal repl --builddir /replbuild all test:foo"
 
         describe "and no test targets are discovered" do
@@ -345,12 +370,12 @@ testResolveCommand = do
                         runPureEff
                             . evalState (Map.singleton "/cabal.project" "")
                             . runFileSystemState
-                            $ resolveCommand pr cfg (Targets []) (TestTargets [])
+                            $ resolveCommand pr cfg [] (parseTestTargets [])
                 actual `shouldBe` "cabal repl --enable-multi-repl --builddir /replbuild all"
   where
     pr = ProjectRoot "/"
     cfg = def {replBuildDir = "/replbuild"}
-    testTargets = TestTargets ["test:foo"]
+    testTargets = parseTestTargets ["test:foo"]
 
 
 testCompareTargets :: Spec
@@ -359,46 +384,46 @@ testCompareTargets = do
         describe "only first target beginnings with 'lib:'" do
             describe "first target's component name normally sorts as LT" do
                 it "should return GT" do
-                    compareTargets "lib:a" "exe:b" `shouldBe` GT
+                    compareTargets (Qualified Lib "a") (Qualified Exe "b") `shouldBe` GT
             describe "both targets have same component name" do
                 it "should return GT" do
-                    compareTargets "lib:a" "exe:a" `shouldBe` GT
+                    compareTargets (Qualified Lib "a") (Qualified Exe "a") `shouldBe` GT
             describe "first target's component name normally sorts as GT" do
                 it "should return GT" do
-                    compareTargets "lib:b" "exe:a" `shouldBe` GT
+                    compareTargets (Qualified Lib "b") (Qualified Exe "a") `shouldBe` GT
 
         describe "only second target begins with 'lib:'" do
             describe "first target's component name normally sorts as LT" do
                 it "should return LT" do
-                    compareTargets "exe:a" "lib:b" `shouldBe` LT
+                    compareTargets (Qualified Exe "a") (Qualified Lib "b") `shouldBe` LT
             describe "both targets have same component name" do
                 it "should return LT" do
-                    compareTargets "exe:a" "lib:a" `shouldBe` LT
+                    compareTargets (Qualified Exe "a") (Qualified Lib "a") `shouldBe` LT
             describe "first target's component name normally sorts as GT" do
                 it "should return LT" do
-                    compareTargets "exe:b" "lib:a" `shouldBe` LT
+                    compareTargets (Qualified Exe "b") (Qualified Lib "a") `shouldBe` LT
 
         describe "both targets begin with 'lib:'" do
             describe "first target's component name normally sorts as LT" do
                 it "should sort normally" do
-                    compareTargets "lib:a" "lib:b" `shouldBe` LT
+                    compareTargets (Qualified Lib "a") (Qualified Lib "b") `shouldBe` LT
             describe "both targets have same component name" do
                 it "should sort normally" do
-                    compareTargets "lib:a" "lib:a" `shouldBe` EQ
+                    compareTargets (Qualified Lib "a") (Qualified Lib "a") `shouldBe` EQ
             describe "first target's component name normally sorts as GT" do
                 it "should sort normally" do
-                    compareTargets "lib:b" "lib:a" `shouldBe` GT
+                    compareTargets (Qualified Lib "b") (Qualified Lib "a") `shouldBe` GT
 
         describe "neither target begin with 'lib:'" do
             describe "first target's component name normally sorts as LT" do
                 it "should sort normally" do
-                    compareTargets "exe:a" "exe:b" `shouldBe` LT
+                    compareTargets (Qualified Exe "a") (Qualified Exe "b") `shouldBe` LT
             describe "both targets have same component name" do
                 it "should sort normally" do
-                    compareTargets "exe:a" "exe:a" `shouldBe` EQ
+                    compareTargets (Qualified Exe "a") (Qualified Exe "a") `shouldBe` EQ
             describe "first target's component name normally sorts as GT" do
                 it "should sort normally" do
-                    compareTargets "exe:b" "exe:a" `shouldBe` GT
+                    compareTargets (Qualified Exe "b") (Qualified Exe "a") `shouldBe` GT
 
 
 --------------------------------------------------------------------------------
@@ -409,6 +434,12 @@ gpd :: GenericPackageDescription
 gpd =
     fromMaybe (error "cabalFixture failed to parse")
         $ parseGenericPackageDescriptionMaybe cabalFixture
+
+
+-- | Build a target list from textual forms, exactly as config and cabal
+-- discovery do via 'parseTarget'.
+mkTargets :: [Text] -> [Target]
+mkTargets = map parseTarget
 
 
 -- | An in-memory project root with a @cabal.project@ listing two packages,

--- a/tricorder/test/Unit/Tricorder/SessionSpec.hs
+++ b/tricorder/test/Unit/Tricorder/SessionSpec.hs
@@ -38,11 +38,17 @@ testParseTarget = do
         it "parses a named lib: target" do
             parseTarget "lib:myapp-utils" `shouldBe` Qualified Lib "myapp-utils"
 
+        it "parses an flib: target" do
+            parseTarget "flib:myapp-flib" `shouldBe` Qualified FLib "myapp-flib"
+
         it "parses an exe: target" do
             parseTarget "exe:myapp-exe" `shouldBe` Qualified Exe "myapp-exe"
 
         it "parses a test: target" do
             parseTarget "test:myapp-test" `shouldBe` Qualified Test "myapp-test"
+
+        it "parses a bench: target" do
+            parseTarget "bench:myapp-bench" `shouldBe` Qualified Bench "myapp-bench"
 
     describe "bare targets" do
         it "parses a name with no kind prefix as bare" do
@@ -50,7 +56,7 @@ testParseTarget = do
 
     describe "unrecognized targets" do
         it "rejects an unknown kind" do
-            parseTarget "bench:myapp-bench" `shouldBe` Unrecognized "bench:myapp-bench"
+            parseTarget "bogus:myapp" `shouldBe` Unrecognized "bogus:myapp"
 
         it "rejects a form with extra colons" do
             parseTarget "lib:a:b" `shouldBe` Unrecognized "lib:a:b"
@@ -77,6 +83,10 @@ testSourceDirsForTarget = do
             it "returns an empty list" do
                 sourceDirsForTarget gpd (Qualified Lib "nonexistent") `shouldBe` []
 
+    describe "Qualified FLib" do
+        it "returns the foreign-library source dirs" do
+            sourceDirsForTarget gpd (Qualified FLib "myapp-flib") `shouldBe` ["flib"]
+
     describe "Qualified Exe" do
         it "returns the executable source dirs" do
             sourceDirsForTarget gpd (Qualified Exe "myapp-exe") `shouldBe` ["app"]
@@ -85,9 +95,13 @@ testSourceDirsForTarget = do
         it "returns the test suite source dirs" do
             sourceDirsForTarget gpd (Qualified Test "myapp-test") `shouldBe` ["test"]
 
+    describe "Qualified Bench" do
+        it "returns the benchmark source dirs" do
+            sourceDirsForTarget gpd (Qualified Bench "myapp-bench") `shouldBe` ["bench"]
+
     describe "Bare (package name)" do
         it "returns every component's source dirs" do
-            sourceDirsForTarget gpd (Bare "myapp") `shouldBe` ["src", "utils", "app", "test"]
+            sourceDirsForTarget gpd (Bare "myapp") `shouldBe` ["src", "utils", "flib", "app", "test", "bench"]
 
     describe "Bare (component name)" do
         context "when it names a sub-library" do
@@ -108,7 +122,7 @@ testSourceDirsForTarget = do
 
     describe "Unrecognized" do
         it "returns an empty list" do
-            sourceDirsForTarget gpd (Unrecognized "bench:x") `shouldBe` []
+            sourceDirsForTarget gpd (Unrecognized "bogus:x") `shouldBe` []
 
 
 testAllComponentTargets :: Spec
@@ -119,15 +133,27 @@ testAllComponentTargets = do
     it "includes sub-libraries" do
         allComponentTargets gpd `shouldContain` [Qualified Lib "myapp-utils"]
 
+    it "includes foreign libraries" do
+        allComponentTargets gpd `shouldContain` [Qualified FLib "myapp-flib"]
+
     it "includes executables" do
         allComponentTargets gpd `shouldContain` [Qualified Exe "myapp-exe"]
 
     it "includes test suites" do
         allComponentTargets gpd `shouldContain` [Qualified Test "myapp-test"]
 
-    it "returns all four components for the fixture" do
+    it "includes benchmarks" do
+        allComponentTargets gpd `shouldContain` [Qualified Bench "myapp-bench"]
+
+    it "returns every component for the fixture" do
         allComponentTargets gpd
-            `shouldBe` [Qualified Lib "myapp", Qualified Lib "myapp-utils", Qualified Exe "myapp-exe", Qualified Test "myapp-test"]
+            `shouldBe` [ Qualified Lib "myapp"
+                       , Qualified Lib "myapp-utils"
+                       , Qualified FLib "myapp-flib"
+                       , Qualified Exe "myapp-exe"
+                       , Qualified Test "myapp-test"
+                       , Qualified Bench "myapp-bench"
+                       ]
 
 
 -- | Pins the discovery contract: a @cabal.project@ selects per-package
@@ -176,7 +202,13 @@ testResolveTargets = do
                         . runFileSystemState
                         $ resolveTargets ["/myapp.cabal"] []
             actual
-                `shouldBe` [Qualified Exe "myapp-exe", Qualified Test "myapp-test", Qualified Lib "myapp", Qualified Lib "myapp-utils"]
+                `shouldBe` [ Qualified Bench "myapp-bench"
+                           , Qualified Exe "myapp-exe"
+                           , Qualified FLib "myapp-flib"
+                           , Qualified Test "myapp-test"
+                           , Qualified Lib "myapp"
+                           , Qualified Lib "myapp-utils"
+                           ]
 
         it "surfaces test-suite components so they can be run after a build" do
             let actual =
@@ -501,6 +533,12 @@ cabalFixture =
     \  build-depends: base\n\
     \  default-language: Haskell2010\n\
     \\n\
+    \foreign-library myapp-flib\n\
+    \  type: native-shared\n\
+    \  hs-source-dirs: flib\n\
+    \  build-depends: base\n\
+    \  default-language: Haskell2010\n\
+    \\n\
     \executable myapp-exe\n\
     \  main-is: Main.hs\n\
     \  hs-source-dirs: app\n\
@@ -511,5 +549,12 @@ cabalFixture =
     \  type: exitcode-stdio-1.0\n\
     \  main-is: Test.hs\n\
     \  hs-source-dirs: test\n\
+    \  build-depends: base\n\
+    \  default-language: Haskell2010\n\
+    \\n\
+    \benchmark myapp-bench\n\
+    \  type: exitcode-stdio-1.0\n\
+    \  main-is: Bench.hs\n\
+    \  hs-source-dirs: bench\n\
     \  build-depends: base\n\
     \  default-language: Haskell2010\n"

--- a/tricorder/test/Unit/Tricorder/SessionSpec.hs
+++ b/tricorder/test/Unit/Tricorder/SessionSpec.hs
@@ -67,6 +67,20 @@ testSourceDirsForTarget = do
         it "returns test suite source dirs" do
             sourceDirsForTarget gpd "test:myapp-test" `shouldBe` ["test"]
 
+    describe "bare package name" do
+        it "returns every component's source dirs" do
+            sourceDirsForTarget gpd "myapp" `shouldBe` ["src", "utils", "app", "test"]
+
+    describe "bare component name" do
+        it "resolves a sub-library by its bare name" do
+            sourceDirsForTarget gpd "myapp-utils" `shouldBe` ["utils"]
+
+        it "resolves an executable by its bare name" do
+            sourceDirsForTarget gpd "myapp-exe" `shouldBe` ["app"]
+
+        it "resolves a test suite by its bare name" do
+            sourceDirsForTarget gpd "myapp-test" `shouldBe` ["test"]
+
     describe "unknown target" do
         it "returns empty list" do
             sourceDirsForTarget gpd "unknown" `shouldBe` []
@@ -203,6 +217,17 @@ testResolveWatchDirs = do
                         $ resolveWatchDirs pr [] def (Targets ["lib:myapp"])
             actual `shouldBe` ["."]
 
+        -- Sharp edge: an unparseable .cabal yields no source dirs, so resolution
+        -- falls back to watching the whole project root. This pins the current
+        -- behavior; if it ever changes to something narrower, update this test.
+        it "falls back to [\".\"] when the cabal file cannot be parsed" do
+            let WatchDirs actual =
+                    runPureEff
+                        . evalState (Map.singleton "/myapp.cabal" malformedCabal)
+                        . runFileSystemState
+                        $ resolveWatchDirs pr ["/myapp.cabal"] def (Targets ["lib:myapp"])
+            actual `shouldBe` ["."]
+
     describe "when the project is a multi-package cabal.project" do
         it "infers per-package source dirs, scoped to each package's directory" do
             let WatchDirs actual =
@@ -216,6 +241,18 @@ testResolveWatchDirs = do
                             (Targets ["lib:pkg-a", "test:pkg-a-test", "lib:pkg-b", "test:pkg-b-test"])
             actual
                 `shouldBe` ["/pkg-a/src", "/pkg-a/test", "/pkg-b/src", "/pkg-b/test"]
+
+        it "scopes a bare package-name target to that package, ignoring siblings" do
+            let WatchDirs actual =
+                    runPureEff
+                        . evalState multiPackageFs
+                        . runFileSystemState
+                        $ resolveWatchDirs
+                            pr
+                            ["/pkg-a/pkg-a.cabal", "/pkg-b/pkg-b.cabal"]
+                            def
+                            (Targets ["pkg-a"])
+            actual `shouldBe` ["/pkg-a/src", "/pkg-a/test"]
   where
     pr = ProjectRoot "/"
 
@@ -408,6 +445,12 @@ libTestCabal name =
             , "  build-depends: base"
             , "  default-language: Haskell2010"
             ]
+
+
+-- | Not a valid @.cabal@ file: @parseGenericPackageDescriptionMaybe@ returns
+-- 'Nothing' for it.
+malformedCabal :: ByteString
+malformedCabal = "this is not a cabal file {{{ <<< @@@\n"
 
 
 cabalFixture :: ByteString

--- a/tricorder/test/Unit/Tricorder/WatcherSpec.hs
+++ b/tricorder/test/Unit/Tricorder/WatcherSpec.hs
@@ -88,6 +88,16 @@ testMakeWatches = do
             matchesAny watches "/proj/src/Foo.hs" `shouldBe` True
             matchesAny watches "/proj/test/FooSpec.hs" `shouldBe` True
 
+        -- Second line of defense: 'cabalWatches' registers the whole project
+        -- root, and 'deduplicateDirs' collapses the narrow source dirs into it,
+        -- so the OS watches the entire repo recursively. 'matchesAny' is what
+        -- re-scopes events back to the configured dirs — a .hs file in a sibling
+        -- package must not match.
+        it "does not match a .hs file in a sibling package outside the watch dirs" do
+            let watches = makeWatches (ProjectRoot "/proj") (watcherSession ["/proj/pkg-a/src"] [])
+            matchesAny watches "/proj/pkg-a/src/Foo.hs" `shouldBe` True
+            matchesAny watches "/proj/pkg-b/src/Foo.hs" `shouldBe` False
+
     describe "cabal watches" do
         it "matches .cabal files under project root" do
             let watches = makeWatches (ProjectRoot "/proj") emptyWatcherSession


### PR DESCRIPTION
Closes #236 

## Summary

This branch fixes a watch-scoping bug and then - in a separate commit - refactors the surrounding code by replacing stringly-typed cabal targets with a small discriminated union.

The bug: with a config like `session: targets: [atelier-core]`, editing a file in a *sibling* package (e.g. `tricorder/`) triggered a rebuild, even though that file lives outside the `atelier-core` source tree. The cause was that a bare package-name target (no `lib:`/`exe:`/`test:` prefix) fell through `sourceDirsForTarget` to an empty catch-all, so target resolution produced no source dirs and `resolveWatchDirsFromTargets` fell back to `["."]` — watching the whole repo.

## What changed

- **Fix — scope watch dirs for bare package-name targets:** a bare target is now resolved as a package name (all of its components' source dirs) or as a single component matched by name. Added regression coverage for bare package/component names, the sibling-package rejection at the watcher layer, and the unparseable-cabal fallback.
- **Refactor — `Target` ADT:** introduced `Target` (`Qualified ComponentKind Text` / `Bare` / `Unrecognized`) with `parseTarget`/`renderTarget` sharing a single `kindPrefix` core via `inverseMap`, so the parser and printer can't drift apart. `sourceDirsForTarget` now matches on the ADT instead of `T.splitOn ":"` list shapes, and `Unrecognized` makes the old silent fall-through explicit.
- **`TestTargets` is now a guarded projection:** it wraps `[Target]` with an unexported data constructor, so the only ways to build one (`projectTestTargets` / `parseTestTargets`) filter to `test:` components — a `TestTargets` can never hold a non-test target. Both the `test_targets` config override and the derived path go through that projection, and the lib's `parseTestTargets` is reused by the tests rather than re-implemented.

## Behavior change

A non-`test:` entry in the `test_targets` config is now dropped rather than forwarded verbatim to the test runner. No existing behavior relied on this; it only affects misconfigured `test_targets`.