### PR TITLE
fix: terminate whole cabal process group on shutdown

### DIFF
--- a/atelier-core/atelier-core.cabal
+++ b/atelier-core/atelier-core.cabal
@@ -62,6 +62,7 @@ library
       Atelier.Effects.Posix.Daemons
       Atelier.Effects.Posix.IO
       Atelier.Effects.Process
+      Atelier.Effects.Process.Internal
       Atelier.Effects.Publishing
       Atelier.Effects.Tally
       Atelier.Effects.Timeout

--- a/atelier-core/src/Atelier/Effects/Process.hs
+++ b/atelier-core/src/Atelier/Effects/Process.hs
@@ -33,17 +33,21 @@ module Atelier.Effects.Process
     , stopProcess
     , waitExitCode
     , interruptProcessGroup
+    , getProcessId
+    , terminateProcessGroup
 
       -- * Interpreters
     , runProcessIO
     ) where
 
+import Control.Exception (IOException, catch)
 import Effectful (Effect, IOE)
 import Effectful.Dispatch.Dynamic (interpret_)
 import Effectful.Exception (trySync)
 import Effectful.TH (makeEffect)
 import System.Exit (ExitCode (..))
-import System.Process (interruptProcessGroupOf)
+import System.Posix.Signals (sigTERM, signalProcessGroup)
+import System.Process (Pid, getPid, interruptProcessGroupOf)
 import System.Process.Typed
     ( ProcessConfig
     , createPipe
@@ -80,6 +84,18 @@ data Process :: Effect where
     -- | Send an interrupt (SIGINT) to the process's group. Requires the process
     -- to have been started with @'setCreateGroup' True@.
     InterruptProcessGroup :: TP.Process i o e -> Process m ()
+    -- | Look up the OS process id of a started process, or 'Nothing' if it has
+    -- already exited and been reaped. Capture this /before/ waiting on or
+    -- stopping the process if you need to address its group afterwards.
+    GetProcessId :: TP.Process i o e -> Process m (Maybe Pid)
+    -- | Send SIGTERM to an entire process group, identified by the group
+    -- leader's 'Pid'. For a process started with @'setCreateGroup' True@ the
+    -- leader's pid equals its process-group id, so passing its 'getProcessId'
+    -- result terminates the leader and every descendant sharing the group
+    -- (e.g. the build subprocesses @cabal repl@ forks) — not just the leader,
+    -- which is all @'stopProcess'@/@terminateProcess@ would reach. Errors (e.g.
+    -- the group already gone) are swallowed.
+    TerminateProcessGroup :: Pid -> Process m ()
 
 
 makeEffect ''Process
@@ -102,3 +118,6 @@ runProcessIO = interpret_ \case
     StopProcess p -> liftIO $ TP.stopProcess p
     WaitExitCode p -> liftIO $ TP.waitExitCode p
     InterruptProcessGroup p -> liftIO $ interruptProcessGroupOf (TP.unsafeProcessHandle p)
+    GetProcessId p -> liftIO $ getPid (TP.unsafeProcessHandle p)
+    TerminateProcessGroup pid ->
+        liftIO $ signalProcessGroup sigTERM pid `catch` \(_ :: IOException) -> pure ()

--- a/atelier-core/src/Atelier/Effects/Process.hs
+++ b/atelier-core/src/Atelier/Effects/Process.hs
@@ -1,12 +1,13 @@
 -- | Effect for spawning and interacting with external processes.
 --
--- Unifies @typed-process@ (configuration, lifecycle and stream capture) and
--- the one operation only @process@ provides (process-group interruption)
--- behind a single effect, so callers never depend on either package directly.
+-- Unifies @typed-process@ (configuration, lifecycle and stream capture) and the
+-- process-group signalling that @process@ provides behind a single effect, so
+-- callers never depend on either package directly.
 --
--- Build a 'ProcessConfig' with the re-exported @typed-process@ DSL
--- ('proc', 'shell', 'setStdin', …), then run it with one of the operations
--- below.
+-- Build a 'ProcessConfig' with the re-exported @typed-process@ DSL ('proc',
+-- 'shell', 'setStdin', …), then run it with 'withProcessGroup', which runs the
+-- process in its own group and guarantees the /whole group/ is torn down on
+-- exit. Callers never manage pids or process groups themselves.
 module Atelier.Effects.Process
     ( -- * Effect
       Process
@@ -20,7 +21,6 @@ module Atelier.Effects.Process
     , setStdout
     , setStderr
     , setWorkingDir
-    , setCreateGroup
     , createPipe
     , getStdin
     , getStdout
@@ -29,12 +29,10 @@ module Atelier.Effects.Process
       -- * Operations
     , readProcessStdout
     , readProcessSafe
-    , startProcess
-    , stopProcess
-    , waitExitCode
-    , interruptProcessGroup
-    , getProcessId
+    , withProcessGroup
     , terminateProcessGroup
+    , interruptProcessGroup
+    , waitExitCode
 
       -- * Interpreters
     , runProcessIO
@@ -43,7 +41,7 @@ module Atelier.Effects.Process
 import Control.Exception (IOException, catch)
 import Effectful (Effect, IOE)
 import Effectful.Dispatch.Dynamic (interpret_)
-import Effectful.Exception (trySync)
+import Effectful.Exception (bracket, trySync)
 import Effectful.TH (makeEffect)
 import System.Exit (ExitCode (..))
 import System.Posix.Signals (sigTERM, signalProcessGroup)
@@ -75,30 +73,58 @@ type RunningProcess = TP.Process
 data Process :: Effect where
     -- | Run a process to completion, returning its exit code and captured stdout.
     ReadProcessStdout :: ProcessConfig i o e -> Process m (ExitCode, LByteString)
-    -- | Spawn a process and return its handle for further interaction.
+    -- | Spawn a process and return its handle. Internal; callers use 'withProcessGroup'.
     StartProcess :: ProcessConfig i o e -> Process m (TP.Process i o e)
-    -- | Stop a process: close its streams, terminate it, and wait for it to exit.
+    -- | Terminate the leader and close its streams. Internal; does not reach the
+    -- rest of the group.
     StopProcess :: TP.Process i o e -> Process m ()
     -- | Block until the process exits and return its exit code.
     WaitExitCode :: TP.Process i o e -> Process m ExitCode
-    -- | Send an interrupt (SIGINT) to the process's group. Requires the process
-    -- to have been started with @'setCreateGroup' True@.
+    -- | Send SIGINT to the process's group. Requires @'setCreateGroup' True@.
     InterruptProcessGroup :: TP.Process i o e -> Process m ()
-    -- | Look up the OS process id of a started process, or 'Nothing' if it has
-    -- already exited and been reaped. Capture this /before/ waiting on or
-    -- stopping the process if you need to address its group afterwards.
+    -- | Look up the OS process id, or 'Nothing' if it has already exited. Internal.
     GetProcessId :: TP.Process i o e -> Process m (Maybe Pid)
-    -- | Send SIGTERM to an entire process group, identified by the group
-    -- leader's 'Pid'. For a process started with @'setCreateGroup' True@ the
-    -- leader's pid equals its process-group id, so passing its 'getProcessId'
-    -- result terminates the leader and every descendant sharing the group
-    -- (e.g. the build subprocesses @cabal repl@ forks) — not just the leader,
-    -- which is all @'stopProcess'@/@terminateProcess@ would reach. Errors (e.g.
-    -- the group already gone) are swallowed.
-    TerminateProcessGroup :: Pid -> Process m ()
+    -- | Send SIGTERM to the given process group. Internal.
+    SignalProcessGroupTerm :: Pid -> Process m ()
 
 
 makeEffect ''Process
+
+
+-- | Run a process in its own process group, terminating the /whole group/ — the
+-- process and every descendant it spawned — when the body returns or throws.
+--
+-- Cleanup is guaranteed even if the process has already exited. The body may
+-- share the handle so another thread can 'terminateProcessGroup' it early.
+withProcessGroup
+    :: (Process :> es)
+    => ProcessConfig i o e
+    -> (RunningProcess i o e -> Eff es a)
+    -> Eff es a
+withProcessGroup cfg body =
+    bracket acquire release (\(p, _) -> body p)
+  where
+    acquire = do
+        p <- startProcess (setCreateGroup True cfg)
+        pgid <- getProcessId p
+        pure (p, pgid)
+    release (p, pgid) = tearDownGroup pgid p
+
+
+-- | Terminate a running process and its /whole group/ immediately. Use this to
+-- abort a process started with 'withProcessGroup' from another thread — for
+-- children that trap SIGINT, where 'interruptProcessGroup' is not enough.
+terminateProcessGroup :: (Process :> es) => RunningProcess i o e -> Eff es ()
+terminateProcessGroup p = do
+    pgid <- getProcessId p
+    tearDownGroup pgid p
+
+
+-- | SIGTERM the group (if its id is known), then best-effort reap the leader.
+tearDownGroup :: (Process :> es) => Maybe Pid -> RunningProcess i o e -> Eff es ()
+tearDownGroup pgid p = do
+    maybe (pure ()) signalProcessGroupTerm pgid
+    void $ trySync $ stopProcess p
 
 
 -- | Run @cmd@ with @args@ and return its stdout as 'Text', or 'Nothing' on any
@@ -119,5 +145,5 @@ runProcessIO = interpret_ \case
     WaitExitCode p -> liftIO $ TP.waitExitCode p
     InterruptProcessGroup p -> liftIO $ interruptProcessGroupOf (TP.unsafeProcessHandle p)
     GetProcessId p -> liftIO $ getPid (TP.unsafeProcessHandle p)
-    TerminateProcessGroup pid ->
+    SignalProcessGroupTerm pid ->
         liftIO $ signalProcessGroup sigTERM pid `catch` \(_ :: IOException) -> pure ()

--- a/atelier-core/src/Atelier/Effects/Process.hs
+++ b/atelier-core/src/Atelier/Effects/Process.hs
@@ -49,9 +49,6 @@ import System.Process (Pid, getPid, interruptProcessGroupOf)
 import System.Process.Typed
     ( ProcessConfig
     , createPipe
-    , getStderr
-    , getStdin
-    , getStdout
     , proc
     , setCreateGroup
     , setStderr
@@ -63,27 +60,38 @@ import System.Process.Typed
 
 import System.Process.Typed qualified as TP
 
+import Atelier.Effects.Process.Internal (RunningProcess (..))
 
--- | @typed-process@'s started-process type, re-exported under a non-clashing
--- name (the effect itself is called 'Process'). Parameterised by its stdin,
--- stdout and stderr stream types.
-type RunningProcess = TP.Process
+
+-- | The process's stdin stream (its type set by the 'ProcessConfig').
+getStdin :: RunningProcess i o e -> i
+getStdin (RunningProcess p) = TP.getStdin p
+
+
+-- | The process's stdout stream.
+getStdout :: RunningProcess i o e -> o
+getStdout (RunningProcess p) = TP.getStdout p
+
+
+-- | The process's stderr stream.
+getStderr :: RunningProcess i o e -> e
+getStderr (RunningProcess p) = TP.getStderr p
 
 
 data Process :: Effect where
     -- | Run a process to completion, returning its exit code and captured stdout.
     ReadProcessStdout :: ProcessConfig i o e -> Process m (ExitCode, LByteString)
     -- | Spawn a process and return its handle. Internal; callers use 'withProcessGroup'.
-    StartProcess :: ProcessConfig i o e -> Process m (TP.Process i o e)
+    StartProcess :: ProcessConfig i o e -> Process m (RunningProcess i o e)
     -- | Terminate the leader and close its streams. Internal; does not reach the
     -- rest of the group.
-    StopProcess :: TP.Process i o e -> Process m ()
+    StopProcess :: RunningProcess i o e -> Process m ()
     -- | Block until the process exits and return its exit code.
-    WaitExitCode :: TP.Process i o e -> Process m ExitCode
+    WaitExitCode :: RunningProcess i o e -> Process m ExitCode
     -- | Send SIGINT to the process's group. Requires @'setCreateGroup' True@.
-    InterruptProcessGroup :: TP.Process i o e -> Process m ()
+    InterruptProcessGroup :: RunningProcess i o e -> Process m ()
     -- | Look up the OS process id, or 'Nothing' if it has already exited. Internal.
-    GetProcessId :: TP.Process i o e -> Process m (Maybe Pid)
+    GetProcessId :: RunningProcess i o e -> Process m (Maybe Pid)
     -- | Send SIGTERM to the given process group. Internal.
     SignalProcessGroupTerm :: Pid -> Process m ()
 
@@ -140,10 +148,10 @@ readProcessSafe cmd args = do
 runProcessIO :: (IOE :> es) => Eff (Process : es) a -> Eff es a
 runProcessIO = interpret_ \case
     ReadProcessStdout cfg -> liftIO $ TP.readProcessStdout cfg
-    StartProcess cfg -> liftIO $ TP.startProcess cfg
-    StopProcess p -> liftIO $ TP.stopProcess p
-    WaitExitCode p -> liftIO $ TP.waitExitCode p
-    InterruptProcessGroup p -> liftIO $ interruptProcessGroupOf (TP.unsafeProcessHandle p)
-    GetProcessId p -> liftIO $ getPid (TP.unsafeProcessHandle p)
+    StartProcess cfg -> liftIO $ RunningProcess <$> TP.startProcess cfg
+    StopProcess (RunningProcess p) -> liftIO $ TP.stopProcess p
+    WaitExitCode (RunningProcess p) -> liftIO $ TP.waitExitCode p
+    InterruptProcessGroup (RunningProcess p) -> liftIO $ interruptProcessGroupOf (TP.unsafeProcessHandle p)
+    GetProcessId (RunningProcess p) -> liftIO $ getPid (TP.unsafeProcessHandle p)
     SignalProcessGroupTerm pid ->
         liftIO $ signalProcessGroup sigTERM pid `catch` \(_ :: IOException) -> pure ()

--- a/atelier-core/src/Atelier/Effects/Process/Internal.hs
+++ b/atelier-core/src/Atelier/Effects/Process/Internal.hs
@@ -1,0 +1,15 @@
+-- | The 'RunningProcess' constructor, for tests that fabricate a handle.
+--
+-- Constructing one directly bypasses 'Atelier.Effects.Process.withProcessGroup'
+-- and its guarantee that the process heads its own group, so the group-signalling
+-- operations may target the wrong group. Production code should not import this.
+module Atelier.Effects.Process.Internal
+    ( RunningProcess (..)
+    ) where
+
+import System.Process.Typed qualified as TP
+
+
+-- | A process run in its own group by 'Atelier.Effects.Process.withProcessGroup'.
+-- Parameterised by its stdin, stdout and stderr stream types.
+newtype RunningProcess i o e = RunningProcess (TP.Process i o e)

--- a/tricorder/package.nix
+++ b/tricorder/package.nix
@@ -137,6 +137,7 @@ in
         "time-units"
         "typed-process"
         "unagi-chan"
+        "unix"
       ];
     };
   };

