### PR TITLE
chore: release atelier-db 0.1.1.0

### DIFF
--- a/atelier-db/CHANGELOG.md
+++ b/atelier-db/CHANGELOG.md
@@ -5,12 +5,17 @@ All notable changes to `atelier-db` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to the [PVP](https://pvp.haskell.org/).
 
-## [0.1.0.0] - 2026-06-29
+## [0.1.1.0] - 2026-06-29
+
+### Added
+
+- `DBConfig` derives `FromJSON` (via `QuietSnake`, mapping fields to
+  `quiet_snake_case` keys), so connection settings can be decoded directly
+  from configuration files.
+
+## [0.1.0.0] - 2026-06-04
 
 ### Added
 
 - Initial release: a relational database effect (Hasql/Rel8) for the atelier
   toolkit.
-- `DBConfig` derives `FromJSON` (via `QuietSnake`, mapping fields to
-  `quiet_snake_case` keys), so connection settings can be decoded directly
-  from configuration files.

--- a/atelier-db/atelier-db.cabal
+++ b/atelier-db/atelier-db.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.0
 -- see: https://github.com/sol/hpack
 
 name:           atelier-db
-version:        0.1.0.0
+version:        0.1.1.0
 synopsis:       Relational database effect for atelier (Hasql/Rel8)
 description:    Relational database access via Hasql and Rel8, exposed as an Effectful effect — part of the atelier toolkit.
 category:       Database

--- a/atelier-db/package.nix
+++ b/atelier-db/package.nix
@@ -4,7 +4,7 @@ let
 in
 {
   name = "atelier-db";
-  version = "0.1.0.0";
+  version = "0.1.1.0";
   synopsis = "Relational database effect for atelier (Hasql/Rel8)";
   description = "Relational database access via Hasql and Rel8, exposed as an Effectful effect — part of the atelier toolkit.";
   github = "atelier-hub/tricorder";


### PR DESCRIPTION
- Bump `atelier-db` to 0.1.1.0
- Correct the changelog: restore the real 0.1.0.0 entry and add a 0.1.1.0 entry for the `FromJSON` instance