### PR TITLE
refactor: separate actions made to the build result after build

### DIFF
--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -47,7 +47,6 @@ import Tricorder.BuildState
     , BuildResult (..)
     , CabalChangeDetected (..)
     , Diagnostic (..)
-    , PostBuild (..)
     , Severity (..)
     , SourceChangeDetected (..)
     , TestPhase (..)
@@ -67,13 +66,23 @@ import Tricorder.Effects.BuildStore (BuildStore)
 import Tricorder.Effects.GhciSession (GhciSession, LoadResult (..))
 import Tricorder.Effects.GhciSession.GhciParser (resolveKnownTargets)
 import Tricorder.Effects.GhciSession.GhciProcess (GhciProcessError (..))
+import Tricorder.Effects.PostBuildStore (PostBuildStore)
 import Tricorder.Effects.SessionStore (SessionStore)
 import Tricorder.Effects.TestRunner (TestRunner)
 import Tricorder.Runtime (ProjectRoot (..))
-import Tricorder.Session (Command (..), Session (..), Target, TestTargets, WatchDirs, getTestTargets, renderTarget)
+import Tricorder.Session
+    ( Command (..)
+    , Session (..)
+    , Target
+    , TestTargets
+    , WatchDirs
+    , getTestTargets
+    , renderTarget
+    )
 
 import Tricorder.Effects.BuildStore qualified as BuildStore
 import Tricorder.Effects.GhciSession qualified as GhciSession
+import Tricorder.Effects.PostBuildStore qualified as PostBuild
 import Tricorder.Effects.SessionStore qualified as SessionStore
 import Tricorder.Effects.TestRunner qualified as TestRunner
 
@@ -480,14 +489,15 @@ afterLoad
     :: ( BuildStore :> es
        , Log :> es
        , Reader ProjectRoot :> es
-       , State BuildId :> es
        , State BuilderState :> es
        , TestRunner :> es
        )
     => BuildConfig -> NewLoadResult -> Eff es ()
 afterLoad config newLoadResult = do
     buildResult <- compileLoadResultsIntoBuildResults config newLoadResult
-    requestTestRunsForNewBuildResults config buildResult
+    when (all ((/= SError) . (.severity)) buildResult.diagnostics)
+        $ BuildStore.withPostBuildPhase buildResult do
+            requestTestRunsForNewBuildResults config.testTargets
 
 
 compileLoadResultsIntoBuildResults
@@ -524,26 +534,21 @@ compileLoadResultsIntoBuildResults session newLoadResult = do
 
 
 requestTestRunsForNewBuildResults