--- a/tricorder/src/Tricorder/Effects/GhciSession/GhciProcess.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession/GhciProcess.hs
@@ -10,6 +10,7 @@ module Tricorder.Effects.GhciSession.GhciProcess
     , execGhci
     , interruptGhci
     , terminateGhciProcess
+    , stopGhciProcess
     , collectGhciResult
     , reloadGhci
     , addGhci
@@ -23,6 +24,7 @@ import Atelier.Effects.Process
     ( Process
     , RunningProcess
     , createPipe
+    , getProcessId
     , getStderr
     , getStdin
     , getStdout
@@ -32,6 +34,7 @@ import Atelier.Effects.Process
     , setStdout
     , setWorkingDir
     , shell
+    , terminateProcessGroup
     )
 import Atelier.Effects.Timeout (Timeout, timeout)
 import Control.Concurrent.STM (TVar, modifyTVar', readTVar, retry, writeTVar)
@@ -321,8 +324,18 @@ interruptGhci ghciProcess = do
 -- SIGINT handlers that finalise the current run rather than aborting it.
 -- After this, any 'execGhci' drain raises 'UnexpectedExit' on the now-closed
 -- handles.
+--
+-- Terminates the whole process /group/, not just the leader: @cabal repl@ is
+-- started with @'setCreateGroup' True@ and forks build subprocesses (a worker
+-- @cabal@, @ghc@) that share its group. 'Process.stopProcess' alone signals
+-- only the leader, orphaning those descendants as dangling processes.
 terminateGhciProcess :: (Process :> es) => GhciProcess -> Eff es ()
-terminateGhciProcess ghciProcess = Process.stopProcess ghciProcess.handle
+terminateGhciProcess ghciProcess = do
+    -- Capture the group id before 'stopProcess' reaps the leader (after which
+    -- 'getProcessId' returns 'Nothing'), then signal the whole group.
+    mpid <- getProcessId ghciProcess.handle
+    for_ mpid terminateProcessGroup
+    Process.stopProcess ghciProcess.handle
 
 
 -- | Stop the GHCi process gracefully, falling back to forced termination.
@@ -332,6 +345,11 @@ stopGhciProcess
     :: (File :> es, Process :> es, Timeout :> es)
     => Config -> GhciProcess -> Eff es ()
 stopGhciProcess config ghciProcess = do
+    -- Capture the process-group id up front: once the leader exits (gracefully
+    -- on :quit, or via the force-kill below) and is reaped, 'getProcessId'
+    -- returns 'Nothing' and we can no longer address its group.
+    mpid <- getProcessId ghciProcess.handle
+
     -- Try to write :quit
     void $ trySync $ do
         File.hPutTextLn ghciProcess.stdin ":quit"
@@ -341,6 +359,12 @@ stopGhciProcess config ghciProcess = do
     result <- timeout config.shutdownTimeout (Process.waitExitCode ghciProcess.handle)
     when (not (isJust result))
         $ Process.stopProcess ghciProcess.handle
+
+    -- Even when the GHCi leader exits cleanly on :quit, the build subprocesses
+    -- @cabal repl@ forked (a worker @cabal@, @ghc@) share its process group and
+    -- can outlive it. Signal the whole group so none are left dangling — the
+    -- leader-only 'stopProcess'/:quit above does not reach them.
+    for_ mpid terminateProcessGroup
 
     -- Close all handles, ignoring errors
     for_ [ghciProcess.stdin, ghciProcess.stdout, ghciProcess.stderr] \h ->

--- a/tricorder/src/Tricorder/Effects/GhciSession/GhciProcess.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession/GhciProcess.hs
@@ -10,7 +10,6 @@ module Tricorder.Effects.GhciSession.GhciProcess
     , execGhci
     , interruptGhci
     , terminateGhciProcess
-    , stopGhciProcess
     , collectGhciResult
     , reloadGhci
     , addGhci
@@ -24,17 +23,14 @@ import Atelier.Effects.Process
     ( Process
     , RunningProcess
     , createPipe
-    , getProcessId
     , getStderr
     , getStdin
     , getStdout
-    , setCreateGroup
     , setStderr
     , setStdin
     , setStdout
     , setWorkingDir
     , shell
-    , terminateProcessGroup
     )
 import Atelier.Effects.Timeout (Timeout, timeout)
 import Control.Concurrent.STM (TVar, modifyTVar', readTVar, retry, writeTVar)
@@ -42,7 +38,7 @@ import Data.Default (Default (..))
 import Data.Time.Units (Second)
 import Effectful.Concurrent (Concurrent)
 import Effectful.Concurrent.STM (atomically, newTVarIO)
-import Effectful.Exception (bracket, finally, throwIO, trySync)
+import Effectful.Exception (finally, throwIO, trySync)
 
 import Atelier.Effects.Conc qualified as Conc
 import Atelier.Effects.File qualified as File
@@ -133,21 +129,18 @@ data GhciProcessError
 instance Exception GhciProcessError
 
 
--- | Start a GHCi subprocess running the given command in the given directory.
+-- | Set up the GHCi protocol on an already-started process and return its
+-- handle together with the output captured during startup.
 --
--- Waits up to 'startupTimeout' seconds for GHCi to print its version banner,
--- then performs initial setup (setting prompts and synchronising) and sends
--- any 'extraSetupCommands' from the config.
-startGhciProcess
+-- The spawn and group teardown are owned by 'withGhciProcess'.
+setupGhciProcess
     :: ( Conc :> es
        , Concurrent :> es
        , File :> es
-       , Process :> es
        , Timeout :> es
        )
     => Config
-    -> Command
-    -> FilePath
+    -> RunningProcess Handle Handle Handle
     -> (GhciLoading -> Eff es ())
     -- ^ Called as each @[N of M] Compiling …@ line is streamed during the
     -- initial-build drain, so the UI can update the progress bar live
@@ -158,15 +151,7 @@ startGhciProcess
     -- for interruption while the slow @cabal repl@ startup (dependency build
     -- and recompilation) is still in progress.
     -> Eff es (GhciProcess, [Text])
-startGhciProcess config cmd dir onProgress onReady = do
-    p <-
-        Process.startProcess
-            $ setStdin createPipe
-            $ setStdout createPipe
-            $ setStderr createPipe
-            $ setCreateGroup True
-            $ setWorkingDir dir
-            $ shell (toString cmd.getCommand)
+setupGhciProcess config p onProgress onReady = do
     let inp = getStdin p
         out = getStdout p
         err = getStderr p
@@ -174,11 +159,8 @@ startGhciProcess config cmd dir onProgress onReady = do
     File.hSetBuffering out LineBuffering
     File.hSetBuffering err LineBuffering
 
-    -- Create the state var and the process handle up front, then register the
-    -- process for interruption *before* the (possibly slow) banner wait. For
-    -- @cabal repl@, dependency building happens before GHCi prints its banner,
-    -- so registering here lets an interrupt terminate the process during that
-    -- window rather than having to wait for the whole startup to complete.
+    -- Register the process for interruption before the (possibly slow) banner
+    -- wait, so an interrupt during @cabal repl@ startup can terminate it.
     stateVar <- newTVarIO (Idle 0)
     let ghciProcess =
             GhciProcess
@@ -197,7 +179,7 @@ startGhciProcess config cmd dir onProgress onReady = do
     -- Wait for the version banner. We concurrently capture stderr so that if
     -- the build command exits before printing a banner (e.g. cabal's
     -- dependency resolution fails) we can surface its error output.
-    waitForBannerOrFail config.startupTimeout out err p
+    waitForBannerOrFail config.startupTimeout out err
 
     -- Send fixed setup commands (protocol requirements)
     File.hPutTextLn inp ":set prompt \"\""
@@ -227,17 +209,12 @@ startGhciProcess config cmd dir onProgress onReady = do
     pure (ghciProcess, initialLines)
 
 
--- | Bracket helper: start a GHCi process, run an action, then stop it.
+-- | Run a GHCi @cabal repl@ session for the duration of @action@.
 --
--- The action receives both the process handle and the output lines captured
--- during the startup sync (stdout ++ stderr). These lines contain the initial
--- compilation progress and any startup diagnostics. The @onProgress@ callback
--- fires for each @[N of M] Compiling …@ line as GHCi emits it during the
--- initial build, so the UI can update its progress bar in real time. The
--- @onReady@ callback (see 'startGhciProcess') fires once the underlying
--- process exists but before the banner wait and initial-load drain — useful
--- for registering the process for early termination while @cabal repl@ startup
--- (dependency build and initial compilation) is still in flight.
+-- The session runs in its own process group, so the whole group is torn down on
+-- exit; 'quitGhci' first asks GHCi to @:quit@ for a graceful shutdown. The
+-- action receives the process handle and the output captured during startup.
+-- See 'setupGhciProcess' for the @onProgress@ and @onReady@ callbacks.
 withGhciProcess
     :: (Conc :> es, Concurrent :> es, File :> es, Process :> es, Timeout :> es)
     => Config
@@ -248,10 +225,16 @@ withGhciProcess
     -> (GhciProcess -> [Text] -> Eff es a)
     -> Eff es a
 withGhciProcess config cmd dir onProgress onReady action =
-    bracket
-        (startGhciProcess config cmd dir onProgress onReady)
-        (stopGhciProcess config . fst)
-        (uncurry action)
+    Process.withProcessGroup processConfig \p -> do
+        (ghciProcess, initialLines) <- setupGhciProcess config p onProgress onReady
+        action ghciProcess initialLines `finally` quitGhci config ghciProcess
+  where
+    processConfig =
+        setStdin createPipe
+            $ setStdout createPipe
+            $ setStderr createPipe
+            $ setWorkingDir dir
+            $ shell (toString cmd.getCommand)
 
 
 -- | Execute a command in GHCi and return the combined stdout+stderr output
@@ -316,59 +299,27 @@ interruptGhci ghciProcess = do
             sendSyncCommand ghciProcess.stdin (markerFor n)
 
 
--- | Forcefully terminate the GHCi process, closing its handles.
+-- | Forcefully terminate a GHCi process and its whole group.
 --
--- Stronger than 'interruptGhci': intended for one-shot processes (such as
--- the per-suite @cabal repl test:…@ used by the test runner) where SIGINT
--- is insufficient — test frameworks like @hspec@ and @tasty@ install
--- SIGINT handlers that finalise the current run rather than aborting it.
--- After this, any 'execGhci' drain raises 'UnexpectedExit' on the now-closed
--- handles.
---
--- Terminates the whole process /group/, not just the leader: @cabal repl@ is
--- started with @'setCreateGroup' True@ and forks build subprocesses (a worker
--- @cabal@, @ghc@) that share its group. 'Process.stopProcess' alone signals
--- only the leader, orphaning those descendants as dangling processes.
+-- Stronger than 'interruptGhci': intended for one-shot processes (such as the
+-- per-suite @cabal repl test:…@ used by the test runner) where SIGINT is
+-- insufficient — test frameworks like @hspec@ and @tasty@ install SIGINT
+-- handlers that finalise the current run rather than aborting it. Safe to call
+-- from another thread while the session is running.
 terminateGhciProcess :: (Process :> es) => GhciProcess -> Eff es ()
-terminateGhciProcess ghciProcess = do
-    -- Capture the group id before 'stopProcess' reaps the leader (after which
-    -- 'getProcessId' returns 'Nothing'), then signal the whole group.
-    mpid <- getProcessId ghciProcess.handle
-    for_ mpid terminateProcessGroup
-    Process.stopProcess ghciProcess.handle
+terminateGhciProcess ghciProcess =
+    Process.terminateProcessGroup ghciProcess.handle
 
 
--- | Stop the GHCi process gracefully, falling back to forced termination.
---
--- Never throws — all errors are swallowed.
-stopGhciProcess
-    :: (File :> es, Process :> es, Timeout :> es)
-    => Config -> GhciProcess -> Eff es ()
-stopGhciProcess config ghciProcess = do
-    -- Capture the process-group id up front: once the leader exits (gracefully
-    -- on :quit, or via the force-kill below) and is reaped, 'getProcessId'
-    -- returns 'Nothing' and we can no longer address its group.
-    mpid <- getProcessId ghciProcess.handle
-
-    -- Try to write :quit
+-- | Ask GHCi to @:quit@ and wait briefly for it to exit cleanly, letting it
+-- shut down gracefully before the enclosing 'withGhciProcess' tears down the
+-- group. Never throws.
+quitGhci :: (File :> es, Process :> es, Timeout :> es) => Config -> GhciProcess -> Eff es ()
+quitGhci config ghciProcess = do
     void $ trySync $ do
         File.hPutTextLn ghciProcess.stdin ":quit"
         File.hFlush ghciProcess.stdin
-
-    -- Wait up to shutdownTimeout seconds for the process to exit, then force-kill
-    result <- timeout config.shutdownTimeout (Process.waitExitCode ghciProcess.handle)
-    when (not (isJust result))
-        $ Process.stopProcess ghciProcess.handle
-
-    -- Even when the GHCi leader exits cleanly on :quit, the build subprocesses
-    -- @cabal repl@ forked (a worker @cabal@, @ghc@) share its process group and
-    -- can outlive it. Signal the whole group so none are left dangling — the
-    -- leader-only 'stopProcess'/:quit above does not reach them.
-    for_ mpid terminateProcessGroup
-
-    -- Close all handles, ignoring errors
-    for_ [ghciProcess.stdin, ghciProcess.stdout, ghciProcess.stderr] \h ->
-        void $ trySync $ File.hClose h
+    void $ timeout config.shutdownTimeout (Process.waitExitCode ghciProcess.handle)
 
 
 -- ---------------------------------------------------------------------------
@@ -450,11 +401,10 @@ waitForBannerOrFail
     :: ( Conc :> es
        , Concurrent :> es
        , File :> es
-       , Process :> es
        , Timeout :> es
        )
-    => Second -> Handle -> Handle -> RunningProcess Handle Handle Handle -> Eff es ()
-waitForBannerOrFail delay out err p = do
+    => Second -> Handle -> Handle -> Eff es ()
+waitForBannerOrFail delay out err = do
     capturedVar <- newTVarIO ([] :: [Text])
     let captureLine line = atomically $ modifyTVar' capturedVar (line :)
         drainStderr = drainUntilEof err captureLine
@@ -473,11 +423,9 @@ waitForBannerOrFail delay out err p = do
                 -- the drain happened to have read so far.
                 _ <- timeout (1 :: Second) (Conc.await stderrThread)
                 captured <- atomically $ readTVar capturedVar
-                Process.stopProcess p
                 throwIO $ StartupFailed $ fromMaybe (startupExitedMessage ex) (renderCapturedLines captured)
             Nothing -> do
                 captured <- atomically $ readTVar capturedVar
-                Process.stopProcess p
                 throwIO $ maybe StartupTimeout StartupFailed (renderCapturedLines captured)
 
 

--- a/tricorder/src/Tricorder/Effects/TestRunner.hs
+++ b/tricorder/src/Tricorder/Effects/TestRunner.hs
@@ -120,7 +120,7 @@ runTestRunnerIO act = do
                 Session {testTimeout} <- SessionStore.get
                 let onProgress = abortGatedProgress abortedRef target
                     noProgress = \_ -> pure ()
-                    -- Register the process as soon as 'startGhciProcess'
+                    -- Register the process as soon as 'setupGhciProcess'
                     -- constructs it — before the initial @cabal repl@
                     -- compile drain runs. Without this, an interrupt that
                     -- arrives during that drain would find

--- a/tricorder/test/Unit/Tricorder/Effects/GhciSession/GhciProcessSpec.hs
+++ b/tricorder/test/Unit/Tricorder/Effects/GhciSession/GhciProcessSpec.hs
@@ -6,18 +6,24 @@ import Atelier.Effects.File (runFile)
 import Atelier.Effects.Process (runProcessIO)
 import Atelier.Effects.Timeout (runTimeout)
 import Atelier.Time (Millisecond)
+import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM (newTVarIO)
-import Control.Exception (catch)
+import Control.Exception (IOException, catch, finally)
+import Data.Char (isDigit)
+import Data.Default (def)
 import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Time.Units (Second)
 import Effectful (runEff)
 import Effectful.Concurrent (runConcurrent)
 import Effectful.Exception (trySync)
+import System.IO (hGetLine)
+import System.Posix.Signals (nullSignal, sigKILL, signalProcess)
 import System.Process.Typed
     ( createPipe
     , getStderr
     , getStdin
     , getStdout
+    , setCreateGroup
     , setStderr
     , setStdin
     , setStdout
@@ -33,14 +39,17 @@ import Atelier.Effects.Delay qualified as Delay
 import Atelier.Effects.File qualified as File
 import Data.Text qualified as T
 import System.Process qualified as Process
+import System.Timeout qualified
 
 import Tricorder.Effects.GhciSession.GhciProcess
-    ( GhciProcess (..)
+    ( Config (..)
+    , GhciProcess (..)
     , GhciProcessError (..)
     , InterruptDecision (..)
     , SessionState (..)
     , decideInterrupt
     , execGhci
+    , stopGhciProcess
     , waitForBannerOrFail
     )
 
@@ -52,6 +61,7 @@ spec_GhciProcess = do
     describe "execGhci (stale marker desync)" testExecGhciStaleMarker
     describe "execGhci (sync marker scope independence)" testSyncMarkerScopeIndependent
     describe "waitForBannerOrFail" testWaitForBannerOrFail
+    describe "stopGhciProcess (process group)" testStopGhciKillsGroup
 
 
 -- | Regression for the touch-during-reload desync. Interrupting a *Busy* GHCi
@@ -226,6 +236,88 @@ testWaitForBannerOrFail =
                     (lastLine `T.isInfixOf` msg) `shouldBe` True
                 other ->
                     expectationFailure ("expected StartupFailed, got: " <> show other)
+
+
+-- | Regression for orphaned/zombie build subprocesses on restart and shutdown.
+--
+-- @cabal repl@ is spawned in its own process group ('setCreateGroup' True), and
+-- it forks build subprocesses (a worker @cabal@, @ghc@) that share that group.
+-- 'stopGhciProcess' used to terminate only the group /leader/, so those
+-- descendants were orphaned — exactly the dangling @cabal@ processes seen after
+-- @tricorder stop@ and after a @.cabal@-triggered restart.
+--
+-- We simulate the tree deterministically: a leader that forks a long-lived
+-- child sharing its process group, prints the child's pid, then exits cleanly
+-- once it reads the @:quit@ 'stopGhciProcess' sends (mirroring GHCi quitting
+-- gracefully while a build subprocess lingers). After 'stopGhciProcess', the
+-- child must be gone, not just the leader.
+testStopGhciKillsGroup :: Spec
+testStopGhciKillsGroup =
+    it "terminates the whole process group, not just the leader" do
+        -- Hard wall-clock bound: a regression must surface as a failed
+        -- assertion, never as a hang that stalls the whole suite.
+        outcome <- System.Timeout.timeout (8_000_000) runScenario
+        case outcome of
+            Nothing -> expectationFailure "test timed out (process did not settle)"
+            Just died -> died `shouldBe` True
+  where
+    runScenario :: IO Bool
+    runScenario = do
+        p <-
+            startProcess
+                $ setStdin createPipe
+                $ setStdout createPipe
+                $ setStderr createPipe
+                $ setCreateGroup True
+                $ shell "sleep 30 & echo \"$!\"; read _quit"
+        -- First line on stdout is the long-lived child's pid.
+        childLine <- hGetLine (getStdout p)
+        childPid <-
+            case readMaybe (takeWhile isDigit (dropWhile (not . isDigit) childLine)) of
+                Just pid -> pure (pid :: Int)
+                Nothing -> fail ("could not parse child pid from: " <> show childLine)
+        -- Always reap the child and leader, even if the assertion fails, so a
+        -- regression never leaks the very orphan it is testing for.
+        let cleanup = do
+                ignoring (signalProcess sigKILL (fromIntegral childPid))
+                ignoring (stopProcess p)
+        (`finally` cleanup) do
+            stateVar <- newTVarIO (Idle 0)
+            let gp =
+                    GhciProcess
+                        { stdin = getStdin p
+                        , stdout = getStdout p
+                        , stderr = getStderr p
+                        , handle = p
+                        , stateVar
+                        }
+            runEff
+                . runConcurrent
+                . runTimeout
+                . runDelay
+                . runFile
+                . runConc
+                . runProcessIO
+                $ stopGhciProcess (def {shutdownTimeout = 1}) gp
+            waitForProcessDeath childPid
+
+    ignoring :: IO () -> IO ()
+    ignoring act = act `catch` \(_ :: SomeException) -> pure ()
+
+
+-- | Poll for up to ~3s for the given pid to disappear from the process table.
+-- @signalProcess nullSignal@ is a liveness probe: it throws once the process is
+-- gone (and reaped by init after being orphaned).
+waitForProcessDeath :: Int -> IO Bool
+waitForProcessDeath pid = go (60 :: Int)
+  where
+    go 0 = not <$> alive
+    go n = do
+        a <- alive
+        if not a then pure True else threadDelay 50_000 >> go (n - 1)
+    alive =
+        (signalProcess nullSignal (fromIntegral pid) >> pure True)
+            `catch` \(_ :: IOException) -> pure False
 
 
 testDecideInterrupt :: Spec

--- a/tricorder/test/Unit/Tricorder/Effects/GhciSession/GhciProcessSpec.hs
+++ b/tricorder/test/Unit/Tricorder/Effects/GhciSession/GhciProcessSpec.hs
@@ -3,14 +3,13 @@ module Unit.Tricorder.Effects.GhciSession.GhciProcessSpec (spec_GhciProcess) whe
 import Atelier.Effects.Conc (runConc)
 import Atelier.Effects.Delay (runDelay)
 import Atelier.Effects.File (runFile)
-import Atelier.Effects.Process (runProcessIO)
+import Atelier.Effects.Process (runProcessIO, terminateProcessGroup, withProcessGroup)
 import Atelier.Effects.Timeout (runTimeout)
 import Atelier.Time (Millisecond)
 import Control.Concurrent (threadDelay)
 import Control.Concurrent.STM (newTVarIO)
-import Control.Exception (IOException, catch, finally)
+import Control.Exception (IOException, catch)
 import Data.Char (isDigit)
-import Data.Default (def)
 import Data.IORef (newIORef, readIORef, writeIORef)
 import Data.Time.Units (Second)
 import Effectful (runEff)
@@ -42,14 +41,12 @@ import System.Process qualified as Process
 import System.Timeout qualified
 
 import Tricorder.Effects.GhciSession.GhciProcess
-    ( Config (..)
-    , GhciProcess (..)
+    ( GhciProcess (..)
     , GhciProcessError (..)
     , InterruptDecision (..)
     , SessionState (..)
     , decideInterrupt
     , execGhci
-    , stopGhciProcess
     , waitForBannerOrFail
     )
 
@@ -61,7 +58,8 @@ spec_GhciProcess = do
     describe "execGhci (stale marker desync)" testExecGhciStaleMarker
     describe "execGhci (sync marker scope independence)" testSyncMarkerScopeIndependent
     describe "waitForBannerOrFail" testWaitForBannerOrFail
-    describe "stopGhciProcess (process group)" testStopGhciKillsGroup
+    describe "withProcessGroup (process group)" testWithProcessGroupCleanup
+    describe "terminateProcessGroup (process group)" testTerminateProcessGroup
 
 
 -- | Regression for the touch-during-reload desync. Interrupting a *Busy* GHCi
@@ -192,17 +190,8 @@ testWaitForBannerOrFail =
     it "captures the full stderr output when the command exits before the banner" do
         let lineCount = 200 :: Int
             lastLine = "err line " <> show lineCount
-        -- 'true' exits immediately. We only need it for the 'Process' handle
-        -- that 'waitForBannerOrFail' stops on the failure path; the banner and
-        -- error streams are pipes we drive ourselves, so the timing is
-        -- deterministic rather than a race against the OS pipe buffer.
-        p <-
-            startProcess
-                $ setStdin createPipe
-                $ setStdout createPipe
-                $ setStderr createPipe
-                $ shell "true"
-        _ <- waitExitCode p
+        -- The banner and error streams are pipes we drive ourselves, so the
+        -- timing is deterministic rather than a race against the OS pipe buffer.
         (bannerOut, bannerOutW) <- Process.createPipe
         (errR, errW) <- Process.createPipe
         result <-
@@ -212,7 +201,6 @@ testWaitForBannerOrFail =
                 . runDelay
                 . runFile
                 . runConc
-                . runProcessIO
                 $ do
                     -- No banner will ever arrive: close the write end so the
                     -- wait sees EOF at once and takes the "command exited"
@@ -227,8 +215,7 @@ testWaitForBannerOrFail =
                         for_ [1 .. lineCount] \i ->
                             File.hPutTextLn errW ("err line " <> show i :: Text)
                         File.hClose errW
-                    trySync (waitForBannerOrFail (5 :: Second) bannerOut errR p)
-        _ <- (Right <$> stopProcess p) `catch` \(_ :: SomeException) -> pure (Left ())
+                    trySync (waitForBannerOrFail (5 :: Second) bannerOut errR)
         case result of
             Right () -> expectationFailure "expected waitForBannerOrFail to throw a startup error"
             Left ex -> case fromException ex of
@@ -240,69 +227,91 @@ testWaitForBannerOrFail =
 
 -- | Regression for orphaned/zombie build subprocesses on restart and shutdown.
 --
--- @cabal repl@ is spawned in its own process group ('setCreateGroup' True), and
--- it forks build subprocesses (a worker @cabal@, @ghc@) that share that group.
--- 'stopGhciProcess' used to terminate only the group /leader/, so those
--- descendants were orphaned — exactly the dangling @cabal@ processes seen after
--- @tricorder stop@ and after a @.cabal@-triggered restart.
---
--- We simulate the tree deterministically: a leader that forks a long-lived
--- child sharing its process group, prints the child's pid, then exits cleanly
--- once it reads the @:quit@ 'stopGhciProcess' sends (mirroring GHCi quitting
--- gracefully while a build subprocess lingers). After 'stopGhciProcess', the
--- child must be gone, not just the leader.
-testStopGhciKillsGroup :: Spec
-testStopGhciKillsGroup =
-    it "terminates the whole process group, not just the leader" do
+-- The original leak was on the /graceful/ path: GHCi exits cleanly on @:quit@,
+-- so its leader is reaped, yet the build subprocesses sharing its group linger.
+-- 'withProcessGroup' must still sweep the whole group even after the leader has
+-- gone. We simulate it with a leader that forks a long-lived child sharing its
+-- group and exits on stdin input (mirroring @:quit@); after 'withProcessGroup'
+-- returns, the child must be gone.
+testWithProcessGroupCleanup :: Spec
+testWithProcessGroupCleanup =
+    it "terminates the whole group on exit, even after the leader has exited" do
+        childPidRef <- newIORef (Nothing :: Maybe Int)
+        let scenario =
+                runEff
+                    . runConcurrent
+                    . runTimeout
+                    . runDelay
+                    . runFile
+                    . runConc
+                    . runProcessIO
+                    $ withProcessGroup procConfig \p -> do
+                        -- First stdout line is the long-lived child's pid.
+                        line <- File.hGetLine (getStdout p)
+                        liftIO $ writeIORef childPidRef (parsePid (T.unpack line))
+                        -- Let the leader exit and reap it, so the cleanup runs
+                        -- with the leader already gone — the path the bug needed.
+                        File.hPutTextLn (getStdin p) ""
+                        File.hFlush (getStdin p)
+                        liftIO $ void $ waitExitCode p
         -- Hard wall-clock bound: a regression must surface as a failed
         -- assertion, never as a hang that stalls the whole suite.
-        outcome <- System.Timeout.timeout (8_000_000) runScenario
+        outcome <- System.Timeout.timeout (8_000_000) scenario
         case outcome of
             Nothing -> expectationFailure "test timed out (process did not settle)"
-            Just died -> died `shouldBe` True
+            Just () ->
+                readIORef childPidRef >>= \case
+                    Nothing -> expectationFailure "could not capture the child pid"
+                    Just childPid -> do
+                        died <- waitForProcessDeath childPid
+                        -- Never leak the child if the assertion fails.
+                        ignoring (signalProcess sigKILL (fromIntegral childPid))
+                        died `shouldBe` True
   where
-    runScenario :: IO Bool
-    runScenario = do
-        p <-
-            startProcess
-                $ setStdin createPipe
-                $ setStdout createPipe
-                $ setStderr createPipe
-                $ setCreateGroup True
-                $ shell "sleep 30 & echo \"$!\"; read _quit"
-        -- First line on stdout is the long-lived child's pid.
-        childLine <- hGetLine (getStdout p)
-        childPid <-
-            case readMaybe (takeWhile isDigit (dropWhile (not . isDigit) childLine)) of
-                Just pid -> pure (pid :: Int)
-                Nothing -> fail ("could not parse child pid from: " <> show childLine)
-        -- Always reap the child and leader, even if the assertion fails, so a
-        -- regression never leaks the very orphan it is testing for.
-        let cleanup = do
-                ignoring (signalProcess sigKILL (fromIntegral childPid))
-                ignoring (stopProcess p)
-        (`finally` cleanup) do
-            stateVar <- newTVarIO (Idle 0)
-            let gp =
-                    GhciProcess
-                        { stdin = getStdin p
-                        , stdout = getStdout p
-                        , stderr = getStderr p
-                        , handle = p
-                        , stateVar
-                        }
-            runEff
-                . runConcurrent
-                . runTimeout
-                . runDelay
-                . runFile
-                . runConc
-                . runProcessIO
-                $ stopGhciProcess (def {shutdownTimeout = 1}) gp
-            waitForProcessDeath childPid
+    procConfig =
+        setStdin createPipe
+            $ setStdout createPipe
+            $ setStderr createPipe
+            $ shell "sleep 30 & echo \"$!\"; read _quit"
 
-    ignoring :: IO () -> IO ()
-    ignoring act = act `catch` \(_ :: SomeException) -> pure ()
+
+-- | 'terminateProcessGroup' must kill the whole group when called mid-flight
+-- (the leader still alive) — the explicit early-termination path the test
+-- runner uses to abort a one-shot @cabal repl test:…@ from another thread.
+testTerminateProcessGroup :: Spec
+testTerminateProcessGroup =
+    it "kills the whole group, not just the leader, mid-flight" do
+        outcome <- System.Timeout.timeout (8_000_000) do
+            p <-
+                startProcess
+                    $ setStdin createPipe
+                    $ setStdout createPipe
+                    $ setStderr createPipe
+                    $ setCreateGroup True
+                    $ shell "sleep 30 & echo \"$!\"; read _quit"
+            childLine <- hGetLine (getStdout p)
+            case parsePid childLine of
+                Nothing -> do
+                    ignoring (stopProcess p)
+                    expectationFailure ("could not parse child pid from: " <> show childLine)
+                    pure False
+                Just childPid -> do
+                    runEff . runProcessIO $ terminateProcessGroup p
+                    died <- waitForProcessDeath childPid
+                    -- Never leak the child if the assertion fails.
+                    ignoring (signalProcess sigKILL (fromIntegral childPid))
+                    pure died
+        outcome `shouldBe` Just True
+
+
+-- | Parse a pid printed on its own line (tolerating surrounding whitespace).
+parsePid :: String -> Maybe Int
+parsePid = readMaybe . takeWhile isDigit . dropWhile (not . isDigit)
+
+
+-- | Swallow any exception from a best-effort cleanup action.
+ignoring :: IO () -> IO ()
+ignoring act = act `catch` \(_ :: SomeException) -> pure ()
 
 
 -- | Poll for up to ~3s for the given pid to disappear from the process table.

--- a/tricorder/test/Unit/Tricorder/Effects/GhciSession/GhciProcessSpec.hs
+++ b/tricorder/test/Unit/Tricorder/Effects/GhciSession/GhciProcessSpec.hs
@@ -4,6 +4,7 @@ import Atelier.Effects.Conc (runConc)
 import Atelier.Effects.Delay (runDelay)
 import Atelier.Effects.File (runFile)
 import Atelier.Effects.Process (runProcessIO, terminateProcessGroup, withProcessGroup)
+import Atelier.Effects.Process.Internal (RunningProcess (..))
 import Atelier.Effects.Timeout (runTimeout)
 import Atelier.Time (Millisecond)
 import Control.Concurrent (threadDelay)
@@ -36,6 +37,7 @@ import Test.Hspec
 import Atelier.Effects.Conc qualified as Conc
 import Atelier.Effects.Delay qualified as Delay
 import Atelier.Effects.File qualified as File
+import Atelier.Effects.Process qualified as AProc
 import Data.Text qualified as T
 import System.Process qualified as Process
 import System.Timeout qualified
@@ -89,7 +91,7 @@ testExecGhciStaleMarker =
                     { stdin = stdinW
                     , stdout = stdoutR
                     , stderr = stderrR
-                    , handle = p
+                    , handle = RunningProcess p
                     , stateVar
                     }
             -- Mirrors 'markerFor': "#~TRI-FINISH-<n>~#".
@@ -147,7 +149,7 @@ testSyncMarkerScopeIndependent =
                     { stdin = stdinW
                     , stdout = stdoutR
                     , stderr = stderrR
-                    , handle = p
+                    , handle = RunningProcess p
                     , stateVar
                     }
             marker = "#~TRI-FINISH-9~#" :: Text
@@ -247,13 +249,13 @@ testWithProcessGroupCleanup =
                     . runProcessIO
                     $ withProcessGroup procConfig \p -> do
                         -- First stdout line is the long-lived child's pid.
-                        line <- File.hGetLine (getStdout p)
+                        line <- File.hGetLine (AProc.getStdout p)
                         liftIO $ writeIORef childPidRef (parsePid (T.unpack line))
                         -- Let the leader exit and reap it, so the cleanup runs
                         -- with the leader already gone — the path the bug needed.
-                        File.hPutTextLn (getStdin p) ""
-                        File.hFlush (getStdin p)
-                        liftIO $ void $ waitExitCode p
+                        File.hPutTextLn (AProc.getStdin p) ""
+                        File.hFlush (AProc.getStdin p)
+                        void $ AProc.waitExitCode p
         -- Hard wall-clock bound: a regression must surface as a failed
         -- assertion, never as a hang that stalls the whole suite.
         outcome <- System.Timeout.timeout (8_000_000) scenario
@@ -296,7 +298,7 @@ testTerminateProcessGroup =
                     expectationFailure ("could not parse child pid from: " <> show childLine)
                     pure False
                 Just childPid -> do
-                    runEff . runProcessIO $ terminateProcessGroup p
+                    runEff . runProcessIO $ terminateProcessGroup (RunningProcess p)
                     died <- waitForProcessDeath childPid
                     -- Never leak the child if the assertion fails.
                     ignoring (signalProcess sigKILL (fromIntegral childPid))
@@ -383,7 +385,7 @@ testExecGhciScope =
                     { stdin = getStdin p
                     , stdout = getStdout p
                     , stderr = getStderr p
-                    , handle = p
+                    , handle = RunningProcess p
                     , stateVar
                     }
         siblingDoneRef <- newIORef False

--- a/tricorder/tricorder.cabal
+++ b/tricorder/tricorder.cabal
@@ -275,6 +275,7 @@ test-suite tricorder-test
     , tricorder-internal
     , typed-process ==0.2.*
     , unagi-chan ==0.4.*
+    , unix ==2.8.*
   mixins:
       base hiding (Prelude)
   default-language: GHC2021


### PR DESCRIPTION
`cabal repl` is spawned in its own process group (`setCreateGroup True`) and forks build subprocesses (a worker `cabal`, `ghc`) that share it. The termination paths only signalled the group *leader* via `terminateProcess`, so those descendants were orphaned — the dangling `cabal` processes seen after `tricorder stop` and after a `.cabal`-triggered restart.

- Add `getProcessId` and `terminateProcessGroup` to the `Process` effect
- `stopGhciProcess`/`terminateGhciProcess` now capture the group id before the leader is reaped, then SIGTERM the whole group so no build subprocess is left behind. The pid must be read up front: once the leader exits (gracefully on `:quit` or via force-kill) and is reaped, the handle no longer yields a pid
- Add a regression test simulating the process tree deterministically