### PR TITLE
feat: derive FromJSON for DBConfig

### DIFF
--- a/atelier-db/CHANGELOG.md
+++ b/atelier-db/CHANGELOG.md
@@ -5,9 +5,12 @@ All notable changes to `atelier-db` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to the [PVP](https://pvp.haskell.org/).
 
-## [Unreleased]
+## [0.1.0.0] - 2026-06-29
 
 ### Added
 
 - Initial release: a relational database effect (Hasql/Rel8) for the atelier
   toolkit.
+- `DBConfig` derives `FromJSON` (via `QuietSnake`, mapping fields to
+  `quiet_snake_case` keys), so connection settings can be decoded directly
+  from configuration files.

--- a/atelier-db/src/Atelier/Effects/DB/Config.hs
+++ b/atelier-db/src/Atelier/Effects/DB/Config.hs
@@ -52,7 +52,8 @@ data DBConfig = DBConfig
     , pool :: PoolConfig
     -- ^ Connection pool settings.
     }
-    deriving stock (Eq, Show)
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON) via QuietSnake DBConfig
 
 
 -- | Separate connection pools for read and write operations.


### PR DESCRIPTION
- Derive `FromJSON` for `DBConfig` via `QuietSnake`, so connection settings decode from `quiet_snake_case` JSON config files
- Finalize `atelier-db` 0.1.0.0 changelog entry for Hackage release