-    :: ( BuildStore :> es
-       , Log :> es
-       , State BuildId :> es
+    :: ( Log :> es
+       , PostBuildStore :> es
        , TestRunner :> es
        )
-    => BuildConfig
-    -> BuildResult
+    => TestTargets
     -> Eff es ()
-requestTestRunsForNewBuildResults config partialResult = do
-    buildId <- get
-    runTestsIfClean config buildId partialResult >>= \case
-        Nothing -> Log.info "Test run aborted by source change; skipping Done transition."
-        Just testRuns ->
-            setNewPhase
-                $ EnteringNewPhase buildId
-                $ BuildComplete
-                    PostBuild
-                        { testPhase = DoneTesting
-                        , result = partialResult {testRuns}
-                        }
+requestTestRunsForNewBuildResults testTargets = case nonEmpty testTargets.getTestTargets of
+    Nothing ->
+        PostBuild.setTestPhase DoneTesting
+    Just tts ->
+        runTestsIfClean tts >>= \case
+            Nothing -> Log.info "Test run aborted by source change; skipping Done transition."
+            Just testRuns -> do
+                PostBuild.setTestPhase DoneTesting
+                PostBuild.updateBuildResult \br -> br {testRuns}
 
 
 -- Run all configured test suites if the build has no errors.
@@ -553,34 +558,26 @@ requestTestRunsForNewBuildResults config partialResult = do
 -- (the caller should not transition to a Done phase in that case). Returns
 -- 'Just' with the collected results otherwise.
 runTestsIfClean
-    :: ( BuildStore :> es
-       , Log :> es
+    :: ( Log :> es
+       , PostBuildStore :> es
        , TestRunner :> es
        )
-    => BuildConfig
-    -> BuildId
-    -> BuildResult
+    => NonEmpty Target
     -> Eff es (Maybe [TestRun])
-runTestsIfClean (BuildConfig {testTargets}) bid partialResult
-    | null targetNames || any (\d -> d.severity == SError) partialResult.diagnostics = pure (Just [])
-    | otherwise = do
-        TestRunner.resetAbort
-        setNewPhase
-            $ EnteringNewPhase bid
-            $ BuildComplete
-                PostBuild
-                    { testPhase = Testing
-                    , result = partialResult {testRuns = map (`TestRunning` Nothing) targetNames}
-                    }
+runTestsIfClean testTargets = do
+    TestRunner.resetAbort
+    PostBuild.setTestPhase Testing
+    PostBuild.updateBuildResult \br ->
+        br {testRuns = map (`TestRunning` Nothing) targetNames}
 
-        Log.info $ "Running " <> show (length targetNames) <> " test suite(s)"
+    Log.info $ "Running " <> show (length targetNames) <> " test suite(s)"
 
-        let initial = (\t -> (t, TestRunning t Nothing)) <$> targetNames
-        runLoop initial targetNames
+    let initial = (\t -> (t, TestRunning t Nothing)) <$> targetNames
+    runLoop initial targetNames
   where
     -- The runner consumes the @test:@ targets as cabal/ghci arguments, so
     -- render the structured targets to their textual form at this boundary.
-    targetNames = map renderTarget testTargets.getTestTargets
+    targetNames = map renderTarget $ toList testTargets
     runLoop acc [] = pure (Just (snd <$> acc))
     runLoop acc (target : rest) = do
         Log.info $ "Running tests: " <> target
@@ -590,14 +587,7 @@ runTestsIfClean (BuildConfig {testTargets}) bid partialResult
             pure Nothing
         else do
             let acc' = insert target result acc
-            setNewPhase
-                $ EnteringNewPhase bid
-                $ BuildComplete
-                    PostBuild
-                        { testPhase = Testing
-                        , result = partialResult {testRuns = snd <$> acc'}
-                        }
-
+            PostBuild.updateBuildResult \br -> br {testRuns = snd <$> acc'}
             runLoop acc' rest
 
     insert _ _ [] = []

--- a/tricorder/src/Tricorder/Effects/BuildStore.hs
+++ b/tricorder/src/Tricorder/Effects/BuildStore.hs
@@ -11,23 +11,41 @@ module Tricorder.Effects.BuildStore
     , waitDirty
     , hasWaiters
 
+      -- * Intermediate interpreters
+    , withPostBuildPhase
+
       -- * Interpreters
     , runBuildStoreScripted
     , runBuildStore
+    , runBuildStoreState
     ) where
 
 import Atelier.Effects.Input (Input, input)
 import Effectful (Effect)
 import Effectful.Concurrent (Concurrent)
-import Effectful.Concurrent.STM (TChan, TVar, atomically, dupTChan, modifyTVar, newBroadcastTChan, newTVar, readTChan, readTVar, retry, writeTChan, writeTVar)
-import Effectful.Dispatch.Dynamic (interpretWith_, reinterpret)
+import Effectful.Concurrent.STM
+    ( TChan
+    , TVar
+    , atomically
+    , dupTChan
+    , modifyTVar
+    , newBroadcastTChan
+    , newTVar
+    , readTChan
+    , readTVar
+    , retry
+    , writeTChan
+    , writeTVar
+    )
+import Effectful.Dispatch.Dynamic (interpretWith_, interpret_, reinterpret)
 import Effectful.Exception (bracket_)
-import Effectful.State.Static.Shared (State, evalState, get, put)
+import Effectful.State.Static.Shared (State, evalState, get, modify, put)
 import Effectful.TH (makeEffect)
 
 import Tricorder.BuildState
     ( BuildId
     , BuildPhase (..)
+    , BuildResult
     , BuildState (..)
     , ChangeKind (..)
     , DaemonInfo (..)
@@ -35,6 +53,7 @@ import Tricorder.BuildState
     , TestPhase (..)
     , initialBuildState
     )
+import Tricorder.Effects.PostBuildStore (PostBuildStore (..))
 
 
 data BuildStore :: Effect where
@@ -62,6 +81,29 @@ data BuildStore :: Effect where
 
 
 makeEffect ''BuildStore
+
+
+withPostBuildPhase :: (BuildStore :> es) => BuildResult -> Eff (PostBuildStore : es) a -> Eff es a
+withPostBuildPhase initialBuildResult =
+    interpret_ \case
+        SetTestPhase tp -> modifyPhase \state -> case state.phase of
+            BuildComplete pb ->
+                BuildComplete pb {testPhase = tp}
+            _ ->
+                BuildComplete
+                    PostBuild
+                        { testPhase = tp
+                        , result = initialBuildResult
+                        }
+        UpdateBuildResult f -> modifyPhase \state -> case state.phase of
+            BuildComplete pb ->
+                BuildComplete pb {result = f pb.result}
+            _ ->
+                BuildComplete
+                    PostBuild
+                        { testPhase = Testing
+                        , result = f initialBuildResult
+                        }
 
 
 -- | Mutable state shared between the production interpreters and writers
@@ -216,3 +258,16 @@ runBuildStore eff = do
         MarkDirty ck -> atomically (modifyTVar refs.dirtyRef (max (Just ck)))
         WaitDirty -> takeDirty refs.dirtyRef
         HasWaiters -> fmap (> 0) $ atomically (readTVar refs.waitersRef)
+
+
+runBuildStoreState :: (State BuildState :> es) => Eff (BuildStore : es) a -> Eff es a
+runBuildStoreState = interpret_ \case
+    GetState -> get
+    ModifyPhase f -> modify \s -> s {phase = f s}
+    WaitUntilDone -> get
+    WaitForNext _ -> get
+    WaitForAnyChange _ -> get
+    SetPhase buildId phase -> modify \s -> s {buildId, phase}
+    MarkDirty _ -> pure ()
+    WaitDirty -> error "runBuildStoreState: waitDirty not supported"
+    HasWaiters -> pure False

--- a/tricorder/src/Tricorder/Effects/PostBuildStore.hs
+++ b/tricorder/src/Tricorder/Effects/PostBuildStore.hs
@@ -1,0 +1,51 @@
+module Tricorder.Effects.PostBuildStore
+    ( PostBuildStore (..)
+    , setTestPhase
+    , updateBuildResult
+    , runPostBuildStoreState
+    , runPostBuildStoreCapture
+    ) where
+
+import Effectful (Effect)
+import Effectful.Dispatch.Dynamic (interpose_, interpret_)
+import Effectful.State.Static.Shared (State, gets, modify)
+import Effectful.TH (makeEffect)
+import Effectful.Writer.Static.Shared (Writer, tell)
+
+import Tricorder.BuildState (BuildResult, PostBuild (..), TestPhase)
+
+
+data PostBuildStore :: Effect where
+    SetTestPhase :: TestPhase -> PostBuildStore m ()
+    UpdateBuildResult :: (BuildResult -> BuildResult) -> PostBuildStore m ()
+
+
+makeEffect ''PostBuildStore
+
+
+-- | For testing. Run a 'PostBuildStore' with a 'PostBuild' state.
+runPostBuildStoreState
+    :: (State PostBuild :> es)
+    => Eff (PostBuildStore : es) a -> Eff es a
+runPostBuildStoreState = interpret_ \case
+    SetTestPhase tp -> modify \pb -> pb {testPhase = tp}
+    UpdateBuildResult f -> modify \pb -> pb {result = f pb.result}
+
+
+-- | For testing. Augment another 'PostBuildStore' interpreter by noting down
+-- the various stages of the 'PostBuild'.
+runPostBuildStoreCapture
+    :: ( PostBuildStore :> es
+       , State PostBuild :> es
+       , Writer [PostBuild] :> es
+       )
+    => Eff es a -> Eff es a
+runPostBuildStoreCapture = interpose_ @PostBuildStore \case
+    SetTestPhase tp -> do
+        pb <- gets \pb -> pb {testPhase = tp}
+        tell [pb]
+        setTestPhase tp
+    UpdateBuildResult f -> do
+        pb <- gets \pb -> pb {result = f pb.result}
+        tell [pb]
+        updateBuildResult \_ -> pb.result

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -18,7 +18,7 @@ import Data.Time (UTCTime (..), addUTCTime, fromGregorian)
 import Effectful (runEff, runPureEff)
 import Effectful.Concurrent (Concurrent, runConcurrent)
 import Effectful.Concurrent.STM (atomically)
-import Effectful.Dispatch.Dynamic (interpret_)
+import Effectful.Dispatch.Dynamic (interpose, interpret_, passthrough)
 import Effectful.Error.Static (runErrorNoCallStack, throwError)
 import Effectful.Exception (throwIO)
 import Effectful.Reader.Static (runReader)
@@ -32,7 +32,21 @@ import Control.Concurrent.STM qualified as STM
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 
-import Tricorder.BuildState (BuildId (..), BuildPhase (..), BuildResult (..), BuildState (..), CabalChangeDetected (..), DaemonInfo (..), Diagnostic (..), PostBuild (..), Severity (..), SourceChangeDetected (..), TestPhase (..), TestRun (..), TestRunCompletion (..))
+import Tricorder.BuildState
+    ( BuildId (..)
+    , BuildPhase (..)
+    , BuildResult (..)
+    , BuildState (..)
+    , CabalChangeDetected (..)
+    , DaemonInfo (..)
+    , Diagnostic (..)
+    , PostBuild (..)
+    , Severity (..)
+    , SourceChangeDetected (..)
+    , TestPhase (..)
+    , TestRun (..)
+    , TestRunCompletion (..)
+    )
 import Tricorder.Builder
     ( BuildConfig (..)
     , EnteringNewPhase (..)
@@ -54,13 +68,19 @@ import Tricorder.Builder.Dispatch
     , mergeDiagnostics
     , preserveFailureVisibility
     )
-import Tricorder.Effects.GhciSession (Controls (..), LoadResult (..), LoadedModule (..), runGhciSessionScripted)
+import Tricorder.Effects.BuildStore (BuildStore, runBuildStoreState)
+import Tricorder.Effects.GhciSession
+    ( Controls (..)
+    , LoadResult (..)
+    , LoadedModule (..)
+    , runGhciSessionScripted
+    )
 import Tricorder.Effects.GhciSession.GhciParser (collectResult, extractTitle, resolveKnownTargets)
+import Tricorder.Effects.PostBuildStore (runPostBuildStoreCapture, runPostBuildStoreState)
 import Tricorder.Effects.TestRunner (TestRunner (..), runTestRunnerScripted)
 import Tricorder.Runtime (ProjectRoot (..))
-import Tricorder.Session (Command (..), WatchDirs (..), parseTestTargets)
+import Tricorder.Session (WatchDirs (..), parseTestTargets)
 
-import Tricorder.BuildState qualified as BuildState
 import Tricorder.Builder qualified as Builder
 import Tricorder.Effects.BuildStore qualified as BuildStore
 
@@ -163,7 +183,8 @@ testBuildWithGhciRecovery = do
                         Delay.wait (40 :: Millisecond) -- let the first launch fail + subscribe
                         publish (SourceChangeDetected "/abs/path/Foo.hs" Modified)
                         Delay.wait (60 :: Millisecond) -- let the retry land
-                        -- The failed launch reports BuildFailed exactly once.
+
+        -- The failed launch reports BuildFailed exactly once.
         length [() | EnteringNewPhase _ (BuildFailed _) <- phases] `shouldBe` 1
         -- The source change drove a second, successful launch to completion.
         -- With the bug the builder is parked, so no Done is ever emitted.
@@ -187,9 +208,11 @@ testBuildWithGhciRecovery = do
             . runDelay
             . runReader (ProjectRoot "/")
             . evalState (BuildId 1)
+            . evalState emptyBuildState
             . evalState emptyBuilderState
             . runLogNoOp
             . execWriter @[EnteringNewPhase]
+            . runBuildStoreState
             . runBuildStoreCapture
             . runTestRunnerScripted []
             . runGhciSessionScripted script
@@ -213,7 +236,7 @@ testReloadOnSourceChange = do
         describe "when the file is loaded in GHCi" do
             it "transitions through Building then Done" do
                 phases <- runTest knownFoo noTargets distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Modified)
-                phases `shouldBe` flow reloadLr
+                phases `shouldMatchList` (flow reloadLr)
 
             it "calls controls.reload" do
                 phases <- runTest knownFoo noTargets distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Modified)
@@ -286,6 +309,7 @@ testReloadOnSourceChange = do
             . runClockConst epoch
             . runReader (ProjectRoot "/")
             . evalState (BuildId 1)
+            . evalState emptyBuildState
             . evalState
                 emptyBuilderState
                     { loadedModules = initialModuleMap
@@ -293,6 +317,7 @@ testReloadOnSourceChange = do
                     }
             . runLogNoOp
             . execWriter @[EnteringNewPhase]
+            . runBuildStoreState
             . runBuildStoreCapture
             . runTestRunnerScripted []
             $ reloadOnSourceChange (def @BuildConfig) ctrls event
@@ -445,52 +470,49 @@ testCompileLoadResultsIntoBuildResults = do
 testRequestTestRunsForNewBuildResults :: Spec
 testRequestTestRunsForNewBuildResults = do
     describe "when there are no test targets" $ it "should skip testing" do
-        phases <- runTest (parseTestTargets []) [] expected
-        length phases `shouldBe` 1
-        phases
-            `shouldMatchList` [ EnteringNewPhase (BuildId 1)
-                                    $ BuildComplete
-                                    $ PostBuild DoneTesting expected
-                              ]
-
-    describe "when there are errors" $ it "should skip testing" do
-        let expected' = expected {BuildState.diagnostics = [errMsg]}
-        phases <- runTest (parseTestTargets ["test:foo"]) [] expected'
-        length phases `shouldBe` 1
-        phases
-            `shouldMatchList` [ EnteringNewPhase (BuildId 1)
-                                    $ BuildComplete
-                                    $ PostBuild DoneTesting expected'
+        phaseResults <- runTest (parseTestTargets []) [] expected
+        phaseResults
+            `shouldMatchList` [ PostBuild DoneTesting expected
                               ]
 
     it "should emit EnteringNewPhase events for each test target" do
-        phases <-
+        actualPhases <-
             runTest
                 (parseTestTargets ["test:foo", "test:bar"])
-                [ Right $ mkTestRun "test:foo"
-                , Right $ mkTestRun "test:bar"
+                [ Right $ mkCompleteTestRun "test:foo"
+                , Right $ mkCompleteTestRun "test:bar"
                 ]
                 expected
-        length phases `shouldBe` 4
         let expectedPhases =
-                [ mkTesting . buildWithTests
-                    $ [ TestRunning "test:foo" Nothing
-                      , TestRunning "test:bar" Nothing
-                      ]
-                , mkTesting . buildWithTests
-                    $ [ mkTestRun "test:foo"
-                      , TestRunning "test:bar" Nothing
-                      ]
-                , mkTesting . buildWithTests
-                    $ [ mkTestRun "test:foo"
-                      , mkTestRun "test:bar"
-                      ]
-                , mkDone . buildWithTests
-                    $ [ mkTestRun "test:foo"
-                      , mkTestRun "test:bar"
-                      ]
+                [ mkPostBuild Testing
+                    $ buildWithTests []
+                , mkPostBuild Testing
+                    $ buildWithTests
+                        [ mkRunningTest "test:foo"
+                        , mkRunningTest "test:bar"
+                        ]
+                , mkPostBuild Testing
+                    $ buildWithTests
+                        [ mkCompleteTestRun "test:foo"
+                        , mkRunningTest "test:bar"
+                        ]
+                , mkPostBuild Testing
+                    $ buildWithTests
+                        [ mkCompleteTestRun "test:foo"
+                        , mkCompleteTestRun "test:bar"
+                        ]
+                , mkPostBuild DoneTesting
+                    $ buildWithTests
+                        [ mkCompleteTestRun "test:foo"
+                        , mkCompleteTestRun "test:bar"
+                        ]
+                , mkPostBuild DoneTesting
+                    $ buildWithTests
+                        [ mkCompleteTestRun "test:foo"
+                        , mkCompleteTestRun "test:bar"
+                        ]
                 ]
-        phases `shouldMatchList` expectedPhases
+        actualPhases `shouldMatchList` expectedPhases
 
     -- Regression for the abort handling in 'runTestsIfClean': when an
     -- interrupt arrives mid-run loop, 'isAborted' becomes True and the loop
@@ -503,48 +525,49 @@ testRequestTestRunsForNewBuildResults = do
             runEff
                 . runConcurrent
                 . runLogNoOp
+                . execWriter
                 . evalState (BuildId 1)
-                . execWriter @[EnteringNewPhase]
-                . runBuildStoreCapture
-                . runTestRunnerAbortAfterFirst (mkTestRun "test:foo")
+                . evalState (PostBuild Testing expected)
+                . runPostBuildStoreState
+                . runPostBuildStoreCapture
+                . runTestRunnerAbortAfterFirst (mkCompleteTestRun "test:foo")
                 $ requestTestRunsForNewBuildResults
-                    BuildConfig
-                        { command = Command ""
-                        , targets = []
-                        , testTargets = parseTestTargets ["test:foo", "test:bar"]
-                        , watchDirs = WatchDirs []
-                        }
-                    expected
+                $ parseTestTargets ["test:foo", "test:bar"]
         -- The critical assertion: no Done phase, because the run was
         -- aborted before completing the second suite. A Done here would
         -- briefly publish a half-finished testRuns list that a
         -- 'status --wait' caller could observe.
-        length [() | EnteringNewPhase _ (BuildComplete (PostBuild DoneTesting _)) <- phases] `shouldBe` 0
+        length
+            [ () | PostBuild DoneTesting _ <- phases
+            ]
+            `shouldBe` 0
         -- Sanity: only the initial Testing transition was published; the
         -- run loop short-circuited after the first 'isAborted' check, so
         -- the post-foo Testing update never fired.
-        length phases `shouldBe` 1
+        phases
+            `shouldMatchList` [ mkPostBuild Testing expected
+                              , mkPostBuild
+                                    Testing
+                                    expected
+                                        { testRuns =
+                                            [ mkRunningTest "test:foo"
+                                            , mkRunningTest "test:bar"
+                                            ]
+                                        }
+                              ]
   where
     runTest testTargets script partial =
         runEff
             . runConcurrent
             . runLogNoOp
+            . execWriter
             . evalState (BuildId 1)
-            . execWriter @[EnteringNewPhase]
-            . runBuildStoreCapture
+            . evalState (mkPostBuild Testing partial)
+            . runPostBuildStoreState
+            . runPostBuildStoreCapture
             . runTestRunnerScripted script
-            $ requestTestRunsForNewBuildResults
-                BuildConfig
-                    { command = Command ""
-                    , targets = []
-                    , testTargets
-                    , watchDirs = WatchDirs []
-                    }
-                partial
+            $ requestTestRunsForNewBuildResults testTargets
 
-    mkPhase = EnteringNewPhase (BuildId 1)
-    mkTesting = mkPhase . BuildComplete . PostBuild Testing
-    mkDone = mkPhase . BuildComplete . PostBuild DoneTesting
     buildWithTests testRuns = expected {testRuns}
 
     expected =
@@ -556,7 +579,7 @@ testRequestTestRunsForNewBuildResults = do
             , testRuns = []
             }
 
-    mkTestRun target =
+    mkCompleteTestRun target =
         TestRunCompleted
             $ TestRunCompletion
                 { target
@@ -565,6 +588,7 @@ testRequestTestRunsForNewBuildResults = do
                 , testCases = []
                 , duration = Nothing
                 }
+    mkRunningTest target = TestRunning target Nothing
 
 
 --------------------------------------------------------------------------------
@@ -944,6 +968,10 @@ testExtractTitle = do
 -- Helpers
 --------------------------------------------------------------------------------
 
+mkPostBuild :: TestPhase -> BuildResult -> PostBuild
+mkPostBuild tp br = PostBuild tp br
+
+
 errMsg :: Diagnostic
 errMsg =
     Diagnostic
@@ -984,6 +1012,15 @@ emptyDaemonInfo =
         , sockPath = ""
         , logFile = ""
         , metricsPort = Nothing
+        }
+
+
+emptyBuildState :: BuildState
+emptyBuildState =
+    BuildState
+        { buildId = BuildId 1
+        , daemonInfo = emptyDaemonInfo
+        , phase = Building Nothing
         }
 
 
@@ -1346,19 +1383,20 @@ runTestRunnerAbortAfterFirst result act = do
         act
 
 
--- | A 'BuildStore' interpreter that records every 'setPhase' call into a
--- 'Writer'. Only the operations used by the Builder pipeline tests are
--- implemented; the rest error.
+-- | A 'BuildStore' interpreter that records every phase transition into a
+-- 'Writer'. Captures both 'SetPhase' (used by 'enterPhase') and 'ModifyPhase'
+-- (used by 'withPostBuildPhase' for BuildComplete transitions).
 runBuildStoreCapture
-    :: (Writer [EnteringNewPhase] :> es)
-    => Eff (BuildStore.BuildStore : es) a -> Eff es a
-runBuildStoreCapture = interpret_ \case
-    BuildStore.SetPhase bid phase -> tell [EnteringNewPhase bid phase]
-    BuildStore.HasWaiters -> pure False
-    BuildStore.MarkDirty _ -> pure ()
-    BuildStore.GetState -> error "runBuildStoreCapture: GetState unsupported"
-    BuildStore.ModifyPhase _ -> error "runBuildStoreCapture: ModifyPhase unsupported"
-    BuildStore.WaitUntilDone -> error "runBuildStoreCapture: WaitUntilDone unsupported"
-    BuildStore.WaitForNext _ -> error "runBuildStoreCapture: WaitForNext unsupported"
-    BuildStore.WaitForAnyChange _ -> error "runBuildStoreCapture: WaitForAnyChange unsupported"
-    BuildStore.WaitDirty -> error "runBuildStoreCapture: WaitDirty unsupported"
+    :: ( BuildStore :> es
+       , Writer [EnteringNewPhase] :> es
+       )
+    => Eff es a -> Eff es a
+runBuildStoreCapture = interpose \env -> \case
+    BuildStore.SetPhase bid phase -> do
+        tell [EnteringNewPhase bid phase]
+        BuildStore.setPhase bid phase
+    BuildStore.ModifyPhase f -> do
+        s <- BuildStore.getState
+        tell [EnteringNewPhase s.buildId (f s)]
+        BuildStore.modifyPhase f
+    e -> passthrough env e

--- a/tricorder/test/Unit/Tricorder/Effects/BuildStoreSpec.hs
+++ b/tricorder/test/Unit/Tricorder/Effects/BuildStoreSpec.hs
@@ -1,4 +1,4 @@
-module Unit.Tricorder.BuildStoreSpec (spec_BuildStore) where
+module Unit.Tricorder.Effects.BuildStoreSpec (spec_BuildStore) where
 
 import Atelier.Effects.Conc (Conc, runConc)
 import Atelier.Effects.Delay (Delay, runDelay)
@@ -7,26 +7,40 @@ import Control.Concurrent (threadDelay)
 import Data.Time (UTCTime (..), fromGregorian)
 import Effectful (IOE, runEff, runPureEff)
 import Effectful.Concurrent (Concurrent, runConcurrent)
+import Effectful.Dispatch.Dynamic (interpret_)
+import Effectful.State.Static.Shared (State, execState, modify)
 import Test.Hspec
 
 import Atelier.Effects.Conc qualified as Conc
 
-import Tricorder.BuildState (BuildId (..), BuildPhase (..), BuildResult (..), BuildState (..), DaemonInfo (..), PostBuild (..), TestPhase (..))
+import Tricorder.BuildState
+    ( BuildId (..)
+    , BuildPhase (..)
+    , BuildResult (..)
+    , BuildState (..)
+    , DaemonInfo (..)
+    , PostBuild (..)
+    , TestPhase (..)
+    )
 import Tricorder.Effects.BuildStore
-    ( BuildStore
+    ( BuildStore (..)
     , getState
     , runBuildStore
     , runBuildStoreScripted
     , setPhase
     , waitForNext
     , waitUntilDone
+    , withPostBuildPhase
     )
+
+import Tricorder.Effects.PostBuildStore qualified as PostBuild
 
 
 spec_BuildStore :: Spec
 spec_BuildStore = do
     describe "runBuildStoreScripted" testScripted
     describe "runBuildStoreSTM" testSTM
+    describe "withPostBuildPhase" testWithPostBuildPhase
 
 
 --------------------------------------------------------------------------------
@@ -149,8 +163,112 @@ testSTM = do
 
 
 --------------------------------------------------------------------------------
+-- PostBuildStore interpreter test
+--------------------------------------------------------------------------------
+
+testWithPostBuildPhase :: Spec
+testWithPostBuildPhase = do
+    describe "with Done build phase" do
+        let runTest = runTest' doneBuildState
+        describe "setTestPhase" $ it "sets test phase" do
+            let actualState = runTest $ PostBuild.setTestPhase DoneTesting
+            actualState
+                `shouldBe` doneBuildState
+                    { phase =
+                        BuildComplete
+                            PostBuild
+                                { testPhase = DoneTesting
+                                , result = emptyBuildResult
+                                }
+                    }
+        describe "updateBuildResult" $ it "updates the build result" do
+            let actualState = runTest $ PostBuild.updateBuildResult \br -> br {moduleCount = 99}
+            actualState
+                `shouldBe` doneBuildState
+                    { phase =
+                        BuildComplete
+                            PostBuild
+                                { testPhase = Testing
+                                , result = emptyBuildResult {moduleCount = 99}
+                                }
+                    }
+
+    describe "with non-Done build phase" do
+        let runTest = runTest' buildingBuildState
+        describe "setTestPhase" do
+            it "sets the build phase to Done and sets test phase" do
+                let actualState = runTest $ PostBuild.setTestPhase DoneTesting
+                actualState
+                    `shouldBe` doneBuildState
+                        { phase =
+                            BuildComplete
+                                PostBuild
+                                    { testPhase = DoneTesting
+                                    , result = emptyBuildResult
+                                    }
+                        }
+        describe "updateBuildResult" do
+            it "sets the build phase to Done and updates the build result from the initial build result" do
+                let actualState = runTest $ PostBuild.updateBuildResult \br -> br {moduleCount = 99}
+                actualState
+                    `shouldBe` doneBuildState
+                        { phase =
+                            BuildComplete
+                                PostBuild
+                                    { testPhase = Testing
+                                    , result = emptyBuildResult {moduleCount = 99}
+                                    }
+                        }
+  where
+    runTest' bs =
+        runPureEff
+            . execState bs
+            . runBuildStoreSimple
+            . withPostBuildPhase emptyBuildResult
+    runBuildStoreSimple :: (State BuildState :> es) => Eff (BuildStore : es) a -> Eff es a
+    runBuildStoreSimple = interpret_ \case
+        ModifyPhase f -> modify \s -> s {phase = f s}
+        _ -> error "runBuildStoreSimple: Unsupported operation"
+
+
+--------------------------------------------------------------------------------
 -- Helpers
 --------------------------------------------------------------------------------
+
+buildingBuildState :: BuildState
+buildingBuildState =
+    BuildState
+        { buildId = BuildId 1
+        , phase = Building Nothing
+        , daemonInfo = emptyDaemonInfo
+        }
+
+
+doneBuildState :: BuildState
+doneBuildState =
+    BuildState
+        { buildId = BuildId 1
+        , phase =
+            BuildComplete
+                PostBuild
+                    { testPhase =
+                        Testing
+                    , result = emptyBuildResult
+                    }
+        , daemonInfo = emptyDaemonInfo
+        }
+
+
+emptyBuildResult :: BuildResult
+emptyBuildResult =
+    BuildResult
+        { completedAt = epoch
+        , duration = 0
+        , moduleCount = 0
+        , diagnostics = []
+        , testRuns = []
+        }
+
 
 emptyDaemonInfo :: DaemonInfo
 emptyDaemonInfo =

--- a/tricorder/test/Unit/Tricorder/TestRunnerSpec.hs
+++ b/tricorder/test/Unit/Tricorder/TestRunnerSpec.hs
@@ -15,7 +15,18 @@ import Effectful.Reader.Static (runReader)
 import Effectful.State.Static.Shared (evalState)
 import Test.Hspec
 
-import Tricorder.BuildState (BuildId (..), BuildPhase (..), BuildProgress (..), BuildResult (..), BuildState (..), DaemonInfo (..), PostBuild (..), TestPhase (..), TestRun (..), TestRunCompletion (..))
+import Tricorder.BuildState
+    ( BuildId (..)
+    , BuildPhase (..)
+    , BuildProgress (..)
+    , BuildResult (..)
+    , BuildState (..)
+    , DaemonInfo (..)
+    , PostBuild (..)
+    , TestPhase (..)
+    , TestRun (..)
+    , TestRunCompletion (..)
+    )
 import Tricorder.Effects.BuildStore (getState)
 import Tricorder.Effects.GhciSession.GhciParser (GhciLoading (..))
 import Tricorder.Effects.TestRunner
@@ -234,10 +245,8 @@ testAbortGatedProgress = do
         finalRuns <- runStore do
             BuildStore.setPhase (BuildId 1)
                 $ BuildComplete
-                    PostBuild
-                        { testPhase = Testing
-                        , result = partialResultWith startingRuns
-                        }
+                $ PostBuild Testing
+                $ partialResultWith startingRuns
             for_ loadings (abortGatedProgress abortedRef "test:foo")
             phaseTestRuns <$> getState
         finalRuns `shouldBe` startingRuns
@@ -245,14 +254,10 @@ testAbortGatedProgress = do
     it "flips behaviour mid-run if abortedRef is set between updates" do
         abortedRef <- newTVarIO False
         finalRuns <- runStore do
-            BuildStore.setPhase
-                (BuildId 1)
+            BuildStore.setPhase (BuildId 1)
                 $ BuildComplete
-                    PostBuild
-                        { testPhase = Testing
-                        , result = partialResultWith startingRuns
-                        }
-
+                $ PostBuild Testing
+                $ partialResultWith startingRuns
             -- This one applies.
             abortGatedProgress abortedRef "test:foo" (mkLoading 3 10)
             -- Simulate the interrupt firing.
@@ -273,10 +278,8 @@ testAbortGatedProgress = do
         runStore do
             BuildStore.setPhase (BuildId 1)
                 $ BuildComplete
-                    PostBuild
-                        { testPhase = Testing
-                        , result = partialResultWith runs
-                        }
+                $ PostBuild Testing
+                $ partialResultWith runs
             abortGatedProgress abortedRef "test:foo" loading
             phaseTestRuns <$> getState
 

--- a/tricorder/tricorder.cabal
+++ b/tricorder/tricorder.cabal
@@ -46,6 +46,7 @@ library tricorder-internal
       Tricorder.Effects.GhciSession.GhciProcess
       Tricorder.Effects.GhcPkg
       Tricorder.Effects.Logging
+      Tricorder.Effects.PostBuildStore
       Tricorder.Effects.SessionStore
       Tricorder.Effects.TestRunner
       Tricorder.Effects.UnixSocket
@@ -219,8 +220,8 @@ test-suite tricorder-test
   other-modules:
       Unit.Tricorder.BuilderSpec
       Unit.Tricorder.BuildStateSpec
-      Unit.Tricorder.BuildStoreSpec
       Unit.Tricorder.CLI.RenderSpec
+      Unit.Tricorder.Effects.BuildStoreSpec
       Unit.Tricorder.Effects.GhciSession.GhciParserSpec
       Unit.Tricorder.Effects.GhciSession.GhciProcessSpec
       Unit.Tricorder.Effects.GhciSessionSpec


### PR DESCRIPTION
Tests and (the upcoming) eval comments perform updates on the build
result _after_ the build has completed. Instead of having to work around
the various possible states of `BuildState`, `PostBuildStore` provides
an effect that can only be interpreted with a proper `PostBuild` value
from a completed build.
