### PR TITLE
fix: wait for daemon socket before declaring start done

### DIFF
--- a/tricorder/src/Tricorder.hs
+++ b/tricorder/src/Tricorder.hs
@@ -59,7 +59,11 @@ run =
                 Console.putStrLn "Daemon already running."
             else do
                 startDaemon
-                Console.putStrLn "Daemon started."
+                ready <- waitForDaemon
+                if ready then
+                    Console.putStrLn "Daemon started."
+                else
+                    Console.putStrLn "Daemon started, but the socket is not responding yet."
         Stop force -> do
             running <- isDaemonRunning
             when running
@@ -99,11 +103,11 @@ run =
             running <- isDaemonRunning
             unless running do
                 startDaemon
-                waitForDaemon
+                void waitForDaemon
             viewUi
         Source moduleNames -> do
             running <- isDaemonRunning
             unless running $ do
                 startDaemon
-                waitForDaemon
+                void waitForDaemon
             showSource moduleNames

--- a/tricorder/src/Tricorder/Daemon.hs
+++ b/tricorder/src/Tricorder/Daemon.hs
@@ -21,7 +21,7 @@ import Atelier.Effects.Posix.Daemons qualified as Daemons
 import Tricorder.Arguments (Force (..))
 import Tricorder.Effects.UnixSocket (UnixSocket)
 import Tricorder.Runtime (PidFile, SocketPath (..))
-import Tricorder.Socket.Client (isDaemonRunning, requestShutdown)
+import Tricorder.Socket.Client (isDaemonReady, requestShutdown)
 
 import Tricorder.Daemon.Main qualified as Daemon.Main
 
@@ -94,9 +94,31 @@ stopDaemon force = do
             pure ()
 
 
--- | Poll until the daemon socket becomes connectable.
-waitForDaemon :: (Daemons :> es, Delay :> es, Reader PidFile :> es, UnixSocket :> es) => Eff es ()
+-- | Poll until the daemon socket becomes connectable, giving up after roughly
+-- ten seconds. Returns 'True' once the socket is accepting connections.
+--
+-- We poll the socket rather than the PID file for two reasons: the daemon
+-- writes its PID /before/ it binds the socket (a client connecting in that
+-- window gets a "connection refused" error), and right after forking the PID
+-- file may not exist yet — so the PID is not a reliable readiness signal either
+-- way.
+waitForDaemon
+    :: ( Delay :> es
+       , Reader SocketPath :> es
+       , UnixSocket :> es
+       )
+    => Eff es Bool
 waitForDaemon = do
-    Delay.wait (200 :: Millisecond)
-    running <- isDaemonRunning
-    unless running waitForDaemon
+    SocketPath sockPath <- ask
+    go sockPath maxAttempts
+  where
+    -- 50 attempts × 200ms ≈ 10s
+    maxAttempts = 50 :: Int
+    go _ 0 = pure False
+    go sockPath n = do
+        ready <- isDaemonReady sockPath
+        if ready then
+            pure True
+        else do
+            Delay.wait (200 :: Millisecond)
+            go sockPath (n - 1)

--- a/tricorder/src/Tricorder/Daemon.hs
+++ b/tricorder/src/Tricorder/Daemon.hs
@@ -94,7 +94,7 @@ stopDaemon force = do
             pure ()
 
 
--- | Poll until the daemon socket becomes connectable, giving up after roughly
+-- | Poll until the daemon binds to the socket, giving up after roughly
 -- ten seconds. Returns 'True' once the socket is accepting connections.
 --
 -- We poll the socket rather than the PID file for two reasons: the daemon

--- a/tricorder/src/Tricorder/Socket/Client.hs
+++ b/tricorder/src/Tricorder/Socket/Client.hs
@@ -7,6 +7,7 @@ module Tricorder.Socket.Client
     , queryDiagnostic
     , requestShutdown
     , isDaemonRunning
+    , isDaemonReady
     ) where
 
 import Atelier.Effects.Delay (Delay)
@@ -151,6 +152,18 @@ isDaemonRunning :: (Daemons :> es, Reader PidFile :> es) => Eff es Bool
 isDaemonRunning = do
     pidFile <- ask
     Daemons.isRunning pidFile
+
+
+-- | Check whether the daemon socket is bound and accepting connections.
+--
+-- The PID file can appear before the daemon has bound its socket, so a
+-- running process is not enough to guarantee a client can connect. This opens
+-- (and immediately closes) a throwaway connection and reports whether it
+-- succeeded.
+isDaemonReady :: (UnixSocket :> es) => FilePath -> Eff es Bool
+isDaemonReady sockPath =
+    either (const False) (const True)
+        <$> trySync (withConnection sockPath \_ -> pass)
 
 
 -- internals

--- a/tricorder/test/Unit/Tricorder/SocketSpec.hs
+++ b/tricorder/test/Unit/Tricorder/SocketSpec.hs
@@ -11,14 +11,17 @@ import Tricorder.Effects.UnixSocket
     , acceptHandle
     , bindSocket
     , removeSocketFile
+    , runUnixSocketIO
     , runUnixSocketScripted
     , socketFileExists
     )
+import Tricorder.Socket.Client (isDaemonReady)
 
 
 spec_Socket :: Spec
 spec_Socket = do
     describe "runUnixSocketScripted" testScripted
+    describe "isDaemonReady" testReady
 
 
 --------------------------------------------------------------------------------
@@ -55,9 +58,36 @@ testScripted = do
 
 
 --------------------------------------------------------------------------------
+-- isDaemonReady (real IO interpreter)
+--------------------------------------------------------------------------------
+
+testReady :: Spec
+testReady = do
+    it "returns False when nothing is listening on the path" do
+        -- A connect to a non-existent socket must be caught, not thrown: this is
+        -- the race the start/status path hit before the socket was bound.
+        result <- runIO' $ isDaemonReady "/tmp/tricorder-isdaemonready-absent.sock"
+        result `shouldBe` False
+
+    it "returns True once a socket is bound and listening" do
+        let path = "/tmp/tricorder-isdaemonready-bound.sock"
+        result <- runIO' do
+            removeSocketFile path
+            _ <- bindSocket path
+            isDaemonReady path
+        runIO' $ removeSocketFile path
+        result `shouldBe` True
+
+
+--------------------------------------------------------------------------------
 -- Helpers
 --------------------------------------------------------------------------------
 
 -- | Run scripted socket operations (no Delay needed).
 runScripted :: [SocketScript] -> Eff '[UnixSocket, File, IOE] a -> IO a
 runScripted script = runEff . runFile . runUnixSocketScripted script
+
+
+-- | Run socket operations against the real IO interpreter.
+runIO' :: Eff '[UnixSocket, File, IOE] a -> IO a
+runIO' = runEff . runFile . runUnixSocketIO


### PR DESCRIPTION
`tricorder start` printed "Daemon started." as soon as the daemon was forked, before it had bound its Unix socket. A following command such as `tricorder status --wait` would then connect and crash with `Network.Socket.connect: does not exist (Connection refused)`.

- Add `isDaemonReady`, which probes actual socket connectability rather than process aliveness (the PID file appears before the socket binds, and may be missing right after the fork — so it is not a reliable readiness signal).
- `waitForDaemon` now polls the socket and returns whether it came up; `start` waits on it and reports accordingly.