### PR TITLE
chore: release atelier-core 0.2.0.0; add tricorder changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+This repository is a multi-package project. Each package keeps its own
+changelog:
 
-### Fixed
-
-#### tricorder
-
-- Renamed the installed executable from `tricorder-exe` to `tricorder` so `cabal install tricorder` provides a binary matching the package name
-
-### Added
-
-#### tricorder
-
-- Daemon-based GHCi build monitor communicating over a Unix socket
-- Commands: `start`, `stop`, `status [--wait]`, `watch`
-- `status` outputs structured JSON with build phase, module count, duration, and messages
-- Each message includes `severity`, `file`, `line`/`col`, `title` (first line), and `text` (full body)
-- Auto-detects cabal/stack projects and builds the `cabal repl --enable-multi-repl` command
-- Parses `.cabal` file to resolve `hs-source-dirs` for targeted file watching
-- Configurable via `.tricorder.toml` (targets, debounce, log file, etc.)
-- File watcher with debouncing; auto-restarts GHCi session on crash (fixes ghcid's crash-on-file-removal bug)
+- [`tricorder`](tricorder/CHANGELOG.md)
+- [`atelier-core`](atelier-core/CHANGELOG.md)
+- [`atelier-prelude`](atelier-prelude/CHANGELOG.md)
+- [`atelier-db`](atelier-db/CHANGELOG.md)
+- [`atelier-testing`](atelier-testing/CHANGELOG.md)

--- a/atelier-core/CHANGELOG.md
+++ b/atelier-core/CHANGELOG.md
@@ -5,7 +5,33 @@ All notable changes to `atelier-core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to the [PVP](https://pvp.haskell.org/).
 
-## [Unreleased]
+## [0.2.0.0] - 2026-06-26
+
+### Added
+
+- `Atelier.Effects.File` now re-exports `IOMode (..)`.
+- `Atelier.Effects.Process`: `withProcessGroup` runs a process in its own
+  process group and guarantees the whole group is torn down when the body
+  returns or throws; `terminateProcessGroup` aborts a running group from
+  another thread (for children that trap `SIGINT`, where interrupting the
+  group is not enough).
+- New module `Atelier.Effects.Process.Internal`, exposing the `RunningProcess`
+  constructor for tests that fabricate a handle. Production code should not
+  import it.
+
+### Changed
+
+- **Breaking:** `Atelier.Effects.Process.RunningProcess` is now a distinct
+  `newtype` wrapping `System.Process.Typed.Process` (previously a type
+  synonym). `getStdin`/`getStdout`/`getStderr` operate on the new type.
+
+### Removed
+
+- **Breaking:** `Atelier.Effects.Process` no longer exports `setCreateGroup`,
+  `startProcess`, or `stopProcess`. Process lifecycle is now managed through
+  `withProcessGroup`.
+
+## [0.1.0.0] - 2026-06-05
 
 ### Added
 

--- a/atelier-core/atelier-core.cabal
+++ b/atelier-core/atelier-core.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.0
 -- see: https://github.com/sol/hpack
 
 name:           atelier-core
-version:        0.1.0.0
+version:        0.2.0.0
 synopsis:       Foundational Effectful-based effects and utilities
 description:    Core effects and utilities for effect-based applications, built on Effectful — part of the atelier toolkit.
 category:       Control
@@ -199,7 +199,7 @@ test-suite atelier-test
   build-depends:
       aeson ==2.2.*
     , async ==2.2.*
-    , atelier-core ==0.1.*
+    , atelier-core ==0.2.*
     , atelier-prelude ==0.1.*
     , base >=4.18 && <4.23
     , bytestring >=0.11 && <0.13

--- a/atelier-core/package.nix
+++ b/atelier-core/package.nix
@@ -4,7 +4,7 @@ let
 in
 {
   name = "atelier-core";
-  version = "0.1.0.0";
+  version = "0.2.0.0";
   synopsis = "Foundational Effectful-based effects and utilities";
   description = "Core effects and utilities for effect-based applications, built on Effectful — part of the atelier toolkit.";
   github = "atelier-hub/tricorder";

--- a/atelier-db/atelier-db.cabal
+++ b/atelier-db/atelier-db.cabal
@@ -60,7 +60,7 @@ library
   ghc-options: -Weverything -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-missing-local-signatures -Wno-missing-import-lists -Wno-implicit-prelude -Wno-unticked-promoted-constructors -Wno-unused-packages -Wno-all-missed-specialisations -Wno-missed-specialisations -fplugin=Effectful.Plugin -threaded
   build-depends:
       aeson ==2.2.*
-    , atelier-core ==0.1.*
+    , atelier-core ==0.2.*
     , atelier-prelude ==0.1.*
     , base >=4.18 && <4.23
     , bytestring >=0.11 && <0.13

--- a/atelier-testing/atelier-testing.cabal
+++ b/atelier-testing/atelier-testing.cabal
@@ -57,7 +57,7 @@ library
       TypeFamilies
   ghc-options: -Weverything -Wno-unsafe -Wno-missing-safe-haskell-mode -Wno-monomorphism-restriction -Wno-missing-kind-signatures -Wno-missing-local-signatures -Wno-missing-import-lists -Wno-implicit-prelude -Wno-unticked-promoted-constructors -Wno-unused-packages -Wno-all-missed-specialisations -Wno-missed-specialisations -fplugin=Effectful.Plugin -threaded
   build-depends:
-      atelier-core ==0.1.*
+      atelier-core ==0.2.*
     , atelier-db ==0.1.*
     , atelier-prelude ==0.1.*
     , base >=4.18 && <4.23

--- a/nix/package/dependencies.nix
+++ b/nix/package/dependencies.nix
@@ -10,7 +10,7 @@ let
     aeson = ">=2.2 && <2.3";
     ansi-terminal = ">=1.1 && <1.2";
     async = ">=2.2 && <2.3";
-    atelier-core = ">=0.1 && <0.2";
+    atelier-core = ">=0.2 && <0.3";
     atelier-db = ">=0.1 && <0.2";
     atelier-prelude = ">=0.1 && <0.2";
     base64-bytestring = ">=1.2 && <1.3";

--- a/tricorder/CHANGELOG.md
+++ b/tricorder/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to `tricorder` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to the [PVP](https://pvp.haskell.org/).
+
+## [0.1.1.0] - 2026-06-26
+
+### Added
+
+- Configurable `watch_exclusion_patterns` to exclude paths from the file
+  watcher.
+- The TUI now presents its different views as tabs.
+
+### Fixed
+
+- Terminate the whole cabal process group on shutdown, so children that trap
+  `SIGINT` are no longer left running.
+- Correct watch-directory scoping for bare package-name targets in a
+  multi-package project.
+- Building no longer fails for packages that use a custom prelude.
+- Use the correct set of targets when constructing the build command.
+- Surface location-less GHCi load failures (e.g. plugin errors) without
+  reporting false positives.
+- Clear stale diagnostics for failed executable and test `Main` modules.
+
+## [0.1.0.1] - 2026-06-06
+
+### Fixed
+
+- Renamed the installed executable from `tricorder-exe` to `tricorder` so
+  `cabal install tricorder` provides a binary matching the package name.
+
+## [0.1.0.0] - 2026-06-05
+
+### Added
+
+- Initial release: daemon-based GHCi build monitor communicating over a Unix
+  socket.
+- Commands: `start`, `stop`, `status [--wait]`, `watch`.
+- `status` outputs structured JSON with build phase, module count, duration,
+  and messages; each message includes `severity`, `file`, `line`/`col`,
+  `title` (first line), and `text` (full body).
+- Auto-detects cabal/stack projects and builds the
+  `cabal repl --enable-multi-repl` command.
+- Parses `.cabal` files to resolve `hs-source-dirs` for targeted file watching.
+- Configurable via `.tricorder.toml` (targets, debounce, log file, etc.).
+- File watcher with debouncing; auto-restarts the GHCi session on crash
+  (fixes ghcid's crash-on-file-removal bug).

--- a/tricorder/package.nix
+++ b/tricorder/package.nix
@@ -9,7 +9,10 @@ in
   description = "tricorder rebuilds your Haskell project continuously and surfaces build status, diagnostics, test results, and documentation - for developers and LLM coding agents. Like ghcid and ghciwatch it reloads on every change, but builds run in a background daemon so multiple clients (an interactive TUI, a status CLI, an agent skill) share a single build state without triggering redundant rebuilds. It discovers components across multi-package cabal.project workspaces automatically and ships context-friendly output for agentic use via the CLI.";
   github = "atelier-hub/tricorder";
   category = "Development";
-  extra-doc-files = [ "README.md" ];
+  extra-doc-files = [
+    "README.md"
+    "CHANGELOG.md"
+  ];
 
   inherit (common)
     author

--- a/tricorder/tricorder.cabal
+++ b/tricorder/tricorder.cabal
@@ -18,6 +18,7 @@ license-file:   LICENSE
 build-type:     Simple
 extra-doc-files:
     README.md
+    CHANGELOG.md
 
 source-repository head
   type: git
@@ -94,7 +95,7 @@ library tricorder-internal
       Cabal-syntax >=3.12 && <3.17
     , aeson ==2.2.*
     , ansi-terminal ==1.1.*
-    , atelier-core ==0.1.*
+    , atelier-core ==0.2.*
     , atelier-prelude ==0.1.*
     , base >=4.18 && <4.23
     , brick ==2.10.*
@@ -254,7 +255,7 @@ test-suite tricorder-test
   build-depends:
       Cabal-syntax >=3.12 && <3.17
     , aeson ==2.2.*
-    , atelier-core ==0.1.*
+    , atelier-core ==0.2.*
     , atelier-prelude ==0.1.*
     , base >=4.18 && <4.23
     , containers >=0.6 && <0.9


### PR DESCRIPTION
Re-release `atelier-core` so tricorder's deps resolve on Hackage. The local `atelier-core` had drifted from the published `0.1.0.0` with PVP-breaking changes (removed `setCreateGroup`/`startProcess`/`stopProcess` exports, `RunningProcess` changed from a type synonym to a `newtype`, new `Atelier.Effects.Process.Internal` used by tricorder's tests).

- **atelier-core** → `0.2.0.0`; dependency bound `>=0.2 && <0.3`, which moves tricorder's bound to `atelier-core ==0.2.*`
- Dated `atelier-core` changelog: new `0.2.0.0` section, prior entry relabeled as the published `0.1.0.0`
- Add per-package `tricorder/CHANGELOG.md` (versioned `0.1.0.0` / `0.1.0.1` / `0.1.1.0`) and ship it via `extra-doc-files`; previously tricorder shipped no changelog at all
- Root `CHANGELOG.md` now points to the per-package changelogs

`atelier-prelude` is unchanged: its source is identical to the published `0.1.0.0`, so it needs no re-release.