### PR TITLE
feat: restart the daemon from the TUI with R

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,13 +208,17 @@ keybindings:
 `keybindings` is an object whose keys are event names and whose values are
 strings of key bindings, each key binding in the string separated by a comma.
 
-The following event names are recognized:
+The following event names are recognized
+(keep this list in sync with the `KeyEvent` type in
+`tricorder/src/Tricorder/UI/Keys.hs` [ref:keybinding_events]):
 
 - `toggle_daemon_info_view`: Toggle displaying the daemon info tab.
 - `toggle_help`: Toggle displaying the help tab. This tab shows available key
   bindings, including your custom key bindings.
 - `cycle_test_view`: Toggle the tests tab and cycle through test results views.
   Cycle past the end to go back to the dashboard.
+- `restart_daemon`: Restart the background daemon — stops it if running, then
+  starts a fresh instance. Bound to `R` by default.
 - `exit_view`: Exit the current view, going back to the dashboard. If you are
   at the dashboard already, this exits the TUI.
 - `scroll_up`: Scroll up in the diagnostic list.

--- a/atelier-core/CHANGELOG.md
+++ b/atelier-core/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to `atelier-core` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to the [PVP](https://pvp.haskell.org/).
 
+## [Unreleased]
+
+### Added
+
+- `Atelier.Effects.Process`: `getExecutablePath` returns the absolute path of
+  the currently running executable, for re-invoking the program as a
+  subprocess.
+
 ## [0.2.0.0] - 2026-06-26
 
 ### Added

--- a/atelier-core/src/Atelier/Effects/Process.hs
+++ b/atelier-core/src/Atelier/Effects/Process.hs
@@ -28,6 +28,7 @@ module Atelier.Effects.Process
 
       -- * Operations
     , readProcessStdout
+    , runProcess
     , readProcessSafe
     , withProcessGroup
     , terminateProcessGroup
@@ -83,6 +84,9 @@ getStderr (RunningProcess p) = TP.getStderr p
 data Process :: Effect where
     -- | Run a process to completion, returning its exit code and captured stdout.
     ReadProcessStdout :: ProcessConfig i o e -> Process m (ExitCode, LByteString)
+    -- | Run a process to completion, returning only its exit code. Unlike
+    -- 'ReadProcessStdout' this does not capture stdout.
+    RunProcess :: ProcessConfig i o e -> Process m ExitCode
     -- | The absolute path of the currently running executable, for re-invoking
     -- this program as a subprocess.
     GetExecutablePath :: Process m FilePath
@@ -153,6 +157,7 @@ readProcessSafe cmd args = do
 runProcessIO :: (IOE :> es) => Eff (Process : es) a -> Eff es a
 runProcessIO = interpret_ \case
     ReadProcessStdout cfg -> liftIO $ TP.readProcessStdout cfg
+    RunProcess cfg -> liftIO $ TP.runProcess cfg
     GetExecutablePath -> liftIO Env.getExecutablePath
     StartProcess cfg -> liftIO $ RunningProcess <$> TP.startProcess cfg
     StopProcess (RunningProcess p) -> liftIO $ TP.stopProcess p

--- a/atelier-core/src/Atelier/Effects/Process.hs
+++ b/atelier-core/src/Atelier/Effects/Process.hs
@@ -33,6 +33,7 @@ module Atelier.Effects.Process
     , terminateProcessGroup
     , interruptProcessGroup
     , waitExitCode
+    , getExecutablePath
 
       -- * Interpreters
     , runProcessIO
@@ -58,6 +59,7 @@ import System.Process.Typed
     , shell
     )
 
+import System.Environment qualified as Env
 import System.Process.Typed qualified as TP
 
 import Atelier.Effects.Process.Internal (RunningProcess (..))
@@ -81,6 +83,9 @@ getStderr (RunningProcess p) = TP.getStderr p
 data Process :: Effect where
     -- | Run a process to completion, returning its exit code and captured stdout.
     ReadProcessStdout :: ProcessConfig i o e -> Process m (ExitCode, LByteString)
+    -- | The absolute path of the currently running executable, for re-invoking
+    -- this program as a subprocess.
+    GetExecutablePath :: Process m FilePath
     -- | Spawn a process and return its handle. Internal; callers use 'withProcessGroup'.
     StartProcess :: ProcessConfig i o e -> Process m (RunningProcess i o e)
     -- | Terminate the leader and close its streams. Internal; does not reach the
