### PR TITLE
refactor: add PostBuild

### DIFF
--- a/tricorder/src/Tricorder/BuildState.hs
+++ b/tricorder/src/Tricorder/BuildState.hs
@@ -9,6 +9,8 @@ module Tricorder.BuildState
     ( BuildId (..)
     , BuildState (..)
     , BuildPhase (..)
+    , PostBuild (..)
+    , TestPhase (..)
     , BuildProgress (..)
     , BuildResult (..)
     , TestRun (..)
@@ -34,6 +36,7 @@ import Atelier.Time (Millisecond)
 import Data.Aeson (FromJSON (..), ToJSON (..), withText)
 import Data.Time (UTCTime)
 import Effectful.Reader.Static (Reader, ask)
+import GHC.Generics (Generically (..))
 import System.FilePath (makeRelative)
 
 import Tricorder.Effects.SessionStore (SessionStore)
@@ -160,11 +163,23 @@ data BuildProgress = BuildProgress
 data BuildPhase
     = Building (Maybe BuildProgress)
     | Restarting
-    | Testing BuildResult
-    | Done BuildResult
+    | BuildComplete PostBuild
     | BuildFailed Text
     deriving stock (Eq, Generic, Show)
     deriving anyclass (FromJSON, ToJSON)
+
+
+data PostBuild = PostBuild
+    { testPhase :: TestPhase
+    , result :: BuildResult
+    }
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via Generically PostBuild
+
+
+data TestPhase = Testing | DoneTesting
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via Generically TestPhase
 
 
 data BuildState = BuildState
@@ -209,8 +224,8 @@ instance ToJSON Severity where
 stateLabel :: BuildPhase -> Text
 stateLabel (Building _) = "building"
 stateLabel Restarting = "restarting"
-stateLabel (Testing _) = "testing"
-stateLabel (Done result)
+stateLabel (BuildComplete (PostBuild Testing _)) = "testing"
+stateLabel (BuildComplete (PostBuild _ result))
     | any (\m -> m.severity == SError) result.diagnostics = "error"
     | any (\m -> m.severity == SWarning) result.diagnostics = "warning"
     | otherwise = "ok"

--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -47,8 +47,10 @@ import Tricorder.BuildState
     , BuildResult (..)
     , CabalChangeDetected (..)
     , Diagnostic (..)
+    , PostBuild (..)
     , Severity (..)
     , SourceChangeDetected (..)
+    , TestPhase (..)
     , TestRun (..)
     )
 import Tricorder.Builder.Dispatch
@@ -535,7 +537,13 @@ requestTestRunsForNewBuildResults config partialResult = do
     runTestsIfClean config buildId partialResult >>= \case
         Nothing -> Log.info "Test run aborted by source change; skipping Done transition."
         Just testRuns ->
-            setNewPhase $ EnteringNewPhase buildId $ Done partialResult {testRuns}
+            setNewPhase
+                $ EnteringNewPhase buildId
+                $ BuildComplete
+                    PostBuild
+                        { testPhase = DoneTesting
+                        , result = partialResult {testRuns}
+                        }
 
 
 -- Run all configured test suites if the build has no errors.
@@ -559,7 +567,11 @@ runTestsIfClean (BuildConfig {testTargets}) bid partialResult
         TestRunner.resetAbort
         setNewPhase
             $ EnteringNewPhase bid
-            $ Testing partialResult {testRuns = map (`TestRunning` Nothing) targetNames}
+            $ BuildComplete
+                PostBuild
+                    { testPhase = Testing
+                    , result = partialResult {testRuns = map (`TestRunning` Nothing) targetNames}
+                    }
 
         Log.info $ "Running " <> show (length targetNames) <> " test suite(s)"
 
@@ -580,7 +592,12 @@ runTestsIfClean (BuildConfig {testTargets}) bid partialResult
             let acc' = insert target result acc
             setNewPhase
                 $ EnteringNewPhase bid
