### PR TITLE
chore: add result job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,16 @@ jobs:
           name: atelier
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix build '.#legacyChecks.${{ matrix.system }}.${{ matrix.ghc-version }}.all' -L
+
+  results:
+    name: Results
+    runs-on: ubuntu-latest
+    if: always()
+    needs:
+      - check
+    steps:
+      - run: |
+          result="${{ needs.check.result }}"
+          if [[ "$result" != "success" ]]; then
+            exit 1
+          fi


### PR DESCRIPTION
Depending on individual matrix jobs is brittle and a real hassle. This
way, we can specify "Results" as the only required CI check for PRs to
be merged. "Results" will _only_ succeed if all dependent jobs succeed.

We should enable required CI checks for PRs, as well as auto-merging.