@@ -148,6 +153,7 @@ readProcessSafe cmd args = do
 runProcessIO :: (IOE :> es) => Eff (Process : es) a -> Eff es a
 runProcessIO = interpret_ \case
     ReadProcessStdout cfg -> liftIO $ TP.readProcessStdout cfg
+    GetExecutablePath -> liftIO Env.getExecutablePath
     StartProcess cfg -> liftIO $ RunningProcess <$> TP.startProcess cfg
     StopProcess (RunningProcess p) -> liftIO $ TP.stopProcess p
     WaitExitCode (RunningProcess p) -> liftIO $ TP.waitExitCode p

--- a/tricorder/CHANGELOG.md
+++ b/tricorder/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to `tricorder` will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to the [PVP](https://pvp.haskell.org/).
 
+## [Unreleased]
+
+### Added
+
+- The TUI can now restart the daemon — press `R` (the `restart_daemon` key
+  event, rebindable like the others). It reconnects automatically once the
+  fresh daemon is ready.
+
 ## [0.1.1.0] - 2026-06-26
 
 ### Added

--- a/tricorder/src/Tricorder.hs
+++ b/tricorder/src/Tricorder.hs
@@ -8,6 +8,7 @@ import Atelier.Effects.Exit (Exit)
 import Atelier.Effects.File (File)
 import Atelier.Effects.FileSystem (FileSystem)
 import Atelier.Effects.Posix.Daemons (Daemons)
+import Atelier.Effects.Process (Process)
 import Atelier.Effects.Timeout (Timeout)
 import Effectful (IOE)
 import Effectful.Reader.Static (Reader, ask, asks)
@@ -19,7 +20,7 @@ import Data.Text qualified as T
 import Tricorder.Arguments (Command (..))
 import Tricorder.BuildState (BuildState (..), DaemonInfo (..))
 import Tricorder.CLI (showLog, showSource, showStatus, showTests)
-import Tricorder.Daemon (startDaemon, stopDaemon, waitForDaemon)
+import Tricorder.Daemon (restartDaemon, startDaemon, stopDaemon, waitForDaemon)
 import Tricorder.Effects.Brick (Brick)
 import Tricorder.Effects.BrickChan (BrickChan)
 import Tricorder.Effects.UnixSocket (UnixSocket)
@@ -42,6 +43,7 @@ run
        , File :> es
        , FileSystem :> es
        , IOE :> es
+       , Process :> es
        , Reader Command :> es
        , Reader Keys.Config :> es
        , Reader LogPath :> es
@@ -111,12 +113,7 @@ run =
                 startDaemon
                 void waitForDaemon
             showSource moduleNames
-        Restart force -> do
-            running <- isDaemonRunning
-            if running then do
-                res <- stopDaemon force
-                whenLeft_ res
-                    $ traverse_ Console.putTextLn
-                startDaemon
-            else do
-                startDaemon
+        Restart force ->
+            restartDaemon force >>= \case
+                Just (Left reasons) -> traverse_ Console.putTextLn reasons
+                _ -> pass

--- a/tricorder/src/Tricorder.hs
+++ b/tricorder/src/Tricorder.hs
@@ -11,6 +11,7 @@ import Atelier.Effects.Posix.Daemons (Daemons)
 import Atelier.Effects.Process (Process)
 import Atelier.Effects.Timeout (Timeout)
 import Effectful (IOE)
+import Effectful.Concurrent (Concurrent)
 import Effectful.Reader.Static (Reader, ask, asks)
 import Prelude hiding (force)
 
@@ -36,6 +37,7 @@ run
        , BrickChan :> es
        , Clock :> es
        , Conc :> es
+       , Concurrent :> es
        , Console :> es
        , Daemons :> es
        , Delay :> es

--- a/tricorder/src/Tricorder/CLI/Main.hs
+++ b/tricorder/src/Tricorder/CLI/Main.hs
@@ -10,6 +10,7 @@ import Atelier.Effects.Exit (runExit)
 import Atelier.Effects.File (runFile)
 import Atelier.Effects.FileSystem (runFileSystemIO)
 import Atelier.Effects.Posix.Daemons (runDaemons)
+import Atelier.Effects.Process (runProcessIO)
 import Atelier.Effects.Timeout (runTimeout)
 import Effectful (runEff)
 import Effectful.Concurrent (runConcurrent)
@@ -47,6 +48,7 @@ main =
         . runLoadedConfig
         . runConfig @"keybindings" @Keys.Config
         . runDaemons
+        . runProcessIO
         . runArgumentsIO
         . runArguments
         . runUnixSocketIO

--- a/tricorder/src/Tricorder/Daemon.hs
+++ b/tricorder/src/Tricorder/Daemon.hs
@@ -1,6 +1,7 @@
 module Tricorder.Daemon
     ( startDaemon
     , stopDaemon
+    , restartDaemon
     , waitForDaemon
     ) where
 
@@ -21,7 +22,7 @@ import Atelier.Effects.Posix.Daemons qualified as Daemons
 import Tricorder.Arguments (Force (..))
 import Tricorder.Effects.UnixSocket (UnixSocket)
 import Tricorder.Runtime (PidFile, SocketPath (..))
-import Tricorder.Socket.Client (isDaemonReady, requestShutdown)
+import Tricorder.Socket.Client (isDaemonReady, isDaemonRunning, requestShutdown)
 
 import Tricorder.Daemon.Main qualified as Daemon.Main
 
@@ -92,6 +93,29 @@ stopDaemon force = do
             rec
         else
             pure ()
+
+
+-- | Restart the daemon: stop it (if running) and then start a fresh instance.
+-- Returns the outcome of the stop attempt, or 'Nothing' if the daemon was not
+-- running. The daemon is started unconditionally afterwards, mirroring the
+-- @restart@ subcommand.
+restartDaemon
+    :: ( Daemons :> es
+       , Delay :> es
+       , File :> es
+       , IOE :> es
+       , Reader PidFile :> es
+       , Reader SocketPath :> es
+       , Timeout :> es
+       , UnixSocket :> es
+       )
+    => Force
+    -> Eff es (Maybe (Either [Text] Text))
+restartDaemon force = do
+    running <- isDaemonRunning
+    res <- if running then Just <$> stopDaemon force else pure Nothing
+    startDaemon
+    pure res
 
 
 -- | Poll until the daemon binds to the socket, giving up after roughly

--- a/tricorder/src/Tricorder/Socket/Client.hs
+++ b/tricorder/src/Tricorder/Socket/Client.hs
@@ -69,23 +69,30 @@ data Restarting = Restarting
 
 -- | Connect and stream build updates, calling the handler after each completed build.
 -- Retries automatically when the connection is lost or the daemon is restarting.
+--
+-- A transient drop is tolerated for a few attempts before giving up. While
+-- @isRestarting@ reports 'True' (a restart we initiated is in flight) the retry
+-- budget is ignored and reconnection continues indefinitely, so the watch
+-- survives the gap between stopping the old daemon and the new one binding its
+-- socket.
 queryWatch
     :: forall es
      . (Delay :> es, File :> es, UnixSocket :> es)
     => FilePath
+    -> Eff es Bool
+    -- ^ Whether a restart is currently in progress.
     -> (Either Restarting BuildState -> Eff es ())
     -> Eff es ()
-queryWatch sockPath handler = evalState retryLimit retryLoop
+queryWatch sockPath isRestarting handler = evalState retryLimit retryLoop
   where
     retryLimit = 3 :: Int
     retryLoop = do
         retries <- get @Int
-        if retries <= 0 then
-            pure ()
-        else do
+        keepGoing <- if retries > 0 then pure True else inject isRestarting
+        when keepGoing do
             void $ trySync $ withConnection sockPath \h -> sendQuery h Watch >> loop h
             Delay.wait (500 :: Millisecond)
-            modify $ subtract 1
+            when (retries > 0) $ modify $ subtract 1
             retryLoop
 
     loop h = do

--- a/tricorder/src/Tricorder/UI.hs
+++ b/tricorder/src/Tricorder/UI.hs
@@ -7,12 +7,18 @@ import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.Console (Console)
 import Atelier.Effects.Delay (Delay)
 import Atelier.Effects.File (File)
+import Atelier.Effects.Process (Process, getExecutablePath, proc, readProcessStdout)
 import Brick (App (..), neverShowCursor)
+import Brick.BChan (BChan, writeBChanNonBlocking)
 import Brick.Keybindings (KeyConfig)
+import Data.IORef (IORef, newIORef, readIORef, writeIORef)
+import Effectful (IOE)
+import Effectful.Exception (trySync)
 import Effectful.Reader.Static (Reader, ask)
 
 import Atelier.Effects.Conc qualified as Conc
 
+import Tricorder.Daemon (waitForDaemon)
 import Tricorder.Effects.Brick (Brick)
 import Tricorder.Effects.BrickChan (BrickChan)
 import Tricorder.Effects.UnixSocket (UnixSocket)
@@ -30,7 +36,8 @@ import Tricorder.UI.State qualified as Model
 
 
 -- | Connect to the daemon and render a live-updating build status display using
--- a brick TUI. Quits on @q@ or @Esc@; arrow keys scroll the viewport.
+-- a brick TUI. Quits on @q@ or @Esc@; arrow keys scroll the viewport; @R@
+-- restarts the daemon.
 viewUi
     :: ( Brick :> es
        , BrickChan :> es
@@ -39,6 +46,8 @@ viewUi
        , Console :> es
        , Delay :> es
        , File :> es
+       , IOE :> es
+       , Process :> es
        , Reader Keys.Config :> es
        , Reader SocketPath :> es
        , UnixSocket :> es
@@ -47,25 +56,62 @@ viewUi
 viewUi = do
     SocketPath sockPath <- ask
     chan <- BrickChan.newBChan 10
+    restartChan <- BrickChan.newBChan 1
+    -- Set while a restart we triggered is in flight, so the watch loop stays
+    -- patient and reconnects to the fresh daemon instead of giving up.
+    restarting <- liftIO $ newIORef False
     initialState <- Model.init
     Conc.scoped do
         _ <-
             Conc.fork do
-                queryWatch sockPath $ BrickChan.writeBChan chan . NewBuildState
+                queryWatch sockPath (liftIO $ readIORef restarting)
+                    $ BrickChan.writeBChan chan . NewBuildState
                 BrickChan.writeBChan chan $ FailedBuild "Lost contact with the daemon"
+        _ <- Conc.fork $ restartWorker restartChan restarting
         keyConfig <- Keys.mkKeyConfig
+        let requestRestart = void $ writeBChanNonBlocking restartChan ()
         void
             $ Brick.runBrickApp
                 chan
-                (watchApp keyConfig)
+                (watchApp requestRestart keyConfig)
                 initialState
 
 
-watchApp :: KeyConfig KeyEvent -> App State Event Viewports
-watchApp kc =
+-- | Wait for restart requests from the TUI and service each one by spawning a
+-- fresh @tricorder restart@ process.
+--
+-- The restart must happen out-of-process: starting the daemon double-forks (see
+-- "System.Posix.Daemon"), and forking this vty-controlled process knocks the
+-- terminal out of the raw mode brick set up, so keystrokes stop being captured.
+-- Delegating to a separate process keeps the fork isolated. The brick event
+-- handler signals us over @restartChan@ because it cannot run these effects.
+restartWorker
+    :: ( BrickChan :> es
+       , Delay :> es
+       , IOE :> es
+       , Process :> es
+       , Reader SocketPath :> es
+       , UnixSocket :> es
+       )
+    => BChan ()
+    -> IORef Bool
+    -> Eff es ()
+restartWorker restartChan restarting = forever do
+    BrickChan.readBChan restartChan
+    liftIO $ writeIORef restarting True
+    self <- getExecutablePath
+    -- Swallow failures: a restart that errors must not take down the TUI, and
+    -- the flag has to be cleared either way.
+    _ <- trySync $ readProcessStdout $ proc self ["restart"]
+    void waitForDaemon
+    liftIO $ writeIORef restarting False
+
+
+watchApp :: IO () -> KeyConfig KeyEvent -> App State Event Viewports
+watchApp requestRestart kc =
     App
         { appDraw = view kc
-        , appHandleEvent = handleEvent $ dispatcher kc
+        , appHandleEvent = handleEvent $ dispatcher requestRestart kc
         , appStartEvent = pure ()
         , appAttrMap = mkAttrMap
         , appChooseCursor = neverShowCursor

--- a/tricorder/src/Tricorder/UI.hs
+++ b/tricorder/src/Tricorder/UI.hs
@@ -7,13 +7,13 @@ import Atelier.Effects.Conc (Conc)
 import Atelier.Effects.Console (Console)
 import Atelier.Effects.Delay (Delay)
 import Atelier.Effects.File (File)
-import Atelier.Effects.Process (Process, getExecutablePath, proc, readProcessStdout)
+import Atelier.Effects.Process (Process, getExecutablePath, proc, runProcess)
 import Brick (App (..), neverShowCursor)
 import Brick.BChan (BChan, writeBChanNonBlocking)
 import Brick.Keybindings (KeyConfig)
-import Data.IORef (IORef, newIORef, readIORef, writeIORef)
-import Effectful (IOE)
-import Effectful.Exception (trySync)
+import Effectful.Concurrent (Concurrent)
+import Effectful.Concurrent.STM (TVar, atomically, newTVarIO, readTVarIO, writeTVar)
+import Effectful.Exception (bracket_, trySync)
 import Effectful.Reader.Static (Reader, ask)
 
 import Atelier.Effects.Conc qualified as Conc
@@ -43,10 +43,10 @@ viewUi
        , BrickChan :> es
        , Clock :> es
        , Conc :> es
+       , Concurrent :> es
        , Console :> es
        , Delay :> es
        , File :> es
-       , IOE :> es
        , Process :> es
        , Reader Keys.Config :> es
        , Reader SocketPath :> es
@@ -59,12 +59,12 @@ viewUi = do
     restartChan <- BrickChan.newBChan 1
     -- Set while a restart we triggered is in flight, so the watch loop stays
     -- patient and reconnects to the fresh daemon instead of giving up.
-    restarting <- liftIO $ newIORef False
+    restarting <- newTVarIO False
     initialState <- Model.init
     Conc.scoped do
         _ <-
             Conc.fork do
-                queryWatch sockPath (liftIO $ readIORef restarting)
+                queryWatch sockPath (readTVarIO restarting)
                     $ BrickChan.writeBChan chan . NewBuildState
                 BrickChan.writeBChan chan $ FailedBuild "Lost contact with the daemon"
         _ <- Conc.fork $ restartWorker restartChan restarting
@@ -87,24 +87,25 @@ viewUi = do
 -- handler signals us over @restartChan@ because it cannot run these effects.
 restartWorker
     :: ( BrickChan :> es
+       , Concurrent :> es
        , Delay :> es
-       , IOE :> es
        , Process :> es
        , Reader SocketPath :> es
        , UnixSocket :> es
        )
     => BChan ()
-    -> IORef Bool
+    -> TVar Bool
     -> Eff es ()
-restartWorker restartChan restarting = forever do
-    BrickChan.readBChan restartChan
-    liftIO $ writeIORef restarting True
-    self <- getExecutablePath
-    -- Swallow failures: a restart that errors must not take down the TUI, and
-    -- the flag has to be cleared either way.
-    _ <- trySync $ readProcessStdout $ proc self ["restart"]
-    void waitForDaemon
-    liftIO $ writeIORef restarting False
+restartWorker restartChan restarting = forever
+    $ bracket_
+        (BrickChan.readBChan restartChan >> atomically (writeTVar restarting True))
+        (atomically $ writeTVar restarting False)
+        do
+            self <- getExecutablePath
+            -- Swallow failures: a restart that errors must not take down the TUI, and
+            -- the flag has to be cleared either way.
+            _ <- trySync $ runProcess $ proc self ["restart"]
+            void waitForDaemon
 
 
 watchApp :: IO () -> KeyConfig KeyEvent -> App State Event Viewports

--- a/tricorder/src/Tricorder/UI/Keys.hs
+++ b/tricorder/src/Tricorder/UI/Keys.hs
@@ -58,7 +58,8 @@ import Data.Text qualified as T
 import Tricorder.UI.Misc (warn)
 import Tricorder.UI.Route (Route)
 import Tricorder.UI.State
-    ( State (..)
+    ( Processed (Waiting)
+    , State (..)
     , Viewports (..)
     , currentRoute
     , cycleTestFilter
@@ -69,11 +70,16 @@ import Tricorder.UI.State
 import Tricorder.UI.Route qualified as Route
 
 
--- When adding a new event here, also list it in the README under "Custom Key Bindings".
+-- | [tag:keybinding_events] The TUI key events. This type is the source of truth
+-- for the event names documented in README.md under "Custom Key Bindings", which
+-- points back here with a matching @ref@. Whenever you add, remove, or rename a
+-- 'KeyEvent', update that list to match — @tagref check@ flags the dangling
+-- reference if this tag is renamed or dropped without touching the docs.
 data KeyEvent
     = ToggleDaemonInfoView
     | ToggleHelp
     | CycleTestView
+    | RestartDaemon
     | ExitView
     | ScrollUp
     | ScrollDown
@@ -99,6 +105,7 @@ keys =
         [ ("toggle daemon info", ToggleDaemonInfoView)
         , ("toggle help", ToggleHelp)
         , ("cycle test view", CycleTestView)
+        , ("restart daemon", RestartDaemon)
         , ("exit view", ExitView)
         , ("scroll up", ScrollUp)
         , ("scroll down", ScrollDown)
@@ -111,6 +118,7 @@ bindings =
     [ (ToggleDaemonInfoView, [bind 'g'])
     , (ToggleHelp, [bind 'h'])
     , (CycleTestView, [bind 't'])
+    , (RestartDaemon, [bind 'R'])
     , (ExitView, [binding KEsc []])
     , (ScrollUp, [binding KUp []])
     , (ScrollDown, [binding KDown []])
@@ -160,8 +168,11 @@ parseKeyEvent :: Text -> Either Text KeyEvent
 parseKeyEvent ev = maybeToRight ("Unrecognized key event: " <> ev) $ textToKeyEvent ev
 
 
-dispatcher :: KeyConfig KeyEvent -> KeyDispatcher KeyEvent (EventM Viewports State)
-dispatcher cfg =
+-- | Build the key dispatcher. @requestRestart@ is run (in 'IO') when the restart
+-- key is pressed; it hands the request off to the worker that owns the daemon
+-- control effects, since brick's 'EventM' cannot run them directly.
+dispatcher :: IO () -> KeyConfig KeyEvent -> KeyDispatcher KeyEvent (EventM Viewports State)
+dispatcher requestRestart cfg =
     -- TODO: Handle this error more gracefully.
     either (error . ("Invalid key dispatcher config: " <>) . stringify) id
         $ keyDispatcher
@@ -186,6 +197,9 @@ dispatcher cfg =
                         else
                             s {testFilter = cycleTestFilter s.testFilter}
                     _ -> navigate Route.Tests s
+            , onEvent RestartDaemon "Restart the daemon" do
+                liftIO requestRestart
+                modify \s -> s {buildState = Waiting}
             , onEvent ExitView "Exit or go back" do
                 gets (.route) >>= \case
                     Route.Main -> halt

--- a/tricorder/src/Tricorder/UI/View.hs
+++ b/tricorder/src/Tricorder/UI/View.hs
@@ -127,7 +127,9 @@ viewMain ws = withBuildState ws (viewDefaultPanel ws.timeZone)
 viewHelp :: KeyConfig KeyEvent -> Widget n
 viewHelp kc = viewKeybindings kc handlers
   where
-    handlers = (.khHandler) . snd <$> keyDispatcherToList (Keys.dispatcher kc)
+    -- The dispatcher is built only to enumerate handler descriptions for the help
+    -- view, so the restart action is a no-op here.
+    handlers = (.khHandler) . snd <$> keyDispatcherToList (Keys.dispatcher (pure ()) kc)
 
 
 withBuildState :: State -> (BuildState -> Widget Viewports) -> Widget Viewports


### PR DESCRIPTION
Add a `restart_daemon` key event (bound to `R`) that restarts the daemon from `tricorder ui`, rebindable like the other key events.

- The brick event handler signals a worker thread over a channel, since it cannot run the daemon-control effects itself.
- The restart runs out-of-process by spawning `tricorder restart`: the daemon spawn double-forks, and forking the vty-controlled TUI process corrupts the terminal, so the fork must stay isolated.
- `queryWatch` stays patient while a restart we initiated is in flight, reconnecting to the fresh daemon instead of giving up.
- Extract a shared `restartDaemon` so the CLI `restart` subcommand and the TUI share one implementation.
- Expose `getExecutablePath` from `Atelier.Effects.Process` for re-invoking the program as a subprocess.
- Tie the README key-event list to the `KeyEvent` type with a tagref cross-reference.