-                $ Testing partialResult {testRuns = snd <$> acc'}
+                $ BuildComplete
+                    PostBuild
+                        { testPhase = Testing
+                        , result = partialResult {testRuns = snd <$> acc'}
+                        }
+
             runLoop acc' rest
 
     insert _ _ [] = []

--- a/tricorder/src/Tricorder/CLI.hs
+++ b/tricorder/src/Tricorder/CLI.hs
@@ -34,9 +34,11 @@ import Tricorder.BuildState
     , BuildResult (..)
     , BuildState (..)
     , Diagnostic (..)
+    , PostBuild (..)
     , Severity (..)
     , TestCase (..)
     , TestCaseOutcome (..)
+    , TestPhase (..)
     , TestRun (..)
     , TestRunCompletion (..)
     , TestRunError (..)
@@ -81,7 +83,7 @@ showStatus opts = do
         case current of
             Right BuildState {phase = Building _} -> Console.putStrLn "Building..."
             Right BuildState {phase = Restarting} -> Console.putStrLn "Restarting..."
-            Right BuildState {phase = Testing _} -> Console.putStrLn "Testing..."
+            Right BuildState {phase = BuildComplete (PostBuild Testing _)} -> Console.putStrLn "Testing..."
             _ -> pure ()
     result <-
         case opts.wait of
@@ -100,9 +102,9 @@ showStatus opts = do
     renderText verbosity expand state = case state.phase of
         Building _ -> Console.putStrLn "Building..."
         Restarting -> Console.putStrLn "Restarting..."
-        Testing _ -> Console.putStrLn "Testing..."
         BuildFailed msg -> reportBuildFailed msg
-        Done r -> do
+        BuildComplete (PostBuild Testing _) -> Console.putStrLn "Testing..."
+        BuildComplete (PostBuild _ r) -> do
             tz <- currentTimeZone
             case expand of
                 Just n ->
@@ -209,8 +211,7 @@ showTests opts = do
             case state.phase of
                 Building _ -> Console.putStrLn "Build in progress, no test results yet."
                 Restarting -> Console.putStrLn "Daemon restarting, no test results yet."
-                Testing r -> renderTestRuns r.testRuns
-                Done r -> renderTestRuns r.testRuns
+                BuildComplete r -> renderTestRuns r.result.testRuns
                 BuildFailed msg -> reportBuildFailed msg
   where
     renderTestRuns [] = Console.putStrLn "No test results."

--- a/tricorder/src/Tricorder/Effects/BuildStore.hs
+++ b/tricorder/src/Tricorder/Effects/BuildStore.hs
@@ -31,6 +31,8 @@ import Tricorder.BuildState
     , BuildState (..)
     , ChangeKind (..)
     , DaemonInfo (..)
+    , PostBuild (..)
+    , TestPhase (..)
     , initialBuildState
     )
 
@@ -96,8 +98,8 @@ isBuilding :: BuildState -> Bool
 isBuilding s = case s.phase of
     Building _ -> True
     Restarting -> True
-    Testing _ -> True
-    Done _ -> False
+    BuildComplete (PostBuild Testing _) -> True
+    BuildComplete (PostBuild DoneTesting _) -> False
     BuildFailed _ -> False
 
 

--- a/tricorder/src/Tricorder/Effects/TestRunner.hs
+++ b/tricorder/src/Tricorder/Effects/TestRunner.hs
@@ -46,6 +46,8 @@ import Tricorder.BuildState
     , BuildProgress (..)
     , BuildResult (..)
     , BuildState (..)
+    , PostBuild (..)
+    , TestPhase (..)
     , TestRun (..)
     , TestRunCompletion (..)
     , TestRunError (..)
@@ -233,12 +235,12 @@ reportTestProgress
     :: (BuildStore :> es) => Text -> GhciLoading -> Eff es ()
 reportTestProgress target loading =
     modifyPhase \state -> case state.phase of
-        Testing partialResult ->
+        BuildComplete (PostBuild Testing partialResult) ->
             let progress = BuildProgress {compiled = loading.index, total = loading.total}
                 updateRun (TestRunning t _) | t == target = TestRunning t (Just progress)
                 updateRun r = r
                 newRuns = map updateRun partialResult.testRuns
-            in  Testing partialResult {testRuns = newRuns}
+            in  BuildComplete (PostBuild Testing partialResult {testRuns = newRuns})
         other -> other
 
 

--- a/tricorder/src/Tricorder/Socket/Server.hs
+++ b/tricorder/src/Tricorder/Socket/Server.hs
@@ -17,7 +17,7 @@ import Atelier.Effects.Conc qualified as Conc
 import Atelier.Effects.Log qualified as Log
 import Data.ByteString.Lazy qualified as BSL
 
-import Tricorder.BuildState (BuildPhase (..), BuildResult (..), BuildState (..), Diagnostic)
+import Tricorder.BuildState (BuildPhase (..), BuildResult (..), BuildState (..), Diagnostic, PostBuild (..), TestPhase (..))
 import Tricorder.Effects.BuildStore (BuildStore, getState, waitForAnyChange, waitUntilDone)
 import Tricorder.Effects.GhcPkg (GhcPkg)
 import Tricorder.Effects.UnixSocket
@@ -192,8 +192,8 @@ respondWhenDone h = awaitResult >>= sendJson h
         case s.phase of
             Building _ -> waitUntilDone
             Restarting -> waitUntilDone
-            Testing _ -> waitUntilDone
-            Done _ -> awaitBuildStart (5 :: Int) s
+            BuildComplete (PostBuild Testing _) -> waitUntilDone
+            BuildComplete (PostBuild DoneTesting _) -> awaitBuildStart (5 :: Int) s
             BuildFailed _ -> pure s
 
     -- Poll up to n × 50ms for a build to start, then wait for it to finish.
@@ -204,8 +204,8 @@ respondWhenDone h = awaitResult >>= sendJson h
         case s'.phase of
             Building _ -> waitUntilDone
             Restarting -> waitUntilDone
-            Testing _ -> waitUntilDone
-            Done _ -> awaitBuildStart (n - 1) s'
+            BuildComplete (PostBuild Testing _) -> waitUntilDone
+            BuildComplete (PostBuild DoneTesting _) -> awaitBuildStart (n - 1) s'
             BuildFailed _ -> pure s'
 
 
@@ -226,7 +226,7 @@ respondDiagnostic :: (BuildStore :> es, UnixSocket :> es) => Int -> Handle -> Ef
 respondDiagnostic idx h = do
     state <- getState
     case state.phase of
-        Done r -> case r.diagnostics !!? (idx - 1) of
+        BuildComplete (PostBuild DoneTesting r) -> case r.diagnostics !!? (idx - 1) of
             Nothing ->
                 sendJson h
                     $ ErrorResponse
@@ -239,7 +239,7 @@ respondDiagnostic idx h = do
         BuildFailed msg -> sendJson h $ ErrorResponse $ "Build command failed:\n" <> msg
         Building _ -> sendJson h $ ErrorResponse "Build in progress"
         Restarting -> sendJson h $ ErrorResponse "Build in progress"
-        Testing _ -> sendJson h $ ErrorResponse "Build in progress"
+        BuildComplete (PostBuild Testing _) -> sendJson h $ ErrorResponse "Build in progress"
 
 
 -- | Look up source for each requested module and send the results as a JSON array.

--- a/tricorder/src/Tricorder/UI/View.hs
+++ b/tricorder/src/Tricorder/UI/View.hs
@@ -40,6 +40,7 @@ import Tricorder.BuildState
     , BuildState (..)
     , DaemonInfo (..)
     , Diagnostic (..)
+    , PostBuild (..)
     , Severity (..)
     , TestCase (..)
     , TestCaseOutcome (..)
@@ -259,8 +260,7 @@ viewBuildPhase tz = \case
     Building Nothing -> warn $ txt "Building..."
     Building (Just p) -> warn $ txt $ "Building (" <> show p.compiled <> "/" <> show p.total <> ")..."
     Restarting -> warn $ txt "Restarting..."
-    Testing result -> vBoxSpaced 1 [viewBuildResult tz result, viewTestRuns result.testRuns]
-    Done result -> vBoxSpaced 1 [viewBuildResult tz result, viewTestRuns result.testRuns]
+    BuildComplete build -> vBoxSpaced 1 [viewBuildResult tz build.result, viewTestRuns build.result.testRuns]
     BuildFailed msg -> viewBuildFailed msg
 
 
@@ -392,8 +392,7 @@ viewBuildPhaseLine tz = \case
     Building Nothing -> warn $ txt "Building..."
     Building (Just p) -> warn $ txt $ "Building (" <> show p.compiled <> "/" <> show p.total <> ")..."
     Restarting -> warn $ txt "Restarting..."
-    Testing result -> viewBuildResultLine tz result
-    Done result -> viewBuildResultLine tz result
+    BuildComplete build -> viewBuildResultLine tz build.result
     BuildFailed _ -> err $ txt "Build command failed"
 
 
@@ -418,8 +417,7 @@ viewBuildResultLine tz result
 
 
 phaseTestRuns :: BuildPhase -> [TestRun]
-phaseTestRuns (Testing r) = r.testRuns
-phaseTestRuns (Done r) = r.testRuns
+phaseTestRuns (BuildComplete r) = r.result.testRuns
 phaseTestRuns _ = []
 
 

--- a/tricorder/test/Unit/Tricorder/BuildStateSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuildStateSpec.hs
@@ -4,7 +4,7 @@ import Data.Aeson (eitherDecode, encode)
 import Data.Time (UTCTime (..), fromGregorian)
 import Test.Hspec
 
-import Tricorder.BuildState (BuildId (..), BuildPhase (..), BuildResult (..), BuildState (..), DaemonInfo (..), Diagnostic (..), Severity (..))
+import Tricorder.BuildState (BuildId (..), BuildPhase (..), BuildResult (..), BuildState (..), DaemonInfo (..), Diagnostic (..), PostBuild (..), Severity (..), TestPhase (..))
 
 
 spec_BuildState :: Spec
@@ -74,8 +74,24 @@ mkBuildState :: [Diagnostic] -> BuildState
 mkBuildState msgs =
     BuildState
         { buildId = BuildId 1
-        , phase = Done (BuildResult {completedAt = epoch, duration = 0, moduleCount = 0, diagnostics = msgs, testRuns = []})
-        , daemonInfo = DaemonInfo {targets = [], watchDirs = [], sockPath = "", logFile = "", metricsPort = Nothing}
+        , phase =
+            BuildComplete
+                $ PostBuild DoneTesting
+                $ BuildResult
+                    { completedAt = epoch
+                    , duration = 0
+                    , moduleCount = 0
+                    , diagnostics = msgs
+                    , testRuns = []
+                    }
+        , daemonInfo =
+            DaemonInfo
+                { targets = []
+                , watchDirs = []
+                , sockPath = ""
+                , logFile = ""
+                , metricsPort = Nothing
+                }
         }
   where
     epoch = UTCTime (fromGregorian 1970 1 1) 0

--- a/tricorder/test/Unit/Tricorder/BuildStoreSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuildStoreSpec.hs
@@ -11,7 +11,7 @@ import Test.Hspec
 
 import Atelier.Effects.Conc qualified as Conc
 
-import Tricorder.BuildState (BuildId (..), BuildPhase (..), BuildResult (..), BuildState (..), DaemonInfo (..))
+import Tricorder.BuildState (BuildId (..), BuildPhase (..), BuildResult (..), BuildState (..), DaemonInfo (..), PostBuild (..), TestPhase (..))
 import Tricorder.Effects.BuildStore
     ( BuildStore
     , getState
@@ -140,12 +140,12 @@ testSTM = do
                     setPhase (BuildId 1) donePhase
                     setPhase (BuildId 2) (Building Nothing)
                 waitUntilDone
-            -- The waiter must report Done(1), NOT skip past it and report
-            -- the later Done(2) (or block forever).
+            -- The waiter must report BuildComplete(1), NOT skip past it and
+            -- report the later BuildComplete(2) (or block forever).
             result.buildId `shouldBe` BuildId 1
             case result.phase of
-                Done _ -> pure ()
-                p -> expectationFailure $ "expected Done phase, got: " <> show p
+                BuildComplete _ -> pure ()
+                p -> expectationFailure $ "expected BuildComplete phase, got: " <> show p
 
 
 --------------------------------------------------------------------------------
@@ -153,7 +153,14 @@ testSTM = do
 --------------------------------------------------------------------------------
 
 emptyDaemonInfo :: DaemonInfo
-emptyDaemonInfo = DaemonInfo {targets = [], watchDirs = [], sockPath = "", logFile = "", metricsPort = Nothing}
+emptyDaemonInfo =
+    DaemonInfo
+        { targets = []
+        , watchDirs = []
+        , sockPath = ""
+        , logFile = ""
+        , metricsPort = Nothing
+        }
 
 
 buildingAt :: Int -> BuildState
@@ -161,7 +168,16 @@ buildingAt n = BuildState (BuildId n) (Building Nothing) emptyDaemonInfo
 
 
 donePhase :: BuildPhase
-donePhase = Done (BuildResult {completedAt = epoch, duration = 0, moduleCount = 0, diagnostics = [], testRuns = []})
+donePhase =
+    BuildComplete
+        $ PostBuild DoneTesting
+        $ BuildResult
+            { completedAt = epoch
+            , duration = 0
+            , moduleCount = 0
+            , diagnostics = []
+            , testRuns = []
+            }
 
 
 doneAt :: Int -> BuildState

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -32,19 +32,7 @@ import Control.Concurrent.STM qualified as STM
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 
-import Tricorder.BuildState
-    ( BuildId (..)
-    , BuildPhase (..)
-    , BuildResult (..)
-    , BuildState (..)
-    , CabalChangeDetected (..)
-    , DaemonInfo (..)
-    , Diagnostic (..)
-    , Severity (..)
-    , SourceChangeDetected (..)
-    , TestRun (..)
-    , TestRunCompletion (..)
-    )
+import Tricorder.BuildState (BuildId (..), BuildPhase (..), BuildResult (..), BuildState (..), CabalChangeDetected (..), DaemonInfo (..), Diagnostic (..), PostBuild (..), Severity (..), SourceChangeDetected (..), TestPhase (..), TestRun (..), TestRunCompletion (..))
 import Tricorder.Builder
     ( BuildConfig (..)
     , EnteringNewPhase (..)
@@ -179,7 +167,7 @@ testBuildWithGhciRecovery = do
         length [() | EnteringNewPhase _ (BuildFailed _) <- phases] `shouldBe` 1
         -- The source change drove a second, successful launch to completion.
         -- With the bug the builder is parked, so no Done is ever emitted.
-        length [() | EnteringNewPhase _ (Done _) <- phases] `shouldSatisfy` (>= 1)
+        length [() | EnteringNewPhase _ (BuildComplete _) <- phases] `shouldSatisfy` (>= 1)
   where
     successLoad =
         LoadResult
@@ -310,11 +298,11 @@ testReloadOnSourceChange = do
             $ reloadOnSourceChange (def @BuildConfig) ctrls event
 
     flow lr =
-        [ EnteringNewPhase (BuildId 1) (Building Nothing)
-        , EnteringNewPhase (BuildId 1) (Done (resultFor lr))
+        [ EnteringNewPhase (BuildId 1) $ Building Nothing
+        , EnteringNewPhase (BuildId 1) $ BuildComplete $ PostBuild DoneTesting (resultFor lr)
         ]
 
-    buildResultsFrom phases = [r | EnteringNewPhase _ (Done r) <- phases]
+    buildResultsFrom phases = [r | EnteringNewPhase _ (BuildComplete (PostBuild _ r)) <- phases]
 
     resultFor lr =
         BuildResult
@@ -459,13 +447,21 @@ testRequestTestRunsForNewBuildResults = do
     describe "when there are no test targets" $ it "should skip testing" do
         phases <- runTest (parseTestTargets []) [] expected
         length phases `shouldBe` 1
-        phases `shouldMatchList` [EnteringNewPhase (BuildId 1) $ Done expected]
+        phases
+            `shouldMatchList` [ EnteringNewPhase (BuildId 1)
+                                    $ BuildComplete
+                                    $ PostBuild DoneTesting expected
+                              ]
 
     describe "when there are errors" $ it "should skip testing" do
         let expected' = expected {BuildState.diagnostics = [errMsg]}
         phases <- runTest (parseTestTargets ["test:foo"]) [] expected'
         length phases `shouldBe` 1
-        phases `shouldMatchList` [EnteringNewPhase (BuildId 1) $ Done expected']
+        phases
+            `shouldMatchList` [ EnteringNewPhase (BuildId 1)
+                                    $ BuildComplete
+                                    $ PostBuild DoneTesting expected'
+                              ]
 
     it "should emit EnteringNewPhase events for each test target" do
         phases <-
@@ -523,7 +519,7 @@ testRequestTestRunsForNewBuildResults = do
         -- aborted before completing the second suite. A Done here would
         -- briefly publish a half-finished testRuns list that a
         -- 'status --wait' caller could observe.
-        length [() | EnteringNewPhase _ (Done _) <- phases] `shouldBe` 0
+        length [() | EnteringNewPhase _ (BuildComplete (PostBuild DoneTesting _)) <- phases] `shouldBe` 0
         -- Sanity: only the initial Testing transition was published; the
         -- run loop short-circuited after the first 'isAborted' check, so
         -- the post-foo Testing update never fired.
@@ -547,8 +543,8 @@ testRequestTestRunsForNewBuildResults = do
                 partial
 
     mkPhase = EnteringNewPhase (BuildId 1)
-    mkTesting = mkPhase . Testing
-    mkDone = mkPhase . Done
+    mkTesting = mkPhase . BuildComplete . PostBuild Testing
+    mkDone = mkPhase . BuildComplete . PostBuild DoneTesting
     buildWithTests testRuns = expected {testRuns}
 
     expected =

--- a/tricorder/test/Unit/Tricorder/TestRunnerSpec.hs
+++ b/tricorder/test/Unit/Tricorder/TestRunnerSpec.hs
@@ -15,16 +15,7 @@ import Effectful.Reader.Static (runReader)
 import Effectful.State.Static.Shared (evalState)
 import Test.Hspec
 
-import Tricorder.BuildState
-    ( BuildId (..)
-    , BuildPhase (..)
-    , BuildProgress (..)
-    , BuildResult (..)
-    , BuildState (..)
-    , DaemonInfo (..)
-    , TestRun (..)
-    , TestRunCompletion (..)
-    )
+import Tricorder.BuildState (BuildId (..), BuildPhase (..), BuildProgress (..), BuildResult (..), BuildState (..), DaemonInfo (..), PostBuild (..), TestPhase (..), TestRun (..), TestRunCompletion (..))
 import Tricorder.Effects.BuildStore (getState)
 import Tricorder.Effects.GhciSession.GhciParser (GhciLoading (..))
 import Tricorder.Effects.TestRunner
@@ -241,7 +232,12 @@ testAbortGatedProgress = do
         abortedRef <- newTVarIO True
         let loadings = [mkLoading i 10 | i <- [1 .. 5]]
         finalRuns <- runStore do
-            BuildStore.setPhase (BuildId 1) (Testing (partialResultWith startingRuns))
+            BuildStore.setPhase (BuildId 1)
+                $ BuildComplete
+                    PostBuild
+                        { testPhase = Testing
+                        , result = partialResultWith startingRuns
+                        }
             for_ loadings (abortGatedProgress abortedRef "test:foo")
             phaseTestRuns <$> getState
         finalRuns `shouldBe` startingRuns
@@ -249,7 +245,14 @@ testAbortGatedProgress = do
     it "flips behaviour mid-run if abortedRef is set between updates" do
         abortedRef <- newTVarIO False
         finalRuns <- runStore do
-            BuildStore.setPhase (BuildId 1) (Testing (partialResultWith startingRuns))
+            BuildStore.setPhase
+                (BuildId 1)
+                $ BuildComplete
+                    PostBuild
+                        { testPhase = Testing
+                        , result = partialResultWith startingRuns
+                        }
+
             -- This one applies.
             abortGatedProgress abortedRef "test:foo" (mkLoading 3 10)
             -- Simulate the interrupt firing.
@@ -268,7 +271,12 @@ testAbortGatedProgress = do
     runProgress aborted loading runs = do
         abortedRef <- newTVarIO aborted
         runStore do
-            BuildStore.setPhase (BuildId 1) (Testing (partialResultWith runs))
+            BuildStore.setPhase (BuildId 1)
+                $ BuildComplete
+                    PostBuild
+                        { testPhase = Testing
+                        , result = partialResultWith runs
+                        }
             abortGatedProgress abortedRef "test:foo" loading
             phaseTestRuns <$> getState
 
@@ -302,7 +310,7 @@ testAbortGatedProgress = do
 
     phaseTestRuns :: BuildState -> [TestRun]
     phaseTestRuns s = case s.phase of
-        Testing r -> r.testRuns
+        BuildComplete (PostBuild Testing r) -> r.testRuns
         _ -> []
 
     epoch :: UTCTime


### PR DESCRIPTION
Once a build is done, there can be a multitude of other things that take
place with the finalized result. One of these things is testing, but in
the future we will also support eval comments that have to be evaluated,
and potentially other "post-build" processes. Keeping these post-build
phases as proper `BuildPhase` values restricts the order they can be
performed, and duplicates the `BuildResult` across multiple post-build
states.

This PR renames `Done` to `BuildComplete` to better signal that it's the
GHC build that is complete, while tests and other post-build processes'
states are kept in `PostBuild` to be updated later by their respective
processes.
