### PR TITLE
fix: make nix-hpack pre-commit hook catch .cabal drift

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,4 +6,29 @@ See `.claude-plugin/tricorder/INSTALL.md` for installation instructions.
 
 ---
 
+## Dependencies and `.cabal` files
+
+**Never edit `*.cabal` files by hand — they are generated.** The source of
+truth is the Nix/hpack setup, and a pre-commit hook (`nix-hpack`) regenerates
+the `.cabal` files and fails the commit if a checked-in `.cabal` has drifted
+from its source. Hand edits are reverted on the next regeneration.
+
+- Version bounds live in `nix/package/dependencies.nix` (the `constraints` set).
+- Each package declares which dependencies its components (internal libraries,
+  executables, tests) use in that package's `package.nix`
+  (e.g. `tricorder/package.nix`).
+- Modules are auto-discovered from the source tree — you do **not** list them.
+
+To add or change a dependency:
+
+1. If the package isn't already in `nix/package/dependencies.nix` `constraints`,
+   add it there with a version bound.
+2. Add the dependency name to the relevant component's dependency list in that
+   package's `package.nix`.
+3. Regenerate the `.cabal` files with `nix-hpack` (no args regenerates every
+   package; or pass a package dir, e.g. `nix-hpack ./tricorder`).
+4. Commit **both** the `package.nix` and the regenerated `.cabal`.
+
+---
+
 See `CONTRIBUTING.md` for project conventions and workflow (mostly relevant for bigger tasks).

--- a/nix/outputs.nix
+++ b/nix/outputs.nix
@@ -64,9 +64,30 @@ let
             enable = true;
             package = tools.nixfmt;
           };
+          # The upstream hpack-dir hook regenerates *.cabal from package.yaml
+          # files, but this project has none on disk — nix-hpack generates them
+          # transiently from package.nix and deletes them. It therefore always
+          # no-ops and reports "Passed", giving false confidence. Disable it in
+          # favour of nix-hpack below.
+          hpack = {
+            package = hpack-dir;
+            enable = false;
+          };
           nix-hpack = {
             enable = true;
-            files = "(^|/)package\\.nix$";
+            # Run whenever anything that feeds .cabal generation changes:
+            #   - *.hs / *.lhs / *.hs-boot : hpack auto-discovers modules from the
+            #     source tree, so adding/removing one changes the generated .cabal
+            #   - *.cabal                  : catches hand-edits — nix-hpack rewrites
+            #     the file from package.nix, so the commit fails if a checked-in
+            #     .cabal drifted from its source
+            #   - package.nix              : the per-package hpack source
+            #   - nix/package/*.nix        : shared constraints / common options
+            # pre-commit only runs a hook when a *staged* file matches `files`, so
+            # the old package.nix-only pattern let direct .cabal edits (and module
+            # additions) through locally; CI runs every hook unconditionally and
+            # caught them. This widens the local trigger to match CI.
+            files = "(\\.l?hs(-boot)?$)|(\\.cabal$)|((^|/)package\\.nix$)|((^|/)nix/package/.*\\.nix$)";
             entry = "${nix-hpack}/bin/nix-hpack";
             pass_filenames = false;
           };


### PR DESCRIPTION
Fixes #240

The `nix-hpack` hook only triggered on `package.nix` changes, so a hand-edited (or stale) generated `.cabal` passed local pre-commit and only failed in CI — where every hook runs unconditionally.

- Widen the hook's `files` to also fire on `*.cabal` (catches hand-edits: nix-hpack rewrites the file from `package.nix`, so the commit fails on drift), `*.hs` (modules are auto-discovered, so they affect the generated `.cabal`), and shared `nix/package/*.nix` inputs
- Disable the upstream `hpack-dir` hook: it regenerates from `package.yaml`, which never exists on disk here, so it always no-ops and reported "Passed", giving false confidence
- Document the dependency workflow in `CLAUDE.md` (edit `package.nix` / `dependencies.nix` then `nix-hpack`, never the `.cabal` directly)