### PR TITLE
refactor: separate test results from BuildResult

### DIFF
--- a/tricorder/src/Tricorder/BuildState.hs
+++ b/tricorder/src/Tricorder/BuildState.hs
@@ -10,14 +10,7 @@ module Tricorder.BuildState
     , BuildState (..)
     , BuildPhase (..)
     , PostBuild (..)
-    , TestPhase (..)
-    , BuildProgress (..)
     , BuildResult (..)
-    , TestRun (..)
-    , TestRunError (..)
-    , TestRunCompletion (..)
-    , TestCase (..)
-    , TestCaseOutcome (..)
     , DaemonInfo (..)
     , loadDaemonInfo
     , runDaemonInfo
@@ -39,12 +32,24 @@ import Effectful.Reader.Static (Reader, ask)
 import GHC.Generics (Generically (..))
 import System.FilePath (makeRelative)
 
+import Tricorder.BuildState.BuildProgress (BuildProgress)
 import Tricorder.Effects.SessionStore (SessionStore)
 import Tricorder.Runtime (LogPath (..), ProjectRoot (..), SocketPath (..))
 import Tricorder.Session (Session (..), Target, WatchDirs (..))
 
+import Tricorder.BuildState.Tests qualified as Test
+import Tricorder.BuildState.Tests qualified as Tests
 import Tricorder.Effects.SessionStore qualified as SessionStore
 import Tricorder.Observability qualified as Observability
+
+
+data BuildState = BuildState
+    { buildId :: BuildId
+    , phase :: BuildPhase
+    , daemonInfo :: DaemonInfo
+    }
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via Generically BuildState
 
 
 newtype BuildId = BuildId Int
@@ -61,7 +66,7 @@ data DaemonInfo = DaemonInfo
     , metricsPort :: Maybe Int
     }
     deriving stock (Eq, Generic, Show)
-    deriving anyclass (FromJSON, ToJSON)
+    deriving (FromJSON, ToJSON) via Generically DaemonInfo
 
 
 loadDaemonInfo
@@ -99,46 +104,13 @@ runDaemonInfo
 runDaemonInfo = runInputEff loadDaemonInfo
 
 
-data TestCaseOutcome
-    = TestCasePassed
-    | TestCaseFailed Text
+data BuildPhase
+    = Restarting
+    | Building (Maybe BuildProgress)
+    | BuildFailed Text
+    | BuildComplete BuildResult PostBuild
     deriving stock (Eq, Generic, Show)
-    deriving anyclass (FromJSON, ToJSON)
-
-
-data TestCase = TestCase
-    { description :: Text
-    , outcome :: TestCaseOutcome
-    }
-    deriving stock (Eq, Generic, Show)
-    deriving anyclass (FromJSON, ToJSON)
-
-
-data TestRunError = TestRunError
-    { target :: Text
-    , message :: Text
-    }
-    deriving stock (Eq, Generic, Show)
-    deriving anyclass (FromJSON, ToJSON)
-
-
-data TestRunCompletion = TestRunCompletion
-    { target :: Text
-    , passed :: Bool
-    , output :: Text
-    , testCases :: [TestCase]
-    , duration :: Maybe Millisecond
-    }
-    deriving stock (Eq, Generic, Show)
-    deriving anyclass (FromJSON, ToJSON)
-
-
-data TestRun
-    = TestRunning Text (Maybe BuildProgress)
-    | TestRunErrored TestRunError
-    | TestRunCompleted TestRunCompletion
-    deriving stock (Eq, Generic, Show)
-    deriving anyclass (FromJSON, ToJSON)
+    deriving (FromJSON, ToJSON) via Generically BuildPhase
 
 
 data BuildResult = BuildResult
@@ -146,49 +118,16 @@ data BuildResult = BuildResult
     , duration :: Millisecond
     , moduleCount :: Int
     , diagnostics :: [Diagnostic]
-    , testRuns :: [TestRun]
     }
     deriving stock (Eq, Generic, Show)
-    deriving anyclass (FromJSON, ToJSON)
-
-
-data BuildProgress = BuildProgress
-    { compiled :: Int
-    , total :: Int
-    }
-    deriving stock (Eq, Generic, Show)
-    deriving anyclass (FromJSON, ToJSON)
-
-
-data BuildPhase
-    = Building (Maybe BuildProgress)
-    | Restarting
-    | BuildComplete PostBuild
-    | BuildFailed Text
-    deriving stock (Eq, Generic, Show)
-    deriving anyclass (FromJSON, ToJSON)
+    deriving (FromJSON, ToJSON) via Generically BuildResult
 
 
 data PostBuild = PostBuild
-    { testPhase :: TestPhase
-    , result :: BuildResult
+    { testSuites :: Test.Suites
     }
     deriving stock (Eq, Generic, Show)
     deriving (FromJSON, ToJSON) via Generically PostBuild
-
-
-data TestPhase = Testing | DoneTesting
-    deriving stock (Eq, Generic, Show)
-    deriving (FromJSON, ToJSON) via Generically TestPhase
-
-
-data BuildState = BuildState
-    { buildId :: BuildId
-    , phase :: BuildPhase
-    , daemonInfo :: DaemonInfo
-    }
-    deriving stock (Eq, Generic, Show)
-    deriving anyclass (FromJSON, ToJSON)
 
 
 data Diagnostic = Diagnostic
@@ -202,7 +141,7 @@ data Diagnostic = Diagnostic
     , text :: Text
     }
     deriving stock (Eq, Generic, Show)
-    deriving anyclass (FromJSON, ToJSON)
+    deriving (FromJSON, ToJSON) via Generically Diagnostic
 
 
 data Severity = SError | SWarning
@@ -224,12 +163,12 @@ instance ToJSON Severity where
 stateLabel :: BuildPhase -> Text
 stateLabel (Building _) = "building"
 stateLabel Restarting = "restarting"
-stateLabel (BuildComplete (PostBuild Testing _)) = "testing"
-stateLabel (BuildComplete (PostBuild _ result))
+stateLabel (BuildFailed _) = "error"
+stateLabel (BuildComplete result pb)
     | any (\m -> m.severity == SError) result.diagnostics = "error"
     | any (\m -> m.severity == SWarning) result.diagnostics = "warning"
+    | Tests.anyRunningTests pb.testSuites = "testing"
     | otherwise = "ok"
-stateLabel (BuildFailed _) = "error"
 
 
 -- | Classifies what kind of file change triggered a dirty signal.

--- a/tricorder/src/Tricorder/BuildState.hs
+++ b/tricorder/src/Tricorder/BuildState.hs
@@ -164,10 +164,10 @@ stateLabel :: BuildPhase -> Text
 stateLabel (Building _) = "building"
 stateLabel Restarting = "restarting"
 stateLabel (BuildFailed _) = "error"
-stateLabel (BuildComplete result pb)
+stateLabel (BuildComplete result postBuild)
     | any (\m -> m.severity == SError) result.diagnostics = "error"
     | any (\m -> m.severity == SWarning) result.diagnostics = "warning"
-    | Tests.anyRunningTests pb.testSuites = "testing"
+    | Tests.anyRunningTests postBuild.testSuites = "testing"
     | otherwise = "ok"
 
 

--- a/tricorder/src/Tricorder/BuildState.hs
+++ b/tricorder/src/Tricorder/BuildState.hs
@@ -37,8 +37,8 @@ import Tricorder.Effects.SessionStore (SessionStore)
 import Tricorder.Runtime (LogPath (..), ProjectRoot (..), SocketPath (..))
 import Tricorder.Session (Session (..), Target, WatchDirs (..))
 
-import Tricorder.BuildState.Tests qualified as Test
-import Tricorder.BuildState.Tests qualified as Tests
+import Tricorder.BuildState.Test qualified as Test
+import Tricorder.BuildState.Test qualified as Tests
 import Tricorder.Effects.SessionStore qualified as SessionStore
 import Tricorder.Observability qualified as Observability
 

--- a/tricorder/src/Tricorder/BuildState/BuildProgress.hs
+++ b/tricorder/src/Tricorder/BuildState/BuildProgress.hs
@@ -1,0 +1,12 @@
+module Tricorder.BuildState.BuildProgress (BuildProgress (..)) where
+
+import Data.Aeson (FromJSON, ToJSON)
+import GHC.Generics (Generically (..))
+
+
+data BuildProgress = BuildProgress
+    { compiled :: Int
+    , total :: Int
+    }
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via Generically BuildProgress

--- a/tricorder/src/Tricorder/BuildState/Test.hs
+++ b/tricorder/src/Tricorder/BuildState/Test.hs
@@ -1,4 +1,4 @@
-module Tricorder.BuildState.Tests
+module Tricorder.BuildState.Test
     ( Suites (..)
     , hasFailedTests
     , suiteRuns

--- a/tricorder/src/Tricorder/BuildState/Tests.hs
+++ b/tricorder/src/Tricorder/BuildState/Tests.hs
@@ -1,0 +1,103 @@
+module Tricorder.BuildState.Tests
+    ( Suites (..)
+    , hasFailedTests
+    , suiteRuns
+    , anyRunningTests
+    , nullSuites
+    , Suite (..)
+    , isFailedRun
+    , Outcome (..)
+    , Case (..)
+    , SuiteCompletion (..)
+    , SuiteError (..)
+    ) where
+
+import Atelier.Time (Millisecond)
+import Data.Aeson (FromJSON, ToJSON)
+import GHC.Generics (Generically (..))
+
+import Data.Map.Strict qualified as Map
+
+import Tricorder.BuildState.BuildProgress (BuildProgress)
+import Tricorder.Session (TestTarget)
+
+
+newtype Suites = Suites {getSuites :: Map TestTarget Suite}
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via Generically Suites
+
+
+hasFailedTests :: Suites -> Bool
+hasFailedTests = any isFailedRun . suiteRuns
+
+
+suiteRuns :: Suites -> [Suite]
+suiteRuns = Map.elems . getSuites
+
+
+anyRunningTests :: Suites -> Bool
+anyRunningTests =
+    any
+        ( \case
+            SuiteRunning _ -> True
+            _ -> False
+        )
+        . toList
+        . getSuites
+
+
+nullSuites :: Suites -> Bool
+nullSuites = Map.null . getSuites
+
+
+data Phase
+    = Testing [Suite]
+    | DoneTesting
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via Generically Phase
+
+
+data Suite
+    = SuiteRunning (Maybe BuildProgress)
+    | SuiteErrored SuiteError
+    | SuiteCompleted SuiteCompletion
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via (Generically Suite)
+
+
+isFailedRun :: Suite -> Bool
+isFailedRun (SuiteCompleted c) = not c.passed
+isFailedRun (SuiteErrored _) = True
+isFailedRun (SuiteRunning _) = False
+
+
+data Outcome
+    = Passed
+    | Failed Text
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via (Generically Outcome)
+
+
+data Case = Case
+    { description :: Text
+    , outcome :: Outcome
+    }
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via (Generically Case)
+
+
+newtype SuiteError = SuiteError
+    { message :: Text
+    }
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via (Generically SuiteError)
+
+
+data SuiteCompletion = SuiteCompletion
+    { passed :: Bool
+    , output :: Text
+    , testCases :: [Case]
+    , duration :: Maybe Millisecond
+    }
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via (Generically SuiteCompletion)

--- a/tricorder/src/Tricorder/BuildState/Tests.hs
+++ b/tricorder/src/Tricorder/BuildState/Tests.hs
@@ -8,6 +8,7 @@ module Tricorder.BuildState.Tests
     , isFailedRun
     , Outcome (..)
     , Case (..)
+    , caseFailed
     , SuiteCompletion (..)
     , SuiteError (..)
     ) where
@@ -77,6 +78,11 @@ data Case = Case
     }
     deriving stock (Eq, Generic, Show)
     deriving (FromJSON, ToJSON) via (Generically Case)
+
+
+caseFailed :: Case -> Bool
+caseFailed (Case _ (Failed _)) = True
+caseFailed _ = False
 
 
 newtype SuiteError = SuiteError

--- a/tricorder/src/Tricorder/BuildState/Tests.hs
+++ b/tricorder/src/Tricorder/BuildState/Tests.hs
@@ -50,13 +50,6 @@ nullSuites :: Suites -> Bool
 nullSuites = Map.null . getSuites
 
 
-data Phase
-    = Testing [Suite]
-    | DoneTesting
-    deriving stock (Eq, Generic, Show)
-    deriving (FromJSON, ToJSON) via Generically Phase
-
-
 data Suite
     = SuiteRunning (Maybe BuildProgress)
     | SuiteErrored SuiteError

--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -7,7 +7,7 @@ module Tricorder.Builder
     , EnteringNewPhase (..)
     , GhciSessionHooks (..)
     , compileLoadResultsIntoBuildResults
-    , requestTestRunsForNewBuildResults
+    , runTestsForTargets
     , buildWithGhciOnChange
     , watchSourceChanges
     , interruptCurrent
@@ -45,6 +45,7 @@ import Tricorder.BuildState
     ( BuildId (..)
     , BuildPhase (..)
     , BuildResult (..)
+    , BuildState (..)
     , CabalChangeDetected (..)
     , Diagnostic (..)
     , PostBuild (..)
@@ -497,7 +498,19 @@ afterLoad config newLoadResult = do
     buildResult <- compileLoadResultsIntoBuildResults config newLoadResult
     runPostBuildStore buildResult do
         if hasTargets config.testTargets && noErrors buildResult then
-            requestTestRunsForNewBuildResults config.testTargets
+            runTestsForTargets config.testTargets >>= \case
+                Aborted -> Log.debug "Test run aborted by source change; skipping BuildComplete transition."
+                NotAborted -> do
+                    curr <- BuildStore.getState
+                    case curr.phase of
+                        Restarting -> pure ()
+                        BuildComplete _ _ -> pure ()
+                        _ ->
+                            BuildStore.setPhase curr.buildId
+                                $ BuildComplete buildResult
+                                $ PostBuild
+                                $ Test.Suites mempty
+                    pure ()
         else do
             PostBuild.modifyPostBuild \postBuild ->
                 postBuild {testSuites = Test.Suites mempty}
@@ -536,19 +549,6 @@ compileLoadResultsIntoBuildResults session newLoadResult = do
   where
     BuildConfig {watchDirs} = session
     NewLoadResult {startTime, endTime, loadResult} = newLoadResult
-
-
-requestTestRunsForNewBuildResults
-    :: ( Log :> es
-       , PostBuildStore :> es
-       , TestRunner :> es
-       )
-    => TestTargets
-    -> Eff es ()
-requestTestRunsForNewBuildResults testTargets =
-    runTestsForTargets testTargets >>= \case
-        Aborted -> Log.info "Test run aborted by source change; skipping Done transition."
-        NotAborted -> pure ()
 
 
 data TestRunAborted = NotAborted | Aborted

--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -499,7 +499,8 @@ afterLoad config newLoadResult = do
         if hasTargets config.testTargets && noErrors buildResult then
             requestTestRunsForNewBuildResults config.testTargets
         else do
-            PostBuild.modifyPostBuild \pb -> pb {testSuites = Test.Suites mempty}
+            PostBuild.modifyPostBuild \postBuild ->
+                postBuild {testSuites = Test.Suites mempty}
   where
     hasTargets testTargets = not $ null testTargets.getTestTargets
     noErrors result = all (\d -> d.severity /= SError) result.diagnostics
@@ -568,7 +569,13 @@ runTestsForTargets
     -> Eff es TestRunAborted
 runTestsForTargets testTargets = do
     TestRunner.resetAbort
-    PostBuild.modifyPostBuild \pb -> pb {testSuites = Test.Suites $ Map.fromList $ (,Test.SuiteRunning Nothing) <$> tgts}
+    PostBuild.modifyPostBuild \postBuild ->
+        postBuild
+            { testSuites =
+                Test.Suites
+                    $ Map.fromList
+                    $ (,Test.SuiteRunning Nothing) <$> tgts
+            }
 
     Log.info $ "Running " <> show (length tgts) <> " test suite(s)"
 
@@ -583,9 +590,10 @@ runTestsForTargets testTargets = do
         if aborted then
             pure Aborted
         else do
-            PostBuild.modifyPostBuild \pb ->
-                pb
-                    { testSuites = Test.Suites $ Map.insert target result' pb.testSuites.getSuites
+            PostBuild.modifyPostBuild \postBuild ->
+                postBuild
+                    { testSuites =
+                        Test.Suites $ Map.insert target result' postBuild.testSuites.getSuites
                     }
 
             runLoop rest

--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -50,8 +50,6 @@ import Tricorder.BuildState
     , PostBuild (..)
     , Severity (..)
     , SourceChangeDetected (..)
-    , TestPhase (..)
-    , TestRun (..)
     )
 import Tricorder.Builder.Dispatch
     ( BuilderState (..)
@@ -67,13 +65,24 @@ import Tricorder.Effects.BuildStore (BuildStore)
 import Tricorder.Effects.GhciSession (GhciSession, LoadResult (..))
 import Tricorder.Effects.GhciSession.GhciParser (resolveKnownTargets)
 import Tricorder.Effects.GhciSession.GhciProcess (GhciProcessError (..))
+import Tricorder.Effects.PostBuildStore (PostBuildStore, runPostBuildStore)
 import Tricorder.Effects.SessionStore (SessionStore)
 import Tricorder.Effects.TestRunner (TestRunner)
 import Tricorder.Runtime (ProjectRoot (..))
-import Tricorder.Session (Command (..), Session (..), Target, TestTargets, WatchDirs, getTestTargets, renderTarget)
+import Tricorder.Session
+    ( Command (..)
+    , Session (..)
+    , Target
+    , TestTargets
+    , WatchDirs
+    , getTestTargets
+    , renderTestTarget
+    )
 
+import Tricorder.BuildState.Tests qualified as Test
 import Tricorder.Effects.BuildStore qualified as BuildStore
 import Tricorder.Effects.GhciSession qualified as GhciSession
+import Tricorder.Effects.PostBuildStore qualified as PostBuild
 import Tricorder.Effects.SessionStore qualified as SessionStore
 import Tricorder.Effects.TestRunner qualified as TestRunner
 
@@ -480,14 +489,20 @@ afterLoad
     :: ( BuildStore :> es
        , Log :> es
        , Reader ProjectRoot :> es
-       , State BuildId :> es
        , State BuilderState :> es
        , TestRunner :> es
        )
     => BuildConfig -> NewLoadResult -> Eff es ()
 afterLoad config newLoadResult = do
     buildResult <- compileLoadResultsIntoBuildResults config newLoadResult
-    requestTestRunsForNewBuildResults config buildResult
+    runPostBuildStore buildResult do
+        if hasTargets config.testTargets && noErrors buildResult then
+            requestTestRunsForNewBuildResults config.testTargets
+        else do
+            PostBuild.modifyPostBuild \pb -> pb {testSuites = Test.Suites mempty}
+  where
+    hasTargets testTargets = not $ null testTargets.getTestTargets
+    noErrors result = all (\d -> d.severity /= SError) result.diagnostics
 
 
 compileLoadResultsIntoBuildResults
@@ -516,7 +531,6 @@ compileLoadResultsIntoBuildResults session newLoadResult = do
             , duration = nominalDiffTime (diffUTCTime endTime startTime) :: Millisecond
             , moduleCount = loadResult.moduleCount
             , diagnostics = sortOn (\d -> (d.severity, d.file, d.line, d.col)) $ concat (Map.elems newAccumulated)
-            , testRuns = []
             }
   where
     BuildConfig {watchDirs} = session
@@ -524,26 +538,19 @@ compileLoadResultsIntoBuildResults session newLoadResult = do
 
 
 requestTestRunsForNewBuildResults
-    :: ( BuildStore :> es
-       , Log :> es
-       , State BuildId :> es
+    :: ( Log :> es
+       , PostBuildStore :> es
        , TestRunner :> es
        )
-    => BuildConfig
-    -> BuildResult
+    => TestTargets
     -> Eff es ()
-requestTestRunsForNewBuildResults config partialResult = do
-    buildId <- get
-    runTestsIfClean config buildId partialResult >>= \case
-        Nothing -> Log.info "Test run aborted by source change; skipping Done transition."
-        Just testRuns ->
-            setNewPhase
-                $ EnteringNewPhase buildId
-                $ BuildComplete
-                    PostBuild
-                        { testPhase = DoneTesting
-                        , result = partialResult {testRuns}
-                        }
+requestTestRunsForNewBuildResults testTargets =
+    runTestsForTargets testTargets >>= \case
+        Aborted -> Log.info "Test run aborted by source change; skipping Done transition."
+        NotAborted -> pure ()
+
+
+data TestRunAborted = NotAborted | Aborted
 
 
 -- Run all configured test suites if the build has no errors.
@@ -552,58 +559,36 @@ requestTestRunsForNewBuildResults config partialResult = do
 -- Returns 'Nothing' if the run was aborted mid-flight by a source change
 -- (the caller should not transition to a Done phase in that case). Returns
 -- 'Just' with the collected results otherwise.
-runTestsIfClean
-    :: ( BuildStore :> es
-       , Log :> es
+runTestsForTargets
+    :: ( Log :> es
+       , PostBuildStore :> es
        , TestRunner :> es
        )
-    => BuildConfig
-    -> BuildId
-    -> BuildResult
-    -> Eff es (Maybe [TestRun])
-runTestsIfClean (BuildConfig {testTargets}) bid partialResult
-    | null targetNames || any (\d -> d.severity == SError) partialResult.diagnostics = pure (Just [])
-    | otherwise = do
-        TestRunner.resetAbort
-        setNewPhase
-            $ EnteringNewPhase bid
-            $ BuildComplete
-                PostBuild
-                    { testPhase = Testing
-                    , result = partialResult {testRuns = map (`TestRunning` Nothing) targetNames}
-                    }
+    => TestTargets
+    -> Eff es TestRunAborted
+runTestsForTargets testTargets = do
+    TestRunner.resetAbort
+    PostBuild.modifyPostBuild \pb -> pb {testSuites = Test.Suites $ Map.fromList $ (,Test.SuiteRunning Nothing) <$> tgts}
 
-        Log.info $ "Running " <> show (length targetNames) <> " test suite(s)"
+    Log.info $ "Running " <> show (length tgts) <> " test suite(s)"
 
-        let initial = (\t -> (t, TestRunning t Nothing)) <$> targetNames
-        runLoop initial targetNames
+    runLoop tgts
   where
-    -- The runner consumes the @test:@ targets as cabal/ghci arguments, so
-    -- render the structured targets to their textual form at this boundary.
-    targetNames = map renderTarget testTargets.getTestTargets
-    runLoop acc [] = pure (Just (snd <$> acc))
-    runLoop acc (target : rest) = do
-        Log.info $ "Running tests: " <> target
-        result <- TestRunner.runTestSuite target
+    tgts = testTargets.getTestTargets
+    runLoop [] = pure NotAborted
+    runLoop (target : rest) = do
+        Log.info $ "Running tests: " <> renderTestTarget target
+        result' <- TestRunner.runTestSuite target
         aborted <- TestRunner.isAborted
         if aborted then
-            pure Nothing
+            pure Aborted
         else do
-            let acc' = insert target result acc
-            setNewPhase
-                $ EnteringNewPhase bid
-                $ BuildComplete
-                    PostBuild
-                        { testPhase = Testing
-                        , result = partialResult {testRuns = snd <$> acc'}
-                        }
+            PostBuild.modifyPostBuild \pb ->
+                pb
+                    { testSuites = Test.Suites $ Map.insert target result' pb.testSuites.getSuites
+                    }
 
-            runLoop acc' rest
-
-    insert _ _ [] = []
-    insert k v ((k', v') : xs)
-        | k == k' = (k, v) : xs
-        | otherwise = (k', v') : insert k v xs
+            runLoop rest
 
 
 --------------------------------------------------------------------------------

--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -79,7 +79,7 @@ import Tricorder.Session
     , renderTestTarget
     )
 
-import Tricorder.BuildState.Tests qualified as Test
+import Tricorder.BuildState.Test qualified as Test
 import Tricorder.Effects.BuildStore qualified as BuildStore
 import Tricorder.Effects.GhciSession qualified as GhciSession
 import Tricorder.Effects.PostBuildStore qualified as PostBuild

--- a/tricorder/src/Tricorder/CLI.hs
+++ b/tricorder/src/Tricorder/CLI.hs
@@ -18,6 +18,7 @@ import Effectful.Reader.Static (Reader, ask)
 
 import Atelier.Effects.Console qualified as Console
 import Data.ByteString.Lazy qualified as BSL
+import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 
 import Tricorder.Arguments
@@ -30,19 +31,13 @@ import Tricorder.Arguments
     )
 import Tricorder.BuildState
     ( BuildPhase (..)
-    , BuildProgress (..)
     , BuildResult (..)
     , BuildState (..)
     , Diagnostic (..)
     , PostBuild (..)
     , Severity (..)
-    , TestCase (..)
-    , TestCaseOutcome (..)
-    , TestPhase (..)
-    , TestRun (..)
-    , TestRunCompletion (..)
-    , TestRunError (..)
     )
+import Tricorder.BuildState.BuildProgress (BuildProgress (..))
 import Tricorder.CLI.Render
     ( diagnosticLineIndexed
     , formatDuration
@@ -51,12 +46,12 @@ import Tricorder.CLI.Render
 import Tricorder.Effects.UnixSocket (UnixSocket)
 import Tricorder.GhcPkg.Types (SourceQuery)
 import Tricorder.Runtime (SocketPath (..))
-import Tricorder.Socket.Client
-    ( querySource
-    , queryStatus
-    , queryStatusWait
-    )
+import Tricorder.Session (renderTestTarget)
+import Tricorder.Socket.Client (querySource, queryStatus, queryStatusWait)
 import Tricorder.TestOutput (stripGhciNoise)
+
+import Tricorder.BuildState.Tests qualified as Test
+import Tricorder.BuildState.Tests qualified as Tests
 
 
 -- | Print a build-command failure message and exit non-zero.
@@ -83,8 +78,11 @@ showStatus opts = do
         case current of
             Right BuildState {phase = Building _} -> Console.putStrLn "Building..."
             Right BuildState {phase = Restarting} -> Console.putStrLn "Restarting..."
-            Right BuildState {phase = BuildComplete (PostBuild Testing _)} -> Console.putStrLn "Testing..."
-            _ -> pure ()
+            Right BuildState {phase = BuildComplete _ pb}
+                | Tests.anyRunningTests pb.testSuites -> Console.putStrLn "Testing..."
+                | otherwise -> pure ()
+            Right BuildState {phase = BuildFailed _} -> pure ()
+            Left _ -> pure ()
     result <-
         case opts.wait of
             WaitForBuild -> queryStatusWait sockPath
@@ -103,52 +101,49 @@ showStatus opts = do
         Building _ -> Console.putStrLn "Building..."
         Restarting -> Console.putStrLn "Restarting..."
         BuildFailed msg -> reportBuildFailed msg
-        BuildComplete (PostBuild Testing _) -> Console.putStrLn "Testing..."
-        BuildComplete (PostBuild _ r) -> do
-            tz <- currentTimeZone
-            case expand of
-                Just n ->
-                    case r.diagnostics !!? (n - 1) of
-                        Nothing ->
-                            Console.putTextLn
-                                $ "No diagnostic #"
-                                    <> show n
-                                    <> " (current build has "
-                                    <> show (length r.diagnostics)
-                                    <> ")"
-                        Just d -> do
-                            Console.putTextLn $ diagnosticLineIndexed n d
-                            Console.putText d.text
-                Nothing -> do
-                    let printDiag (i, d) = case verbosity of
-                            Verbose -> do
-                                Console.putTextLn $ diagnosticLineIndexed i d
+        BuildComplete r pb
+            | Tests.anyRunningTests pb.testSuites -> Console.putStrLn "Testing..."
+            | otherwise -> do
+                tz <- currentTimeZone
+                case expand of
+                    Just n ->
+                        case r.diagnostics !!? (n - 1) of
+                            Nothing ->
+                                Console.putTextLn
+                                    $ "No diagnostic #"
+                                        <> show n
+                                        <> " (current build has "
+                                        <> show (length r.diagnostics)
+                                        <> ")"
+                            Just d -> do
+                                Console.putTextLn $ diagnosticLineIndexed n d
                                 Console.putText d.text
-                            Concise ->
-                                Console.putTextLn $ diagnosticLineIndexed i d
-                    mapM_ printDiag (zip [1 ..] r.diagnostics)
-                    Console.putTextLn $ buildSummary tz r
-                    mapM_ (printTestRun verbosity) r.testRuns
-                    when (buildHasErrors r || testsFailed r) exitFailure
+                    Nothing -> do
+                        let printDiag (i, d) = case verbosity of
+                                Verbose -> do
+                                    Console.putTextLn $ diagnosticLineIndexed i d
+                                    Console.putText d.text
+                                Concise ->
+                                    Console.putTextLn $ diagnosticLineIndexed i d
+                        mapM_ printDiag (zip [1 ..] r.diagnostics)
+                        Console.putTextLn $ buildSummary tz r
+                        mapM_ (uncurry (printTestRun verbosity)) $ Map.toList pb.testSuites.getSuites
+                        when (buildHasErrors r || Tests.hasFailedTests pb.testSuites) exitFailure
 
-    printTestRun verbosity tr = do
+    printTestRun verbosity tgt tr = do
         Console.putTextLn $ case tr of
-            TestRunning t Nothing -> t <> "  running..."
-            TestRunning t (Just p) -> t <> "  running... (" <> show p.compiled <> "/" <> show p.total <> ")"
-            TestRunErrored e -> e.target <> "  error: " <> e.message
-            TestRunCompleted c -> c.target <> "  " <> completionSummary c
+            Test.SuiteRunning Nothing -> t <> "  running..."
+            Test.SuiteRunning (Just p) -> t <> "  running... (" <> show p.compiled <> "/" <> show p.total <> ")"
+            Test.SuiteErrored e -> t <> "  error: " <> e.message
+            Test.SuiteCompleted c -> t <> "  " <> completionSummary c
         when (verbosity == Verbose) $ case tr of
-            TestRunCompleted c ->
+            Test.SuiteCompleted c ->
                 mapM_ (Console.putTextLn . ("  " <>)) (stripGhciNoise (T.lines c.output))
             _ -> pure ()
+      where
+        t = renderTestTarget tgt
 
     buildHasErrors r = any ((== SError) . (.severity)) r.diagnostics
-    testsFailed r = any isFailedRun r.testRuns
-      where
-        isFailedRun (TestRunCompleted c) = not c.passed
-        isFailedRun (TestRunErrored _) = True
-        isFailedRun (TestRunning _ _) = False
-
     buildSummary tz r =
         let errs = length $ filter ((== SError) . (.severity)) r.diagnostics
             warns = length $ filter ((== SWarning) . (.severity)) r.diagnostics
@@ -160,7 +155,7 @@ showStatus opts = do
                 show errs <> " error(s), " <> show warns <> " warning(s) " <> stats <> " " <> ts
 
 
-completionSummary :: TestRunCompletion -> Text
+completionSummary :: Test.SuiteCompletion -> Text
 completionSummary c = statusText <> maybe "" (\d -> " (" <> formatDuration d <> ")") c.duration
   where
     statusText
@@ -172,7 +167,7 @@ completionSummary c = statusText <> maybe "" (\d -> " (" <> formatDuration d <> 
                     "passed (" <> show total <> ")"
                 else
                     show failedCount <> "/" <> show total <> " failed"
-    isFailedCase (TestCase _ (TestCaseFailed _)) = True
+    isFailedCase (Test.Case _ (Test.Failed _)) = True
     isFailedCase _ = False
 
 
@@ -211,41 +206,33 @@ showTests opts = do
             case state.phase of
                 Building _ -> Console.putStrLn "Build in progress, no test results yet."
                 Restarting -> Console.putStrLn "Daemon restarting, no test results yet."
-                BuildComplete r -> renderTestRuns r.result.testRuns
+                BuildComplete _ pb -> renderTestRuns pb.testSuites.getSuites
                 BuildFailed msg -> reportBuildFailed msg
   where
-    renderTestRuns [] = Console.putStrLn "No test results."
-    renderTestRuns testRuns
-        | null runs = do
+    renderTestRuns suites
+        | Map.null suites = Console.putStrLn "No test results."
+        | Map.null filteredSuites = do
             Console.putStrLn "All passed."
-            mapM_ (Console.putTextLn . ("  " <>) . testRunTarget) testRuns
+            mapM_ (Console.putTextLn . ("  " <>) . renderTestTarget) $ Map.keys suites
         | otherwise = do
-            mapM_ printTestOutput runs
-            when (any isFailed runs) exitFailure
+            mapM_ (uncurry printTestOutput) $ Map.toList filteredSuites
+            when (any Tests.isFailedRun filteredSuites) exitFailure
       where
-        runs =
+        filteredSuites =
             if opts.failedOnly then
-                filter isFailed testRuns
+                Map.filter Tests.isFailedRun suites
             else
-                testRuns
+                suites
 
-    isFailed (TestRunCompleted c) = not c.passed
-    isFailed (TestRunErrored _) = True
-    isFailed (TestRunning _ _) = False
-
-    testRunTarget (TestRunning t _) = t
-    testRunTarget (TestRunErrored e) = e.target
-    testRunTarget (TestRunCompleted c) = c.target
-
-    printTestOutput tr = case tr of
-        TestRunning t Nothing ->
-            Console.putTextLn $ t <> "  running..."
-        TestRunning t (Just p) ->
-            Console.putTextLn $ t <> "  running... (" <> show p.compiled <> "/" <> show p.total <> ")"
-        TestRunErrored e ->
-            Console.putTextLn $ e.target <> "  error: " <> e.message
-        TestRunCompleted c -> do
-            Console.putTextLn $ c.target <> "  " <> completionSummary c
+    printTestOutput tgt tr = case tr of
+        Test.SuiteRunning Nothing ->
+            Console.putTextLn $ t <> "running..."
+        Test.SuiteRunning (Just p) ->
+            Console.putTextLn $ t <> "running... (" <> show p.compiled <> "/" <> show p.total <> ")"
+        Test.SuiteErrored e ->
+            Console.putTextLn $ t <> "error: " <> e.message
+        Test.SuiteCompleted c -> do
+            Console.putTextLn $ t <> completionSummary c
             if opts.failedOnly then
                 if null c.testCases then do
                     Console.putTextLn "  (unrecognised test runner format — showing full output)"
@@ -254,16 +241,18 @@ showTests opts = do
                     mapM_ printFailedCase (filter isCaseFailed c.testCases)
             else
                 mapM_ (Console.putTextLn . ("  " <>)) (stripGhciNoise (lines c.output))
+      where
+        t = renderTestTarget tgt <> "  "
 
-    isCaseFailed (TestCase _ (TestCaseFailed _)) = True
+    isCaseFailed (Test.Case _ (Test.Failed _)) = True
     isCaseFailed _ = False
 
     printFailedCase tc = do
         Console.putTextLn $ "  " <> tc.description
         case tc.outcome of
-            TestCaseFailed details ->
+            Test.Failed details ->
                 mapM_ (Console.putTextLn . ("    " <>)) (T.lines details)
-            TestCasePassed -> pure ()
+            Test.Passed -> pure ()
 
 
 showSource

--- a/tricorder/src/Tricorder/CLI.hs
+++ b/tricorder/src/Tricorder/CLI.hs
@@ -50,8 +50,8 @@ import Tricorder.Session (renderTestTarget)
 import Tricorder.Socket.Client (querySource, queryStatus, queryStatusWait)
 import Tricorder.TestOutput (stripGhciNoise)
 
-import Tricorder.BuildState.Tests qualified as Test
-import Tricorder.BuildState.Tests qualified as Tests
+import Tricorder.BuildState.Test qualified as Test
+import Tricorder.BuildState.Test qualified as Tests
 
 
 -- | Print a build-command failure message and exit non-zero.

--- a/tricorder/src/Tricorder/CLI.hs
+++ b/tricorder/src/Tricorder/CLI.hs
@@ -238,14 +238,11 @@ showTests opts = do
                     Console.putTextLn "  (unrecognised test runner format — showing full output)"
                     mapM_ (Console.putTextLn . ("  " <>)) (stripGhciNoise (lines c.output))
                 else
-                    mapM_ printFailedCase (filter isCaseFailed c.testCases)
+                    mapM_ printFailedCase (filter Test.caseFailed c.testCases)
             else
                 mapM_ (Console.putTextLn . ("  " <>)) (stripGhciNoise (lines c.output))
       where
         t = renderTestTarget tgt <> "  "
-
-    isCaseFailed (Test.Case _ (Test.Failed _)) = True
-    isCaseFailed _ = False
 
     printFailedCase tc = do
         Console.putTextLn $ "  " <> tc.description

--- a/tricorder/src/Tricorder/CLI.hs
+++ b/tricorder/src/Tricorder/CLI.hs
@@ -78,8 +78,8 @@ showStatus opts = do
         case current of
             Right BuildState {phase = Building _} -> Console.putStrLn "Building..."
             Right BuildState {phase = Restarting} -> Console.putStrLn "Restarting..."
-            Right BuildState {phase = BuildComplete _ pb}
-                | Tests.anyRunningTests pb.testSuites -> Console.putStrLn "Testing..."
+            Right BuildState {phase = BuildComplete _ postBuild}
+                | Tests.anyRunningTests postBuild.testSuites -> Console.putStrLn "Testing..."
                 | otherwise -> pure ()
             Right BuildState {phase = BuildFailed _} -> pure ()
             Left _ -> pure ()
@@ -101,19 +101,19 @@ showStatus opts = do
         Building _ -> Console.putStrLn "Building..."
         Restarting -> Console.putStrLn "Restarting..."
         BuildFailed msg -> reportBuildFailed msg
-        BuildComplete r pb
-            | Tests.anyRunningTests pb.testSuites -> Console.putStrLn "Testing..."
+        BuildComplete result postBuild
+            | Tests.anyRunningTests postBuild.testSuites -> Console.putStrLn "Testing..."
             | otherwise -> do
                 tz <- currentTimeZone
                 case expand of
                     Just n ->
-                        case r.diagnostics !!? (n - 1) of
+                        case result.diagnostics !!? (n - 1) of
                             Nothing ->
                                 Console.putTextLn
                                     $ "No diagnostic #"
                                         <> show n
                                         <> " (current build has "
-                                        <> show (length r.diagnostics)
+                                        <> show (length result.diagnostics)
                                         <> ")"
                             Just d -> do
                                 Console.putTextLn $ diagnosticLineIndexed n d
@@ -125,10 +125,10 @@ showStatus opts = do
                                     Console.putText d.text
                                 Concise ->
                                     Console.putTextLn $ diagnosticLineIndexed i d
-                        mapM_ printDiag (zip [1 ..] r.diagnostics)
-                        Console.putTextLn $ buildSummary tz r
-                        mapM_ (uncurry (printTestRun verbosity)) $ Map.toList pb.testSuites.getSuites
-                        when (buildHasErrors r || Tests.hasFailedTests pb.testSuites) exitFailure
+                        mapM_ printDiag (zip [1 ..] result.diagnostics)
+                        Console.putTextLn $ buildSummary tz result
+                        mapM_ (uncurry (printTestRun verbosity)) $ Map.toList postBuild.testSuites.getSuites
+                        when (buildHasErrors result || Tests.hasFailedTests postBuild.testSuites) exitFailure
 
     printTestRun verbosity tgt tr = do
         Console.putTextLn $ case tr of
@@ -206,7 +206,7 @@ showTests opts = do
             case state.phase of
                 Building _ -> Console.putStrLn "Build in progress, no test results yet."
                 Restarting -> Console.putStrLn "Daemon restarting, no test results yet."
-                BuildComplete _ pb -> renderTestRuns pb.testSuites.getSuites
+                BuildComplete _ postBuild -> renderTestRuns postBuild.testSuites.getSuites
                 BuildFailed msg -> reportBuildFailed msg
   where
     renderTestRuns suites

--- a/tricorder/src/Tricorder/Effects/BuildStore.hs
+++ b/tricorder/src/Tricorder/Effects/BuildStore.hs
@@ -35,7 +35,7 @@ import Tricorder.BuildState
     , initialBuildState
     )
 
-import Tricorder.BuildState.Tests qualified as Test
+import Tricorder.BuildState.Test qualified as Test
 
 
 data BuildStore :: Effect where

--- a/tricorder/src/Tricorder/Effects/BuildStore.hs
+++ b/tricorder/src/Tricorder/Effects/BuildStore.hs
@@ -99,7 +99,7 @@ isBuilding :: BuildState -> Bool
 isBuilding s = case s.phase of
     Building _ -> True
     Restarting -> True
-    BuildComplete _ pb -> Test.anyRunningTests pb.testSuites
+    BuildComplete _ postBuild -> Test.anyRunningTests postBuild.testSuites
     BuildFailed _ -> False
 
 

--- a/tricorder/src/Tricorder/Effects/BuildStore.hs
+++ b/tricorder/src/Tricorder/Effects/BuildStore.hs
@@ -32,9 +32,10 @@ import Tricorder.BuildState
     , ChangeKind (..)
     , DaemonInfo (..)
     , PostBuild (..)
-    , TestPhase (..)
     , initialBuildState
     )
+
+import Tricorder.BuildState.Tests qualified as Test
 
 
 data BuildStore :: Effect where
@@ -98,8 +99,7 @@ isBuilding :: BuildState -> Bool
 isBuilding s = case s.phase of
     Building _ -> True
     Restarting -> True
-    BuildComplete (PostBuild Testing _) -> True
-    BuildComplete (PostBuild DoneTesting _) -> False
+    BuildComplete _ pb -> Test.anyRunningTests pb.testSuites
     BuildFailed _ -> False
 
 

--- a/tricorder/src/Tricorder/Effects/GhciSession.hs
+++ b/tricorder/src/Tricorder/Effects/GhciSession.hs
@@ -38,7 +38,8 @@ import Effectful.Exception (throwIO)
 import Effectful.State.Static.Shared (State, evalState, state)
 import Effectful.TH (makeEffect)
 
-import Tricorder.BuildState (BuildPhase (..), BuildProgress (..))
+import Tricorder.BuildState (BuildPhase (..))
+import Tricorder.BuildState.BuildProgress (BuildProgress (..))
 import Tricorder.Effects.BuildStore (BuildStore, modifyPhase)
 import Tricorder.Effects.GhciSession.GhciParser
     ( GhciLoading (..)

--- a/tricorder/src/Tricorder/Effects/PostBuildStore.hs
+++ b/tricorder/src/Tricorder/Effects/PostBuildStore.hs
@@ -37,18 +37,18 @@ runPostBuildStore
     => BuildResult
     -> Eff (PostBuildStore : es) a
     -> Eff es a
-runPostBuildStore initialBr act = do
+runPostBuildStore initialBuildResult act = do
     res <- interpretWith_ act \case
         ModifyPostBuild f -> do
             BuildStore.modifyPhase \s -> case s.phase of
-                BuildComplete br pb -> BuildComplete br $ f pb
-                _ -> BuildComplete initialBr $ f $ PostBuild $ Test.Suites mempty
+                BuildComplete buildResult postBuild -> BuildComplete buildResult $ f postBuild
+                _ -> BuildComplete initialBuildResult $ f $ PostBuild $ Test.Suites mempty
     curr <- BuildStore.getState
     case curr.phase of
         BuildComplete _ _ -> pure ()
         _ ->
             BuildStore.setPhase curr.buildId
-                $ BuildComplete initialBr
+                $ BuildComplete initialBuildResult
                 $ PostBuild
                 $ Test.Suites mempty
     pure res

--- a/tricorder/src/Tricorder/Effects/PostBuildStore.hs
+++ b/tricorder/src/Tricorder/Effects/PostBuildStore.hs
@@ -1,0 +1,72 @@
+module Tricorder.Effects.PostBuildStore
+    ( PostBuildStore
+    , modifyPostBuild
+    , runPostBuildStore
+    , runPostBuildState
+    , runPostBuildCapture
+    )
+where
+
+import Effectful (Effect)
+import Effectful.Dispatch.Dynamic (interpose_, interpretWith_, interpret_)
+import Effectful.State.Static.Shared (State, get, modify)
+import Effectful.TH (makeEffect)
+import Effectful.Writer.Static.Shared (Writer, tell)
+
+import Tricorder.BuildState (BuildPhase (..), BuildResult, BuildState (..), PostBuild (..))
+import Tricorder.Effects.BuildStore (BuildStore)
+
+import Tricorder.BuildState.Tests qualified as Test
+import Tricorder.Effects.BuildStore qualified as BuildStore
+
+
+data PostBuildStore :: Effect where
+    ModifyPostBuild :: (PostBuild -> PostBuild) -> PostBuildStore m ()
+
+
+makeEffect ''PostBuildStore
+
+
+-- | Ensures actions that rely on 'PostBuildStore' have access to a 'PostBuild'
+-- to modify and update.
+--
+-- This interpreter ensures that the 'BuildState''s @phase@ is @BuildComplete@
+-- once this interpreter finishes.
+runPostBuildStore
+    :: (BuildStore :> es)
+    => BuildResult
+    -> Eff (PostBuildStore : es) a
+    -> Eff es a
+runPostBuildStore initialBr act = do
+    res <- interpretWith_ act \case
+        ModifyPostBuild f -> do
+            BuildStore.modifyPhase \s -> case s.phase of
+                BuildComplete br pb -> BuildComplete br $ f pb
+                _ -> BuildComplete initialBr $ f $ PostBuild $ Test.Suites mempty
+    curr <- BuildStore.getState
+    case curr.phase of
+        BuildComplete _ _ -> pure ()
+        _ ->
+            BuildStore.setPhase curr.buildId
+                $ BuildComplete initialBr
+                $ PostBuild
+                $ Test.Suites mempty
+    pure res
+
+
+runPostBuildState :: (State PostBuild :> es) => Eff (PostBuildStore : es) a -> Eff es a
+runPostBuildState = interpret_ \case
+    ModifyPostBuild f -> modify f
+
+
+runPostBuildCapture
+    :: ( PostBuildStore :> es
+       , State PostBuild :> es
+       , Writer [PostBuild] :> es
+       )
+    => Eff es a -> Eff es a
+runPostBuildCapture = interpose_ \case
+    ModifyPostBuild f -> do
+        curr <- get
+        tell [f curr]
+        modifyPostBuild f

--- a/tricorder/src/Tricorder/Effects/PostBuildStore.hs
+++ b/tricorder/src/Tricorder/Effects/PostBuildStore.hs
@@ -8,7 +8,7 @@ module Tricorder.Effects.PostBuildStore
 where
 
 import Effectful (Effect)
-import Effectful.Dispatch.Dynamic (interpose_, interpretWith_, interpret_)
+import Effectful.Dispatch.Dynamic (interpose_, interpret_)
 import Effectful.State.Static.Shared (State, get, modify)
 import Effectful.TH (makeEffect)
 import Effectful.Writer.Static.Shared (Writer, tell)
@@ -37,21 +37,14 @@ runPostBuildStore
     => BuildResult
     -> Eff (PostBuildStore : es) a
     -> Eff es a
-runPostBuildStore initialBuildResult act = do
-    res <- interpretWith_ act \case
+runPostBuildStore initialBuildResult = do
+    interpret_ \case
         ModifyPostBuild f -> do
             BuildStore.modifyPhase \s -> case s.phase of
-                BuildComplete buildResult postBuild -> BuildComplete buildResult $ f postBuild
-                _ -> BuildComplete initialBuildResult $ f $ PostBuild $ Test.Suites mempty
-    curr <- BuildStore.getState
-    case curr.phase of
-        BuildComplete _ _ -> pure ()
-        _ ->
-            BuildStore.setPhase curr.buildId
-                $ BuildComplete initialBuildResult
-                $ PostBuild
-                $ Test.Suites mempty
-    pure res
+                BuildComplete buildResult postBuild ->
+                    BuildComplete buildResult $ f postBuild
+                _ ->
+                    BuildComplete initialBuildResult $ f $ PostBuild $ Test.Suites mempty
 
 
 runPostBuildState :: (State PostBuild :> es) => Eff (PostBuildStore : es) a -> Eff es a

--- a/tricorder/src/Tricorder/Effects/PostBuildStore.hs
+++ b/tricorder/src/Tricorder/Effects/PostBuildStore.hs
@@ -16,7 +16,7 @@ import Effectful.Writer.Static.Shared (Writer, tell)
 import Tricorder.BuildState (BuildPhase (..), BuildResult, BuildState (..), PostBuild (..))
 import Tricorder.Effects.BuildStore (BuildStore)
 
-import Tricorder.BuildState.Tests qualified as Test
+import Tricorder.BuildState.Test qualified as Test
 import Tricorder.Effects.BuildStore qualified as BuildStore
 
 

--- a/tricorder/src/Tricorder/Effects/TestRunner.hs
+++ b/tricorder/src/Tricorder/Effects/TestRunner.hs
@@ -249,9 +249,9 @@ reportTestProgress target loading =
         BuildComplete result pb
             | Test.anyRunningTests pb.testSuites ->
                 let progress = BuildProgress {compiled = loading.index, total = loading.total}
-                    updateRun tgt (Test.SuiteRunning _) | tgt == target = Test.SuiteRunning (Just progress)
-                    updateRun _ r = r
-                    newRuns = Test.Suites $ Map.mapWithKey updateRun pb.testSuites.getSuites
+                    updateRun (Test.SuiteRunning _) = Test.SuiteRunning (Just progress)
+                    updateRun r = r
+                    newRuns = Test.Suites $ Map.adjust updateRun target pb.testSuites.getSuites
                 in  BuildComplete result pb {testSuites = newRuns}
         other -> other
 

--- a/tricorder/src/Tricorder/Effects/TestRunner.hs
+++ b/tricorder/src/Tricorder/Effects/TestRunner.hs
@@ -39,34 +39,42 @@ import Effectful.TH (makeEffect)
 
 import Atelier.Effects.Log qualified as Log
 import Data.List qualified as List
+import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 
 import Tricorder.BuildState
     ( BuildPhase (..)
-    , BuildProgress (..)
-    , BuildResult (..)
     , BuildState (..)
     , PostBuild (..)
-    , TestPhase (..)
-    , TestRun (..)
-    , TestRunCompletion (..)
-    , TestRunError (..)
     )
+import Tricorder.BuildState.BuildProgress (BuildProgress (..))
 import Tricorder.Effects.BuildStore (BuildStore, modifyPhase)
 import Tricorder.Effects.GhciSession.GhciParser (GhciLoading (..))
-import Tricorder.Effects.GhciSession.GhciProcess (GhciProcess, execGhci, terminateGhciProcess, withGhciProcess)
+import Tricorder.Effects.GhciSession.GhciProcess
+    ( GhciProcess
+    , execGhci
+    , terminateGhciProcess
+    , withGhciProcess
+    )
 import Tricorder.Effects.SessionStore (SessionStore)
 import Tricorder.Runtime (ProjectRoot (..))
-import Tricorder.Session (Command (..), Session (..), TestTimeout (..))
+import Tricorder.Session
+    ( Command (..)
+    , Session (..)
+    , TestTarget
+    , TestTimeout (..)
+    , renderTestTarget
+    )
 import Tricorder.TestOutput (parseHspecDuration, parseHspecOutput)
 
+import Tricorder.BuildState.Tests qualified as Test
 import Tricorder.Effects.SessionStore qualified as SessionStore
 
 
 data TestRunner :: Effect where
     -- | Run a single test suite in a short-lived @cabal repl@ process and
     -- return the captured output and detected outcome.
-    RunTestSuite :: Text -> TestRunner m TestRun
+    RunTestSuite :: TestTarget -> TestRunner m Test.Suite
     -- | Interrupt the test currently in flight (if any) and latch an abort
     -- flag so that subsequent 'RunTestSuite' calls short-circuit until
     -- 'ResetAbort' is called.
@@ -117,7 +125,7 @@ runTestRunnerIO act = do
         RunTestSuite target -> do
             alreadyAborted <- atomically (readTVar abortedRef)
             if alreadyAborted then
-                pure $ TestRunErrored $ TestRunError {target, message = "Test run aborted"}
+                pure $ Test.SuiteErrored $ Test.SuiteError {message = "Test run aborted"}
             else do
                 Session {testTimeout} <- SessionStore.get
                 let onProgress = abortGatedProgress abortedRef target
@@ -138,7 +146,7 @@ runTestRunnerIO act = do
                     $ bracket_
                         (pure ())
                         (atomically (writeTVar currentProcRef Nothing))
-                    $ withGhciProcess def (Command $ "cabal repl " <> target) projectRoot onProgress onReady \ghci _ ->
+                    $ withGhciProcess def (Command $ "cabal repl " <> renderTestTarget target) projectRoot onProgress onReady \ghci _ ->
                         atomically (readTVar abortedRef) >>= \case
                             -- An interrupt may have landed during the
                             -- @cabal repl@ load. The returned value is
@@ -153,21 +161,24 @@ runTestRunnerIO act = do
                                         Just ls -> pure (Right ls)
                 case result of
                     Left ex ->
-                        pure $ TestRunErrored $ TestRunError {target, message = show ex}
+                        pure
+                            $ Test.SuiteErrored
+                            $ Test.SuiteError {message = show ex}
                     Right (Left secs) -> do
-                        Log.warn $ "Test suite " <> target <> " timed out after " <> show secs <> "s"
-                        pure $ TestRunErrored $ TestRunError {target, message = "Test suite timed out after " <> show secs <> "s"}
+                        Log.warn $ "Test suite " <> renderTestTarget target <> " timed out after " <> show secs <> "s"
+                        pure
+                            $ Test.SuiteErrored
+                            $ Test.SuiteError {message = "Test suite timed out after " <> show secs <> "s"}
                     Right (Right mainLines) ->
                         pure
                             $ let output = T.unlines mainLines
                               in  case detectOutcome output of
                                     GhciCrashed msg ->
-                                        TestRunErrored $ TestRunError {target, message = msg}
+                                        Test.SuiteErrored $ Test.SuiteError {message = msg}
                                     outcome ->
-                                        TestRunCompleted
-                                            $ TestRunCompletion
-                                                { target
-                                                , passed = outcome == GhciPassed
+                                        Test.SuiteCompleted
+                                            $ Test.SuiteCompletion
+                                                { passed = outcome == GhciPassed
                                                 , output
                                                 , testCases = parseHspecOutput output
                                                 , duration = parseHspecDuration output
@@ -181,7 +192,7 @@ runTestRunnerIO act = do
 runTestRunnerScripted
     :: forall es a
      . (Concurrent :> es, IOE :> es)
-    => [Either SomeException TestRun]
+    => [Either SomeException Test.Suite]
     -> Eff (TestRunner : es) a
     -> Eff es a
 runTestRunnerScripted results act = do
@@ -200,7 +211,7 @@ runTestRunnerScripted results act = do
         )
         act
   where
-    popResult :: Eff (State [Either SomeException TestRun] : es) TestRun
+    popResult :: Eff (State [Either SomeException Test.Suite] : es) Test.Suite
     popResult =
         get >>= \case
             [] -> error "TestRunnerScripted: no more results in queue"
@@ -214,7 +225,7 @@ runTestRunnerScripted results act = do
 -- user has already touched a file — do not push the counter forward.
 abortGatedProgress
     :: (BuildStore :> es, Concurrent :> es)
-    => TVar Bool -> Text -> GhciLoading -> Eff es ()
+    => TVar Bool -> TestTarget -> GhciLoading -> Eff es ()
 abortGatedProgress abortedRef target loading = do
     aborted <- atomically (readTVar abortedRef)
     unless aborted $ reportTestProgress target loading
@@ -232,15 +243,16 @@ abortGatedProgress abortedRef target loading = do
 -- triggered 'Restarting' or 'Building'), the progress event is dropped rather
 -- than reverting the phase.
 reportTestProgress
-    :: (BuildStore :> es) => Text -> GhciLoading -> Eff es ()
+    :: (BuildStore :> es) => TestTarget -> GhciLoading -> Eff es ()
 reportTestProgress target loading =
     modifyPhase \state -> case state.phase of
-        BuildComplete (PostBuild Testing partialResult) ->
-            let progress = BuildProgress {compiled = loading.index, total = loading.total}
-                updateRun (TestRunning t _) | t == target = TestRunning t (Just progress)
-                updateRun r = r
-                newRuns = map updateRun partialResult.testRuns
-            in  BuildComplete (PostBuild Testing partialResult {testRuns = newRuns})
+        BuildComplete result pb
+            | Test.anyRunningTests pb.testSuites ->
+                let progress = BuildProgress {compiled = loading.index, total = loading.total}
+                    updateRun tgt (Test.SuiteRunning _) | tgt == target = Test.SuiteRunning (Just progress)
+                    updateRun _ r = r
+                    newRuns = Test.Suites $ Map.mapWithKey updateRun pb.testSuites.getSuites
+                in  BuildComplete result pb {testSuites = newRuns}
         other -> other
 
 

--- a/tricorder/src/Tricorder/Effects/TestRunner.hs
+++ b/tricorder/src/Tricorder/Effects/TestRunner.hs
@@ -246,13 +246,13 @@ reportTestProgress
     :: (BuildStore :> es) => TestTarget -> GhciLoading -> Eff es ()
 reportTestProgress target loading =
     modifyPhase \state -> case state.phase of
-        BuildComplete result pb
-            | Test.anyRunningTests pb.testSuites ->
+        BuildComplete result postBuild
+            | Test.anyRunningTests postBuild.testSuites ->
                 let progress = BuildProgress {compiled = loading.index, total = loading.total}
                     updateRun (Test.SuiteRunning _) = Test.SuiteRunning (Just progress)
                     updateRun r = r
-                    newRuns = Test.Suites $ Map.adjust updateRun target pb.testSuites.getSuites
-                in  BuildComplete result pb {testSuites = newRuns}
+                    newRuns = Test.Suites $ Map.adjust updateRun target postBuild.testSuites.getSuites
+                in  BuildComplete result postBuild {testSuites = newRuns}
         other -> other
 
 

--- a/tricorder/src/Tricorder/Effects/TestRunner.hs
+++ b/tricorder/src/Tricorder/Effects/TestRunner.hs
@@ -67,7 +67,7 @@ import Tricorder.Session
     )
 import Tricorder.TestOutput (parseHspecDuration, parseHspecOutput)
 
-import Tricorder.BuildState.Tests qualified as Test
+import Tricorder.BuildState.Test qualified as Test
 import Tricorder.Effects.SessionStore qualified as SessionStore
 
 

--- a/tricorder/src/Tricorder/Session.hs
+++ b/tricorder/src/Tricorder/Session.hs
@@ -9,6 +9,8 @@ module Tricorder.Session
     , ComponentKind (..)
     , parseTarget
     , renderTarget
+    , TestTarget (..)
+    , renderTestTarget
     , WatchDirs (..)
     , WatchExclusionPatterns (..)
     , ReplBuildDir (..)
@@ -33,7 +35,7 @@ import Atelier.Effects.FileSystem (FileSystem, doesFileExist, listDirectory, rea
 import Atelier.Effects.Log (Log)
 import Atelier.Types.QuietSnake (QuietSnake (..))
 import Atelier.Types.WithDefaults (WithDefaults (..))
-import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Aeson (FromJSON (..), FromJSONKey, ToJSON (..), ToJSONKey)
 import Data.Default (Default (..))
 import Data.List (nub)
 import Data.Traversable (for)
@@ -132,19 +134,19 @@ newtype Command = Command {getCommand :: Text}
 -- target list onto its @test:@ components via 'projectTestTargets'; the data
 -- constructor is not exported, so a 'TestTargets' can never hold a non-test
 -- target [ref:test_targets_invariant].
-newtype TestTargets = TestTargets {getTestTargets :: [Target]}
+newtype TestTargets = TestTargets {getTestTargets :: [TestTarget]}
     deriving stock (Eq, Generic, Show)
-    deriving (FromJSON, ToJSON) via [Target]
+    deriving (FromJSON, ToJSON) via [TestTarget]
 
 
 -- | [tag:test_targets_invariant] Project a target list onto its test suites —
 -- the only way to build a 'TestTargets', so the @test:@-only invariant holds by
 -- construction.
 projectTestTargets :: [Target] -> TestTargets
-projectTestTargets = TestTargets . filter isTestTarget
+projectTestTargets = TestTargets . mapMaybe mkTestTarget
   where
-    isTestTarget (Qualified Test _) = True
-    isTestTarget _ = False
+    mkTestTarget tgt@(Qualified Test _) = Just $ TestTarget tgt
+    mkTestTarget _ = Nothing
 
 
 -- | Parse raw target strings (e.g. the @test_targets@ config) and project them
@@ -164,13 +166,13 @@ data Target
       Bare Text
     | -- | A form we don't recognize: an unknown kind, or extra colons.
       Unrecognized Text
-    deriving stock (Eq, Show)
+    deriving stock (Eq, Generic, Ord, Show)
 
 
 -- | The kind of cabal component a 'Qualified' target names. Covers every
 -- component kind cabal models (matching @Distribution.Types.ComponentName@).
 data ComponentKind = Lib | FLib | Exe | Test | Bench
-    deriving stock (Bounded, Enum, Eq, Show)
+    deriving stock (Bounded, Enum, Eq, Generic, Ord, Show)
 
 
 -- | [tag:kind_prefix_sole_source] The canonical prefix cabal uses for each
@@ -227,6 +229,20 @@ instance FromJSON Target where
     parseJSON = fmap parseTarget . parseJSON
 
 
+instance ToJSONKey Target
+instance FromJSONKey Target
+
+
+newtype TestTarget = TestTarget {getTestTarget :: Target}
+    deriving stock (Eq, Generic, Ord, Show)
+    deriving (FromJSON, ToJSON) via Target
+    deriving (FromJSONKey, ToJSONKey) via Target
+
+
+renderTestTarget :: TestTarget -> Text
+renderTestTarget = renderTarget . getTestTarget
+
+
 newtype WatchDirs = WatchDirs {getWatchDirs :: [FilePath]}
     deriving stock (Eq, Generic, Show)
     deriving (FromJSON, ToJSON) via [FilePath]
@@ -278,7 +294,7 @@ detectCommand targets (TestTargets testTargets) replBuildDir (ProjectRoot projec
     hasStack <- doesFileExist (projectRoot </> "stack.yaml")
     let targetStr
             | not (null targets) = unwords (map renderTarget targets)
-            | otherwise = unwords ("all" : map renderTarget testTargets)
+            | otherwise = unwords ("all" : map renderTestTarget testTargets)
         buildDirFlag = "--builddir " <> toText replBuildDir <> " "
     pure
         if

--- a/tricorder/src/Tricorder/Socket/Server.hs
+++ b/tricorder/src/Tricorder/Socket/Server.hs
@@ -18,7 +18,13 @@ import Atelier.Effects.Conc qualified as Conc
 import Atelier.Effects.Log qualified as Log
 import Data.ByteString.Lazy qualified as BSL
 
-import Tricorder.BuildState (BuildPhase (..), BuildResult (..), BuildState (..), Diagnostic, PostBuild (..), TestPhase (..))
+import Tricorder.BuildState
+    ( BuildPhase (..)
+    , BuildResult (..)
+    , BuildState (..)
+    , Diagnostic
+    , PostBuild (..)
+    )
 import Tricorder.Effects.BuildStore (BuildStore, getState, waitForAnyChange, waitUntilDone)
 import Tricorder.Effects.Cabal (Cabal)
 import Tricorder.Effects.GhcPkg (GhcPkg)
@@ -44,6 +50,7 @@ import Tricorder.Socket.Protocol
 import Tricorder.SourceLookup (ModuleName, ModuleSourceResult, PackageId, lookupModuleSource)
 import Tricorder.Version (VersionMismatch (..), checkVersion)
 
+import Tricorder.BuildState.Tests qualified as Test
 import Tricorder.Effects.BuildStore qualified as BuildStore
 
 
@@ -202,8 +209,9 @@ respondWhenDone h = awaitResult >>= sendJson h
         case s.phase of
             Building _ -> waitUntilDone
             Restarting -> waitUntilDone
-            BuildComplete (PostBuild Testing _) -> waitUntilDone
-            BuildComplete (PostBuild DoneTesting _) -> awaitBuildStart (5 :: Int) s
+            BuildComplete _ pb
+                | Test.anyRunningTests pb.testSuites -> waitUntilDone
+                | otherwise -> awaitBuildStart (5 :: Int) s
             BuildFailed _ -> pure s
 
     -- Poll up to n × 50ms for a build to start, then wait for it to finish.
@@ -214,8 +222,9 @@ respondWhenDone h = awaitResult >>= sendJson h
         case s'.phase of
             Building _ -> waitUntilDone
             Restarting -> waitUntilDone
-            BuildComplete (PostBuild Testing _) -> waitUntilDone
-            BuildComplete (PostBuild DoneTesting _) -> awaitBuildStart (n - 1) s'
+            BuildComplete _ pb
+                | Test.anyRunningTests pb.testSuites -> waitUntilDone
+                | otherwise -> awaitBuildStart (n - 1) s'
             BuildFailed _ -> pure s'
 
 
@@ -236,20 +245,21 @@ respondDiagnostic :: (BuildStore :> es, UnixSocket :> es) => Int -> Handle -> Ef
 respondDiagnostic idx h = do
     state <- getState
     case state.phase of
-        BuildComplete (PostBuild DoneTesting r) -> case r.diagnostics !!? (idx - 1) of
-            Nothing ->
-                sendJson h
-                    $ ErrorResponse
-                    $ "No diagnostic #"
-                        <> show idx
-                        <> " (current build has "
-                        <> show (length r.diagnostics)
-                        <> ")"
-            Just d -> sendJson h (d :: Diagnostic)
+        BuildComplete r pb
+            | not $ Test.anyRunningTests pb.testSuites -> case r.diagnostics !!? (idx - 1) of
+                Nothing ->
+                    sendJson h
+                        $ ErrorResponse
+                        $ "No diagnostic #"
+                            <> show idx
+                            <> " (current build has "
+                            <> show (length r.diagnostics)
+                            <> ")"
+                Just d -> sendJson h (d :: Diagnostic)
+            | otherwise -> sendJson h $ ErrorResponse "Build in progress"
         BuildFailed msg -> sendJson h $ ErrorResponse $ "Build command failed:\n" <> msg
         Building _ -> sendJson h $ ErrorResponse "Build in progress"
         Restarting -> sendJson h $ ErrorResponse "Build in progress"
-        BuildComplete (PostBuild Testing _) -> sendJson h $ ErrorResponse "Build in progress"
 
 
 -- | Look up source for each requested module and send the results as a JSON array.

--- a/tricorder/src/Tricorder/Socket/Server.hs
+++ b/tricorder/src/Tricorder/Socket/Server.hs
@@ -50,7 +50,7 @@ import Tricorder.Socket.Protocol
 import Tricorder.SourceLookup (ModuleName, ModuleSourceResult, PackageId, lookupModuleSource)
 import Tricorder.Version (VersionMismatch (..), checkVersion)
 
-import Tricorder.BuildState.Tests qualified as Test
+import Tricorder.BuildState.Test qualified as Test
 import Tricorder.Effects.BuildStore qualified as BuildStore
 
 

--- a/tricorder/src/Tricorder/Socket/Server.hs
+++ b/tricorder/src/Tricorder/Socket/Server.hs
@@ -209,8 +209,8 @@ respondWhenDone h = awaitResult >>= sendJson h
         case s.phase of
             Building _ -> waitUntilDone
             Restarting -> waitUntilDone
-            BuildComplete _ pb
-                | Test.anyRunningTests pb.testSuites -> waitUntilDone
+            BuildComplete _ postBuild
+                | Test.anyRunningTests postBuild.testSuites -> waitUntilDone
                 | otherwise -> awaitBuildStart (5 :: Int) s
             BuildFailed _ -> pure s
 
@@ -222,8 +222,8 @@ respondWhenDone h = awaitResult >>= sendJson h
         case s'.phase of
             Building _ -> waitUntilDone
             Restarting -> waitUntilDone
-            BuildComplete _ pb
-                | Test.anyRunningTests pb.testSuites -> waitUntilDone
+            BuildComplete _ postBuild
+                | Test.anyRunningTests postBuild.testSuites -> waitUntilDone
                 | otherwise -> awaitBuildStart (n - 1) s'
             BuildFailed _ -> pure s'
 
@@ -245,17 +245,18 @@ respondDiagnostic :: (BuildStore :> es, UnixSocket :> es) => Int -> Handle -> Ef
 respondDiagnostic idx h = do
     state <- getState
     case state.phase of
-        BuildComplete r pb
-            | not $ Test.anyRunningTests pb.testSuites -> case r.diagnostics !!? (idx - 1) of
-                Nothing ->
-                    sendJson h
-                        $ ErrorResponse
-                        $ "No diagnostic #"
-                            <> show idx
-                            <> " (current build has "
-                            <> show (length r.diagnostics)
-                            <> ")"
-                Just d -> sendJson h (d :: Diagnostic)
+        BuildComplete result postBuild
+            | not $ Test.anyRunningTests postBuild.testSuites ->
+                case result.diagnostics !!? (idx - 1) of
+                    Nothing ->
+                        sendJson h
+                            $ ErrorResponse
+                            $ "No diagnostic #"
+                                <> show idx
+                                <> " (current build has "
+                                <> show (length result.diagnostics)
+                                <> ")"
+                    Just d -> sendJson h (d :: Diagnostic)
             | otherwise -> sendJson h $ ErrorResponse "Build in progress"
         BuildFailed msg -> sendJson h $ ErrorResponse $ "Build command failed:\n" <> msg
         Building _ -> sendJson h $ ErrorResponse "Build in progress"

--- a/tricorder/src/Tricorder/TestOutput.hs
+++ b/tricorder/src/Tricorder/TestOutput.hs
@@ -5,7 +5,7 @@ import Data.Char (isDigit)
 
 import Data.Text qualified as T
 
-import Tricorder.BuildState.Tests qualified as Test
+import Tricorder.BuildState.Test qualified as Test
 
 
 -- | Parse hspec output into individual test case results.

--- a/tricorder/src/Tricorder/TestOutput.hs
+++ b/tricorder/src/Tricorder/TestOutput.hs
@@ -5,7 +5,7 @@ import Data.Char (isDigit)
 
 import Data.Text qualified as T
 
-import Tricorder.BuildState (TestCase (..), TestCaseOutcome (..))
+import Tricorder.BuildState.Tests qualified as Test
 
 
 -- | Parse hspec output into individual test case results.
@@ -14,18 +14,18 @@ import Tricorder.BuildState (TestCase (..), TestCaseOutcome (..))
 -- with or without a trailing timing annotation like @(0.05s)@ or @(120ms)@.
 -- For failing tests, collects the indented detail lines that follow as the
 -- failure message.
-parseHspecOutput :: Text -> [TestCase]
+parseHspecOutput :: Text -> [Test.Case]
 parseHspecOutput = go . T.lines
   where
     go [] = []
     go (l : ls)
         | T.isSuffixOf "OK" norm =
-            TestCase {description = extractDesc "OK" norm, outcome = TestCasePassed}
+            Test.Case {description = extractDesc "OK" norm, outcome = Test.Passed}
                 : go ls
         | T.isSuffixOf "FAIL" norm =
             let (detailLines, rest) = span (\dl -> indentOf dl > indentOf l) ls
                 details = T.intercalate "\n" $ filter (not . T.null) $ map T.strip detailLines
-            in  TestCase {description = extractDesc "FAIL" norm, outcome = TestCaseFailed details}
+            in  Test.Case {description = extractDesc "FAIL" norm, outcome = Test.Failed details}
                     : go rest
         | otherwise = go ls
       where

--- a/tricorder/src/Tricorder/UI/View.hs
+++ b/tricorder/src/Tricorder/UI/View.hs
@@ -368,7 +368,7 @@ viewCompletionStatus c = case c.duration of
         | null c.testCases = if c.passed then ok (txt "passed") else err (txt "failed")
         | otherwise =
             let total = length c.testCases
-                failed = length $ filter isCaseFailed c.testCases
+                failed = length $ filter Test.caseFailed c.testCases
             in  if failed == 0 then
                     ok $ txt $ "passed (" <> show total <> ")"
                 else
@@ -474,7 +474,7 @@ viewTestOutput :: TestFilter -> Test.SuiteCompletion -> Widget n
 viewTestOutput TestFilterAll c =
     padLeft (Pad 2) $ vBox $ txt <$> stripGhciNoise (T.lines c.output)
 viewTestOutput TestFilterFailedOnly c
-    | not (any isCaseFailed c.testCases) && c.passed = emptyWidget
+    | not (any Test.caseFailed c.testCases) && c.passed = emptyWidget
     | null c.testCases =
         padLeft (Pad 2)
             $ vBox
@@ -482,12 +482,7 @@ viewTestOutput TestFilterFailedOnly c
                 , vBox $ txt <$> stripGhciNoise (T.lines c.output)
                 ]
     | otherwise =
-        padLeft (Pad 2) $ vBox $ viewFailedCase <$> filter isCaseFailed c.testCases
-
-
-isCaseFailed :: Test.Case -> Bool
-isCaseFailed (Test.Case _ (Test.Failed _)) = True
-isCaseFailed _ = False
+        padLeft (Pad 2) $ vBox $ viewFailedCase <$> filter Test.caseFailed c.testCases
 
 
 viewFailedCase :: Test.Case -> Widget n

--- a/tricorder/src/Tricorder/UI/View.hs
+++ b/tricorder/src/Tricorder/UI/View.hs
@@ -29,32 +29,29 @@ import Brick.Widgets.Core
 import Data.Time (UTCTime, defaultTimeLocale, formatTime, utcToLocalTime)
 import System.FilePath (isAbsolute)
 
+import Data.Map.Strict qualified as Map
 import Data.Text qualified as T
 import Graphics.Vty.Attributes qualified as Attr
 import Graphics.Vty.Attributes.Color qualified as Color
 
 import Tricorder.BuildState
     ( BuildPhase (..)
-    , BuildProgress (..)
     , BuildResult (..)
     , BuildState (..)
     , DaemonInfo (..)
     , Diagnostic (..)
     , PostBuild (..)
     , Severity (..)
-    , TestCase (..)
-    , TestCaseOutcome (..)
-    , TestRun (..)
-    , TestRunCompletion (..)
-    , TestRunError (..)
     )
-import Tricorder.Session (Target, renderTarget)
+import Tricorder.BuildState.BuildProgress (BuildProgress (..))
+import Tricorder.Session (Target, TestTarget, renderTarget, renderTestTarget)
 import Tricorder.TestOutput (stripGhciNoise)
 import Tricorder.UI.Keys (KeyEvent, keybindForRoute, viewKeybindings)
 import Tricorder.UI.Misc (emphasis, err, hBoxSpaced, ok, subtle, vBoxSpaced, warn)
 import Tricorder.UI.Route (Route)
 import Tricorder.UI.State (Processed (..), State (..), TestFilter (..), Viewports (..), currentRoute)
 
+import Tricorder.BuildState.Tests qualified as Test
 import Tricorder.UI.Keys qualified as Keys
 import Tricorder.UI.Route qualified as Route
 import Tricorder.Version qualified as Version
@@ -260,7 +257,7 @@ viewBuildPhase tz = \case
     Building Nothing -> warn $ txt "Building..."
     Building (Just p) -> warn $ txt $ "Building (" <> show p.compiled <> "/" <> show p.total <> ")..."
     Restarting -> warn $ txt "Restarting..."
-    BuildComplete build -> vBoxSpaced 1 [viewBuildResult tz build.result, viewTestRuns build.result.testRuns]
+    BuildComplete result pb -> vBoxSpaced 1 [viewBuildResult tz result, viewTestRuns pb.testSuites]
     BuildFailed msg -> viewBuildFailed msg
 
 
@@ -338,20 +335,31 @@ viewDuration :: Millisecond -> Widget n
 viewDuration d = txt $ "(" <> formatDuration d <> ")"
 
 
-viewTestRuns :: [TestRun] -> Widget n
-viewTestRuns [] = emptyWidget
-viewTestRuns runs = vBox $ viewTestRun <$> runs
+viewTestRuns :: Test.Suites -> Widget n
+viewTestRuns suites = vBox $ uncurry viewTestRun <$> Map.toList suites.getSuites
 
 
-viewTestRun :: TestRun -> Widget n
-viewTestRun (TestRunning t Nothing) = hBox [txt t, txt "  ", warn $ txt "running..."]
-viewTestRun (TestRunning t (Just p)) =
-    hBox [txt t, txt "  ", warn $ txt $ "running... (" <> show p.compiled <> "/" <> show p.total <> ")"]
-viewTestRun (TestRunErrored e) = hBox [txt e.target, txt "  ", err $ txt "error: ", txt e.message]
-viewTestRun (TestRunCompleted c) = hBox [txt c.target, txt "  ", viewCompletionStatus c]
+viewTestRun :: TestTarget -> Test.Suite -> Widget n
+viewTestRun tgt run =
+    hBox $ [txt $ renderTestTarget tgt, txt "  "] <> status
+  where
+    status = case run of
+        Test.SuiteRunning Nothing ->
+            [ warn $ txt "running..."
+            ]
+        Test.SuiteRunning (Just p) ->
+            [ warn $ txt $ "running... (" <> show p.compiled <> "/" <> show p.total <> ")"
+            ]
+        Test.SuiteErrored e ->
+            [ err $ txt "error: "
+            , txt e.message
+            ]
+        Test.SuiteCompleted c ->
+            [ viewCompletionStatus c
+            ]
 
 
-viewCompletionStatus :: TestRunCompletion -> Widget n
+viewCompletionStatus :: Test.SuiteCompletion -> Widget n
 viewCompletionStatus c = case c.duration of
     Nothing -> statusWidget
     Just d -> hBoxSpaced 1 [statusWidget, subtle $ viewDuration d]
@@ -392,7 +400,7 @@ viewBuildPhaseLine tz = \case
     Building Nothing -> warn $ txt "Building..."
     Building (Just p) -> warn $ txt $ "Building (" <> show p.compiled <> "/" <> show p.total <> ")..."
     Restarting -> warn $ txt "Restarting..."
-    BuildComplete build -> viewBuildResultLine tz build.result
+    BuildComplete result _ -> viewBuildResultLine tz result
     BuildFailed _ -> err $ txt "Build command failed"
 
 
@@ -416,34 +424,53 @@ viewBuildResultLine tz result
         in  hBoxSpaced 1 [header, viewDuration result.duration, viewTimestamp tz result.completedAt]
 
 
-phaseTestRuns :: BuildPhase -> [TestRun]
-phaseTestRuns (BuildComplete r) = r.result.testRuns
-phaseTestRuns _ = []
+phaseTestRuns :: BuildPhase -> Test.Suites
+phaseTestRuns (BuildComplete _ pb) = pb.testSuites
+phaseTestRuns _ = Test.Suites mempty
 
 
-viewTestPanel :: TestFilter -> [TestRun] -> Widget Viewports
-viewTestPanel _ [] = subtle $ txt "No test results."
-viewTestPanel tvf runs = scrollableRuns tvf runs
+viewTestPanel :: TestFilter -> Test.Suites -> Widget Viewports
+viewTestPanel tvf suites
+    | Test.nullSuites suites = subtle $ txt "No test results."
+    | otherwise = scrollableRuns tvf suites
 
 
-scrollableRuns :: TestFilter -> [TestRun] -> Widget Viewports
-scrollableRuns tvf runs =
-    vScrollViewport TestViewport (viewTestRunDetail tvf <$> runs)
+scrollableRuns :: TestFilter -> Test.Suites -> Widget Viewports
+scrollableRuns tvf suites =
+    vScrollViewport TestViewport (uncurry (viewTestRunDetail tvf) <$> Map.toList suites.getSuites)
 
 
-viewTestRunDetail :: TestFilter -> TestRun -> Widget n
-viewTestRunDetail _ (TestRunning t Nothing) = hBox [txt t, txt "  ", warn $ txt "running..."]
-viewTestRunDetail _ (TestRunning t (Just p)) =
-    hBox [txt t, txt "  ", warn $ txt $ "running... (" <> show p.compiled <> "/" <> show p.total <> ")"]
-viewTestRunDetail _ (TestRunErrored e) = hBoxSpaced 1 [txt e.target, err $ txt "error:", txt e.message]
-viewTestRunDetail tvf (TestRunCompleted c) =
-    vBox
-        [ hBox [txt c.target, txt "  ", viewCompletionStatus c]
-        , viewTestOutput tvf c
-        ]
+viewTestRunDetail :: TestFilter -> TestTarget -> Test.Suite -> Widget n
+viewTestRunDetail tvf tgt = \case
+    Test.SuiteRunning Nothing ->
+        hBox
+            [ txt t
+            , txt "  "
+            , warn $ txt "running..."
+            ]
+    Test.SuiteRunning (Just p) ->
+        hBox
+            [ txt t
+            , txt "  "
+            , warn $ txt $ "running... (" <> show p.compiled <> "/" <> show p.total <> ")"
+            ]
+    Test.SuiteErrored e ->
+        hBoxSpaced
+            1
+            [ txt t
+            , err $ txt "error:"
+            , txt e.message
+            ]
+    Test.SuiteCompleted c ->
+        vBox
+            [ hBox [txt $ t <> "  ", viewCompletionStatus c]
+            , viewTestOutput tvf c
+            ]
+  where
+    t = renderTestTarget tgt
 
 
-viewTestOutput :: TestFilter -> TestRunCompletion -> Widget n
+viewTestOutput :: TestFilter -> Test.SuiteCompletion -> Widget n
 viewTestOutput TestFilterAll c =
     padLeft (Pad 2) $ vBox $ txt <$> stripGhciNoise (T.lines c.output)
 viewTestOutput TestFilterFailedOnly c
@@ -458,16 +485,16 @@ viewTestOutput TestFilterFailedOnly c
         padLeft (Pad 2) $ vBox $ viewFailedCase <$> filter isCaseFailed c.testCases
 
 
-isCaseFailed :: TestCase -> Bool
-isCaseFailed (TestCase _ (TestCaseFailed _)) = True
+isCaseFailed :: Test.Case -> Bool
+isCaseFailed (Test.Case _ (Test.Failed _)) = True
 isCaseFailed _ = False
 
 
-viewFailedCase :: TestCase -> Widget n
+viewFailedCase :: Test.Case -> Widget n
 viewFailedCase tc =
     vBox
         [ err $ txt tc.description
         , case tc.outcome of
-            TestCaseFailed details -> padLeft (Pad 2) $ txtWrap details
-            TestCasePassed -> emptyWidget
+            Test.Failed details -> padLeft (Pad 2) $ txtWrap details
+            Test.Passed -> emptyWidget
         ]

--- a/tricorder/src/Tricorder/UI/View.hs
+++ b/tricorder/src/Tricorder/UI/View.hs
@@ -51,7 +51,7 @@ import Tricorder.UI.Misc (emphasis, err, hBoxSpaced, ok, subtle, vBoxSpaced, war
 import Tricorder.UI.Route (Route)
 import Tricorder.UI.State (Processed (..), State (..), TestFilter (..), Viewports (..), currentRoute)
 
-import Tricorder.BuildState.Tests qualified as Test
+import Tricorder.BuildState.Test qualified as Test
 import Tricorder.UI.Keys qualified as Keys
 import Tricorder.UI.Route qualified as Route
 import Tricorder.Version qualified as Version

--- a/tricorder/src/Tricorder/UI/View.hs
+++ b/tricorder/src/Tricorder/UI/View.hs
@@ -254,11 +254,16 @@ viewWatchDir dir = hBox [txt "- ", txt $ toText displayDir]
 
 viewBuildPhase :: TimeZone -> BuildPhase -> Widget Viewports
 viewBuildPhase tz = \case
-    Building Nothing -> warn $ txt "Building..."
-    Building (Just p) -> warn $ txt $ "Building (" <> show p.compiled <> "/" <> show p.total <> ")..."
-    Restarting -> warn $ txt "Restarting..."
-    BuildComplete result pb -> vBoxSpaced 1 [viewBuildResult tz result, viewTestRuns pb.testSuites]
-    BuildFailed msg -> viewBuildFailed msg
+    Building Nothing ->
+        warn $ txt "Building..."
+    Building (Just p) ->
+        warn $ txt $ "Building (" <> show p.compiled <> "/" <> show p.total <> ")..."
+    Restarting ->
+        warn $ txt "Restarting..."
+    BuildComplete result postBuild ->
+        vBoxSpaced 1 [viewBuildResult tz result, viewTestRuns postBuild.testSuites]
+    BuildFailed msg ->
+        viewBuildFailed msg
 
 
 viewBuildFailed :: Text -> Widget Viewports
@@ -425,7 +430,7 @@ viewBuildResultLine tz result
 
 
 phaseTestRuns :: BuildPhase -> Test.Suites
-phaseTestRuns (BuildComplete _ pb) = pb.testSuites
+phaseTestRuns (BuildComplete _ postBuild) = postBuild.testSuites
 phaseTestRuns _ = Test.Suites mempty
 
 

--- a/tricorder/test/Unit/Tricorder/BuildStateSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuildStateSpec.hs
@@ -15,7 +15,7 @@ import Tricorder.BuildState
     , Severity (..)
     )
 
-import Tricorder.BuildState.Tests qualified as Test
+import Tricorder.BuildState.Test qualified as Test
 
 
 spec_BuildState :: Spec

--- a/tricorder/test/Unit/Tricorder/BuildStateSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuildStateSpec.hs
@@ -4,7 +4,18 @@ import Data.Aeson (eitherDecode, encode)
 import Data.Time (UTCTime (..), fromGregorian)
 import Test.Hspec
 
-import Tricorder.BuildState (BuildId (..), BuildPhase (..), BuildResult (..), BuildState (..), DaemonInfo (..), Diagnostic (..), PostBuild (..), Severity (..), TestPhase (..))
+import Tricorder.BuildState
+    ( BuildId (..)
+    , BuildPhase (..)
+    , BuildResult (..)
+    , BuildState (..)
+    , DaemonInfo (..)
+    , Diagnostic (..)
+    , PostBuild (..)
+    , Severity (..)
+    )
+
+import Tricorder.BuildState.Tests qualified as Test
 
 
 spec_BuildState :: Spec
@@ -76,14 +87,15 @@ mkBuildState msgs =
         { buildId = BuildId 1
         , phase =
             BuildComplete
-                $ PostBuild DoneTesting
-                $ BuildResult
+                ( BuildResult
                     { completedAt = epoch
                     , duration = 0
                     , moduleCount = 0
                     , diagnostics = msgs
-                    , testRuns = []
                     }
+                )
+                $ PostBuild
+                $ Test.Suites mempty
         , daemonInfo =
             DaemonInfo
                 { targets = []

--- a/tricorder/test/Unit/Tricorder/BuildStoreSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuildStoreSpec.hs
@@ -11,7 +11,14 @@ import Test.Hspec
 
 import Atelier.Effects.Conc qualified as Conc
 
-import Tricorder.BuildState (BuildId (..), BuildPhase (..), BuildResult (..), BuildState (..), DaemonInfo (..), PostBuild (..), TestPhase (..))
+import Tricorder.BuildState
+    ( BuildId (..)
+    , BuildPhase (..)
+    , BuildResult (..)
+    , BuildState (..)
+    , DaemonInfo (..)
+    , PostBuild (..)
+    )
 import Tricorder.Effects.BuildStore
     ( BuildStore
     , getState
@@ -21,6 +28,8 @@ import Tricorder.Effects.BuildStore
     , waitForNext
     , waitUntilDone
     )
+
+import Tricorder.BuildState.Tests qualified as Test
 
 
 spec_BuildStore :: Spec
@@ -144,7 +153,7 @@ testSTM = do
             -- report the later BuildComplete(2) (or block forever).
             result.buildId `shouldBe` BuildId 1
             case result.phase of
-                BuildComplete _ -> pure ()
+                BuildComplete _ _ -> pure ()
                 p -> expectationFailure $ "expected BuildComplete phase, got: " <> show p
 
 
@@ -170,14 +179,15 @@ buildingAt n = BuildState (BuildId n) (Building Nothing) emptyDaemonInfo
 donePhase :: BuildPhase
 donePhase =
     BuildComplete
-        $ PostBuild DoneTesting
-        $ BuildResult
+        ( BuildResult
             { completedAt = epoch
             , duration = 0
             , moduleCount = 0
             , diagnostics = []
-            , testRuns = []
             }
+        )
+        $ PostBuild
+        $ Test.Suites mempty
 
 
 doneAt :: Int -> BuildState

--- a/tricorder/test/Unit/Tricorder/BuildStoreSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuildStoreSpec.hs
@@ -29,7 +29,7 @@ import Tricorder.Effects.BuildStore
     , waitUntilDone
     )
 
-import Tricorder.BuildState.Tests qualified as Test
+import Tricorder.BuildState.Test qualified as Test
 
 
 spec_BuildStore :: Spec

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -77,7 +77,7 @@ import Tricorder.Effects.TestRunner (TestRunner (..), runTestRunnerScripted)
 import Tricorder.Runtime (ProjectRoot (..))
 import Tricorder.Session (TestTarget (..), WatchDirs (..), parseTarget, parseTestTargets)
 
-import Tricorder.BuildState.Tests qualified as Test
+import Tricorder.BuildState.Test qualified as Test
 import Tricorder.Builder qualified as Builder
 import Tricorder.Effects.BuildStore qualified as BuildStore
 

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -72,7 +72,7 @@ import Tricorder.Effects.GhciSession
     , runGhciSessionScripted
     )
 import Tricorder.Effects.GhciSession.GhciParser (collectResult, extractTitle, resolveKnownTargets)
-import Tricorder.Effects.PostBuildStore (runPostBuildCapture, runPostBuildState)
+import Tricorder.Effects.PostBuildStore (modifyPostBuild, runPostBuildCapture, runPostBuildState, runPostBuildStore)
 import Tricorder.Effects.TestRunner (TestRunner (..), runTestRunnerScripted)
 import Tricorder.Runtime (ProjectRoot (..))
 import Tricorder.Session (TestTarget (..), WatchDirs (..), parseTarget, parseTestTargets)
@@ -89,6 +89,7 @@ spec_Builder = do
     describe "extractTitle" testExtractTitle
     describe "compileLoadResultsIntoBuildResults" testCompileLoadResultsIntoBuildResults
     describe "requestTestRunsForNewBuildResults" testRequestTestRunsForNewBuildResults
+    describe "runPostBuildStore" testPostBuildStoreFinalizer
     describe "setNewPhase" testSetNewPhase
     describe "onRestart" testOnRestart
     describe "restartOnCabalChange" testRestartOnCabalChange
@@ -533,6 +534,61 @@ testRequestTestRunsForNewBuildResults = do
                 , testCases = []
                 , duration = Nothing
                 }
+
+
+-- | [regression] A @.cabal@ change can fire while a post-build cycle is
+-- finishing. The restart coordinator ('restartOnCabalChange' -> 'preRestart')
+-- runs on a /separate/ fiber and flips the shared phase to 'Restarting'; it
+-- does NOT latch the test-runner abort flag, so the post-build action on the
+-- worker fiber runs to completion unaware of it.
+--
+-- 'runPostBuildStore' must leave that fresh 'Restarting' phase alone. Its
+-- finalizer instead re-reads the phase, sees it is not 'BuildComplete', and
+-- force-writes a stale empty 'BuildComplete' carrying the old build result.
+-- That reads as "done" ('anyRunningTests' is False for empty suites), so
+-- 'isBuilding' flips to False and a 'status --wait' caller wakes on the
+-- previous build's result while a restart is actually in flight.
+--
+-- This drives the production 'runPostBuildStore' (via the stateful
+-- 'runBuildStoreCapture', whose 'getState' the finalizer reads) — unlike the
+-- abort test above, which runs under 'runPostBuildState' and never exercises
+-- the finalizer.
+testPostBuildStoreFinalizer :: Spec
+testPostBuildStoreFinalizer =
+    it "does not clobber a concurrently-set Restarting phase in its finalizer" do
+        (_, finalState) <-
+            runEff
+                . runState initialState
+                . execWriter @[EnteringNewPhase]
+                . runBuildStoreCapture
+                . runPostBuildStore buildResult
+                $ do
+                    -- afterLoad publishes the running suites on every clean
+                    -- build with test targets, so the phase is BuildComplete
+                    -- at this point...
+                    modifyPostBuild \pb -> pb {testSuites = runningSuites}
+                    -- ...and then a concurrent .cabal restart flips it to
+                    -- Restarting just before this action returns.
+                    BuildStore.setPhase (BuildId 1) Restarting
+        finalState.phase `shouldBe` Restarting
+  where
+    initialState =
+        BuildState
+            { buildId = BuildId 1
+            , phase = Building Nothing
+            , daemonInfo = emptyDaemonInfo
+            }
+
+    buildResult =
+        BuildResult
+            { completedAt = epoch
+            , duration = 0
+            , moduleCount = 1
+            , diagnostics = []
+            }
+
+    runningSuites =
+        Test.Suites $ Map.fromList [(mkTestTarget "test:foo", Test.SuiteRunning Nothing)]
 
 
 --------------------------------------------------------------------------------

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -322,7 +322,7 @@ testReloadOnSourceChange = do
         , EnteringNewPhase (BuildId 1) $ BuildComplete (resultFor lr) $ PostBuild $ Test.Suites mempty
         ]
 
-    buildResultsFrom phases = [r | EnteringNewPhase _ (BuildComplete r _) <- phases]
+    buildResultsFrom phases = [result | EnteringNewPhase _ (BuildComplete result _) <- phases]
 
     resultFor lr =
         BuildResult
@@ -566,7 +566,8 @@ testPostBuildStoreFinalizer =
                     -- afterLoad publishes the running suites on every clean
                     -- build with test targets, so the phase is BuildComplete
                     -- at this point...
-                    modifyPostBuild \pb -> pb {testSuites = runningSuites}
+                    modifyPostBuild \postBuild ->
+                        postBuild {testSuites = runningSuites}
                     -- ...and then a concurrent .cabal restart flips it to
                     -- Restarting just before this action returns.
                     BuildStore.setPhase (BuildId 1) Restarting

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -52,7 +52,7 @@ import Tricorder.Builder
     , compileLoadResultsIntoBuildResults
     , onRestart
     , reloadOnSourceChange
-    , requestTestRunsForNewBuildResults
+    , runTestsForTargets
     , setNewPhase
     , watchSourceChanges
     )
@@ -72,7 +72,7 @@ import Tricorder.Effects.GhciSession
     , runGhciSessionScripted
     )
 import Tricorder.Effects.GhciSession.GhciParser (collectResult, extractTitle, resolveKnownTargets)
-import Tricorder.Effects.PostBuildStore (modifyPostBuild, runPostBuildCapture, runPostBuildState, runPostBuildStore)
+import Tricorder.Effects.PostBuildStore (runPostBuildCapture, runPostBuildState)
 import Tricorder.Effects.TestRunner (TestRunner (..), runTestRunnerScripted)
 import Tricorder.Runtime (ProjectRoot (..))
 import Tricorder.Session (TestTarget (..), WatchDirs (..), parseTarget, parseTestTargets)
@@ -88,8 +88,7 @@ spec_Builder = do
     describe "filterToWatchDirs" testFilterToWatchDirs
     describe "extractTitle" testExtractTitle
     describe "compileLoadResultsIntoBuildResults" testCompileLoadResultsIntoBuildResults
-    describe "requestTestRunsForNewBuildResults" testRequestTestRunsForNewBuildResults
-    describe "runPostBuildStore" testPostBuildStoreFinalizer
+    describe "runTestsForTargets" testRunTestsForTargets
     describe "setNewPhase" testSetNewPhase
     describe "onRestart" testOnRestart
     describe "restartOnCabalChange" testRestartOnCabalChange
@@ -460,8 +459,8 @@ testCompileLoadResultsIntoBuildResults = do
         in  (builderState.diagnosticMap, buildResult)
 
 
-testRequestTestRunsForNewBuildResults :: Spec
-testRequestTestRunsForNewBuildResults = do
+testRunTestsForTargets :: Spec
+testRunTestsForTargets = do
     it "should emit EnteringNewPhase events for each test target" do
         phases <-
             runTest
@@ -502,7 +501,7 @@ testRequestTestRunsForNewBuildResults = do
                 . runPostBuildState
                 . runPostBuildCapture
                 . runTestRunnerAbortAfterFirst suiteCompleted
-                $ requestTestRunsForNewBuildResults
+                $ runTestsForTargets
                 $ parseTestTargets ["test:foo", "test:bar"]
         phases
             `shouldMatchList` [ PostBuild
@@ -522,7 +521,7 @@ testRequestTestRunsForNewBuildResults = do
             . runPostBuildState
             . runPostBuildCapture
             . runTestRunnerScripted script
-            $ requestTestRunsForNewBuildResults testTargets
+            $ runTestsForTargets testTargets
 
     postBuildWithTests = PostBuild . Test.Suites . Map.fromList
 
@@ -534,62 +533,6 @@ testRequestTestRunsForNewBuildResults = do
                 , testCases = []
                 , duration = Nothing
                 }
-
-
--- | [regression] A @.cabal@ change can fire while a post-build cycle is
--- finishing. The restart coordinator ('restartOnCabalChange' -> 'preRestart')
--- runs on a /separate/ fiber and flips the shared phase to 'Restarting'; it
--- does NOT latch the test-runner abort flag, so the post-build action on the
--- worker fiber runs to completion unaware of it.
---
--- 'runPostBuildStore' must leave that fresh 'Restarting' phase alone. Its
--- finalizer instead re-reads the phase, sees it is not 'BuildComplete', and
--- force-writes a stale empty 'BuildComplete' carrying the old build result.
--- That reads as "done" ('anyRunningTests' is False for empty suites), so
--- 'isBuilding' flips to False and a 'status --wait' caller wakes on the
--- previous build's result while a restart is actually in flight.
---
--- This drives the production 'runPostBuildStore' (via the stateful
--- 'runBuildStoreCapture', whose 'getState' the finalizer reads) — unlike the
--- abort test above, which runs under 'runPostBuildState' and never exercises
--- the finalizer.
-testPostBuildStoreFinalizer :: Spec
-testPostBuildStoreFinalizer =
-    it "does not clobber a concurrently-set Restarting phase in its finalizer" do
-        (_, finalState) <-
-            runEff
-                . runState initialState
-                . execWriter @[EnteringNewPhase]
-                . runBuildStoreCapture
-                . runPostBuildStore buildResult
-                $ do
-                    -- afterLoad publishes the running suites on every clean
-                    -- build with test targets, so the phase is BuildComplete
-                    -- at this point...
-                    modifyPostBuild \postBuild ->
-                        postBuild {testSuites = runningSuites}
-                    -- ...and then a concurrent .cabal restart flips it to
-                    -- Restarting just before this action returns.
-                    BuildStore.setPhase (BuildId 1) Restarting
-        finalState.phase `shouldBe` Restarting
-  where
-    initialState =
-        BuildState
-            { buildId = BuildId 1
-            , phase = Building Nothing
-            , daemonInfo = emptyDaemonInfo
-            }
-
-    buildResult =
-        BuildResult
-            { completedAt = epoch
-            , duration = 0
-            , moduleCount = 1
-            , diagnostics = []
-            }
-
-    runningSuites =
-        Test.Suites $ Map.fromList [(mkTestTarget "test:foo", Test.SuiteRunning Nothing)]
 
 
 --------------------------------------------------------------------------------

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -22,7 +22,7 @@ import Effectful.Dispatch.Dynamic (interpret_)
 import Effectful.Error.Static (runErrorNoCallStack, throwError)
 import Effectful.Exception (throwIO)
 import Effectful.Reader.Static (runReader)
-import Effectful.State.Static.Shared (evalState, runState)
+import Effectful.State.Static.Shared (State, evalState, get, put, runState)
 import Effectful.Writer.Static.Shared (Writer, execWriter, tell)
 import Test.Hspec (Spec, describe, it, shouldBe, shouldMatchList, shouldSatisfy)
 
@@ -32,7 +32,18 @@ import Control.Concurrent.STM qualified as STM
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
 
-import Tricorder.BuildState (BuildId (..), BuildPhase (..), BuildResult (..), BuildState (..), CabalChangeDetected (..), DaemonInfo (..), Diagnostic (..), PostBuild (..), Severity (..), SourceChangeDetected (..), TestPhase (..), TestRun (..), TestRunCompletion (..))
+import Tricorder.BuildState
+    ( BuildId (..)
+    , BuildPhase (..)
+    , BuildResult (..)
+    , BuildState (..)
+    , CabalChangeDetected (..)
+    , DaemonInfo (..)
+    , Diagnostic (..)
+    , PostBuild (..)
+    , Severity (..)
+    , SourceChangeDetected (..)
+    )
 import Tricorder.Builder
     ( BuildConfig (..)
     , EnteringNewPhase (..)
@@ -54,13 +65,19 @@ import Tricorder.Builder.Dispatch
     , mergeDiagnostics
     , preserveFailureVisibility
     )
-import Tricorder.Effects.GhciSession (Controls (..), LoadResult (..), LoadedModule (..), runGhciSessionScripted)
+import Tricorder.Effects.GhciSession
+    ( Controls (..)
+    , LoadResult (..)
+    , LoadedModule (..)
+    , runGhciSessionScripted
+    )
 import Tricorder.Effects.GhciSession.GhciParser (collectResult, extractTitle, resolveKnownTargets)
+import Tricorder.Effects.PostBuildStore (runPostBuildCapture, runPostBuildState)
 import Tricorder.Effects.TestRunner (TestRunner (..), runTestRunnerScripted)
 import Tricorder.Runtime (ProjectRoot (..))
-import Tricorder.Session (Command (..), WatchDirs (..), parseTestTargets)
+import Tricorder.Session (TestTarget (..), WatchDirs (..), parseTarget, parseTestTargets)
 
-import Tricorder.BuildState qualified as BuildState
+import Tricorder.BuildState.Tests qualified as Test
 import Tricorder.Builder qualified as Builder
 import Tricorder.Effects.BuildStore qualified as BuildStore
 
@@ -153,6 +170,7 @@ testBuildWithGhciRecovery = do
     it "retries the build on a source change after a startup failure" do
         phases <-
             runTest
+                completeBuildState
                 -- First launch throws (startup failure); the retry succeeds.
                 [ Left (toException (ErrorCall "ghci failed to start"))
                 , Right successLoad
@@ -167,7 +185,7 @@ testBuildWithGhciRecovery = do
         length [() | EnteringNewPhase _ (BuildFailed _) <- phases] `shouldBe` 1
         -- The source change drove a second, successful launch to completion.
         -- With the bug the builder is parked, so no Done is ever emitted.
-        length [() | EnteringNewPhase _ (BuildComplete _) <- phases] `shouldSatisfy` (>= 1)
+        length [() | EnteringNewPhase _ (BuildComplete _ _) <- phases] `shouldSatisfy` (>= 1)
   where
     successLoad =
         LoadResult
@@ -178,7 +196,7 @@ testBuildWithGhciRecovery = do
             , diagnostics = []
             }
 
-    runTest script body =
+    runTest initialState script =
         runEff
             . runConcurrent
             . runTracingNoOp
@@ -188,6 +206,7 @@ testBuildWithGhciRecovery = do
             . runReader (ProjectRoot "/")
             . evalState (BuildId 1)
             . evalState emptyBuilderState
+            . evalState initialState
             . runLogNoOp
             . execWriter @[EnteringNewPhase]
             . runBuildStoreCapture
@@ -196,7 +215,6 @@ testBuildWithGhciRecovery = do
             . runPubSub @SourceChangeDetected
             . runConc
             . runDebounceNoOp
-            $ body
 
 
 --------------------------------------------------------------------------------
@@ -291,6 +309,7 @@ testReloadOnSourceChange = do
                     { loadedModules = initialModuleMap
                     , knownTargets = initialTargets
                     }
+            . evalState completeBuildState
             . runLogNoOp
             . execWriter @[EnteringNewPhase]
             . runBuildStoreCapture
@@ -299,10 +318,10 @@ testReloadOnSourceChange = do
 
     flow lr =
         [ EnteringNewPhase (BuildId 1) $ Building Nothing
-        , EnteringNewPhase (BuildId 1) $ BuildComplete $ PostBuild DoneTesting (resultFor lr)
+        , EnteringNewPhase (BuildId 1) $ BuildComplete (resultFor lr) $ PostBuild $ Test.Suites mempty
         ]
 
-    buildResultsFrom phases = [r | EnteringNewPhase _ (BuildComplete (PostBuild _ r)) <- phases]
+    buildResultsFrom phases = [r | EnteringNewPhase _ (BuildComplete r _) <- phases]
 
     resultFor lr =
         BuildResult
@@ -310,7 +329,6 @@ testReloadOnSourceChange = do
             , duration = 0
             , moduleCount = lr.moduleCount
             , diagnostics = []
-            , testRuns = []
             }
 
     noTargets = KnownTargetNames Set.empty
@@ -429,7 +447,6 @@ testCompileLoadResultsIntoBuildResults = do
                     , duration = 10_000
                     , moduleCount = 2
                     , diagnostics = [warnMsg]
-                    , testRuns = []
                     }
         r `shouldBe` expected
   where
@@ -444,123 +461,74 @@ testCompileLoadResultsIntoBuildResults = do
 
 testRequestTestRunsForNewBuildResults :: Spec
 testRequestTestRunsForNewBuildResults = do
-    describe "when there are no test targets" $ it "should skip testing" do
-        phases <- runTest (parseTestTargets []) [] expected
-        length phases `shouldBe` 1
-        phases
-            `shouldMatchList` [ EnteringNewPhase (BuildId 1)
-                                    $ BuildComplete
-                                    $ PostBuild DoneTesting expected
-                              ]
-
-    describe "when there are errors" $ it "should skip testing" do
-        let expected' = expected {BuildState.diagnostics = [errMsg]}
-        phases <- runTest (parseTestTargets ["test:foo"]) [] expected'
-        length phases `shouldBe` 1
-        phases
-            `shouldMatchList` [ EnteringNewPhase (BuildId 1)
-                                    $ BuildComplete
-                                    $ PostBuild DoneTesting expected'
-                              ]
-
     it "should emit EnteringNewPhase events for each test target" do
         phases <-
             runTest
                 (parseTestTargets ["test:foo", "test:bar"])
-                [ Right $ mkTestRun "test:foo"
-                , Right $ mkTestRun "test:bar"
+                [ Right suiteCompleted
+                , Right suiteCompleted
                 ]
-                expected
-        length phases `shouldBe` 4
+        length phases `shouldBe` 3
         let expectedPhases =
-                [ mkTesting . buildWithTests
-                    $ [ TestRunning "test:foo" Nothing
-                      , TestRunning "test:bar" Nothing
+                [ postBuildWithTests
+                    $ [ (mkTestTarget "test:foo", Test.SuiteRunning Nothing)
+                      , (mkTestTarget "test:bar", Test.SuiteRunning Nothing)
                       ]
-                , mkTesting . buildWithTests
-                    $ [ mkTestRun "test:foo"
-                      , TestRunning "test:bar" Nothing
+                , postBuildWithTests
+                    $ [ (mkTestTarget "test:foo", suiteCompleted)
+                      , (mkTestTarget "test:bar", Test.SuiteRunning Nothing)
                       ]
-                , mkTesting . buildWithTests
-                    $ [ mkTestRun "test:foo"
-                      , mkTestRun "test:bar"
-                      ]
-                , mkDone . buildWithTests
-                    $ [ mkTestRun "test:foo"
-                      , mkTestRun "test:bar"
+                , postBuildWithTests
+                    $ [ (mkTestTarget "test:foo", suiteCompleted)
+                      , (mkTestTarget "test:bar", suiteCompleted)
                       ]
                 ]
         phases `shouldMatchList` expectedPhases
 
     -- Regression for the abort handling in 'runTestsIfClean': when an
     -- interrupt arrives mid-run loop, 'isAborted' becomes True and the loop
-    -- returns 'Nothing'. The caller MUST then skip the 'Done' transition —
-    -- otherwise the BuildStore briefly publishes a Done with a partial
-    -- testRuns list, and a 'status --wait' caller reads that stale result
-    -- before the new cycle starts.
-    it "does not transition to Done when the run is aborted mid-flight" do
+    -- returns 'Aborted'. The caller MUST then skip updating the 'PostBuild'
+    -- — otherwise the BuildStore briefly publishes a BuildComplete
+    -- with a partial 'Test.Suites', and a 'status --wait' caller reads that
+    -- stale result before the new cycle starts.
+    it "does not transition to BuildComplete when the run is aborted mid-flight" do
         phases <-
             runEff
                 . runConcurrent
                 . runLogNoOp
-                . evalState (BuildId 1)
-                . execWriter @[EnteringNewPhase]
-                . runBuildStoreCapture
-                . runTestRunnerAbortAfterFirst (mkTestRun "test:foo")
+                . evalState (PostBuild $ Test.Suites mempty)
+                . execWriter @[PostBuild]
+                . runPostBuildState
+                . runPostBuildCapture
+                . runTestRunnerAbortAfterFirst suiteCompleted
                 $ requestTestRunsForNewBuildResults
-                    BuildConfig
-                        { command = Command ""
-                        , targets = []
-                        , testTargets = parseTestTargets ["test:foo", "test:bar"]
-                        , watchDirs = WatchDirs []
-                        }
-                    expected
-        -- The critical assertion: no Done phase, because the run was
-        -- aborted before completing the second suite. A Done here would
-        -- briefly publish a half-finished testRuns list that a
-        -- 'status --wait' caller could observe.
-        length [() | EnteringNewPhase _ (BuildComplete (PostBuild DoneTesting _)) <- phases] `shouldBe` 0
-        -- Sanity: only the initial Testing transition was published; the
-        -- run loop short-circuited after the first 'isAborted' check, so
-        -- the post-foo Testing update never fired.
-        length phases `shouldBe` 1
+                $ parseTestTargets ["test:foo", "test:bar"]
+        phases
+            `shouldMatchList` [ PostBuild
+                                    $ Test.Suites
+                                    $ Map.fromList
+                                        [ (mkTestTarget "test:bar", Test.SuiteRunning Nothing)
+                                        , (mkTestTarget "test:foo", Test.SuiteRunning Nothing)
+                                        ]
+                              ]
   where
-    runTest testTargets script partial =
+    runTest testTargets script =
         runEff
             . runConcurrent
             . runLogNoOp
-            . evalState (BuildId 1)
-            . execWriter @[EnteringNewPhase]
-            . runBuildStoreCapture
+            . evalState (PostBuild $ Test.Suites mempty)
+            . execWriter @[PostBuild]
+            . runPostBuildState
+            . runPostBuildCapture
             . runTestRunnerScripted script
-            $ requestTestRunsForNewBuildResults
-                BuildConfig
-                    { command = Command ""
-                    , targets = []
-                    , testTargets
-                    , watchDirs = WatchDirs []
-                    }
-                partial
+            $ requestTestRunsForNewBuildResults testTargets
 
-    mkPhase = EnteringNewPhase (BuildId 1)
-    mkTesting = mkPhase . BuildComplete . PostBuild Testing
-    mkDone = mkPhase . BuildComplete . PostBuild DoneTesting
-    buildWithTests testRuns = expected {testRuns}
+    postBuildWithTests = PostBuild . Test.Suites . Map.fromList
 
-    expected =
-        BuildResult
-            { completedAt = addUTCTime 10 epoch
-            , duration = 10_000
-            , moduleCount = 2
-            , diagnostics = [warnMsg]
-            , testRuns = []
-            }
-
-    mkTestRun target =
-        TestRunCompleted
-            $ TestRunCompletion
-                { target
-                , passed = True
+    suiteCompleted =
+        Test.SuiteCompleted
+            $ Test.SuiteCompletion
+                { passed = True
                 , output = ""
                 , testCases = []
                 , duration = Nothing
@@ -987,6 +955,10 @@ emptyDaemonInfo =
         }
 
 
+mkTestTarget :: Text -> TestTarget
+mkTestTarget = TestTarget . parseTarget
+
+
 --------------------------------------------------------------------------------
 -- Event coalescing (watchSourceChanges)
 --
@@ -1327,7 +1299,7 @@ testInterruptCurrent = do
 -- — simulating an external interrupt that arrives between two test suites.
 runTestRunnerAbortAfterFirst
     :: (Concurrent :> es)
-    => TestRun -> Eff (TestRunner : es) a -> Eff es a
+    => Test.Suite -> Eff (TestRunner : es) a -> Eff es a
 runTestRunnerAbortAfterFirst result act = do
     callCountRef <- atomically (STM.newTVar (0 :: Int))
     abortedRef <- atomically (STM.newTVar False)
@@ -1346,19 +1318,49 @@ runTestRunnerAbortAfterFirst result act = do
         act
 
 
--- | A 'BuildStore' interpreter that records every 'setPhase' call into a
--- 'Writer'. Only the operations used by the Builder pipeline tests are
--- implemented; the rest error.
+completeBuildState :: BuildState
+completeBuildState =
+    BuildState
+        { buildId = BuildId 1
+        , phase =
+            BuildComplete
+                ( BuildResult
+                    { completedAt = epoch
+                    , duration = 0
+                    , moduleCount = 1
+                    , diagnostics = []
+                    }
+                )
+                $ PostBuild
+                $ Test.Suites mempty
+        , daemonInfo = emptyDaemonInfo
+        }
+
+
+-- | A 'BuildStore' interpreter that records every phase transition into a
+-- 'Writer'. Captures both 'SetPhase' (used by 'enterPhase') and 'ModifyPhase'
+-- (used by 'withPostBuildPhase' for BuildComplete transitions).
 runBuildStoreCapture
-    :: (Writer [EnteringNewPhase] :> es)
+    :: (State BuildState :> es, Writer [EnteringNewPhase] :> es)
     => Eff (BuildStore.BuildStore : es) a -> Eff es a
 runBuildStoreCapture = interpret_ \case
-    BuildStore.SetPhase bid phase -> tell [EnteringNewPhase bid phase]
+    BuildStore.SetPhase bid phase -> do
+        tell [EnteringNewPhase bid phase]
+        put
+            BuildState
+                { buildId = bid
+                , phase
+                , daemonInfo = emptyDaemonInfo
+                }
     BuildStore.HasWaiters -> pure False
     BuildStore.MarkDirty _ -> pure ()
-    BuildStore.GetState -> error "runBuildStoreCapture: GetState unsupported"
-    BuildStore.ModifyPhase _ -> error "runBuildStoreCapture: ModifyPhase unsupported"
-    BuildStore.WaitUntilDone -> error "runBuildStoreCapture: WaitUntilDone unsupported"
-    BuildStore.WaitForNext _ -> error "runBuildStoreCapture: WaitForNext unsupported"
-    BuildStore.WaitForAnyChange _ -> error "runBuildStoreCapture: WaitForAnyChange unsupported"
+    BuildStore.GetState -> get
+    BuildStore.ModifyPhase f -> do
+        curr <- get
+        let new = f curr
+        tell [EnteringNewPhase curr.buildId new]
+        put $ curr {phase = new}
+    BuildStore.WaitUntilDone -> get
+    BuildStore.WaitForNext _ -> get
+    BuildStore.WaitForAnyChange _ -> get
     BuildStore.WaitDirty -> error "runBuildStoreCapture: WaitDirty unsupported"

--- a/tricorder/test/Unit/Tricorder/TestOutputSpec.hs
+++ b/tricorder/test/Unit/Tricorder/TestOutputSpec.hs
@@ -4,7 +4,7 @@ import Test.Hspec
 
 import Tricorder.TestOutput (parseHspecDuration, parseHspecOutput, stripGhciNoise)
 
-import Tricorder.BuildState.Tests qualified as Test
+import Tricorder.BuildState.Test qualified as Test
 
 
 spec_TestOutput :: Spec

--- a/tricorder/test/Unit/Tricorder/TestOutputSpec.hs
+++ b/tricorder/test/Unit/Tricorder/TestOutputSpec.hs
@@ -2,8 +2,9 @@ module Unit.Tricorder.TestOutputSpec (spec_TestOutput) where
 
 import Test.Hspec
 
-import Tricorder.BuildState (TestCase (..), TestCaseOutcome (..))
 import Tricorder.TestOutput (parseHspecDuration, parseHspecOutput, stripGhciNoise)
+
+import Tricorder.BuildState.Tests qualified as Test
 
 
 spec_TestOutput :: Spec
@@ -15,12 +16,12 @@ spec_TestOutput = do
         it "parses a passing test" do
             let output = "  foo\n    bar baz:                                      OK\n"
             parseHspecOutput output
-                `shouldBe` [TestCase {description = "bar baz:", outcome = TestCasePassed}]
+                `shouldBe` [Test.Case {description = "bar baz:", outcome = Test.Passed}]
 
         it "parses a failing test" do
             let output = "  foo\n    bar baz:                                      FAIL\n"
             parseHspecOutput output
-                `shouldBe` [TestCase {description = "bar baz:", outcome = TestCaseFailed ""}]
+                `shouldBe` [Test.Case {description = "bar baz:", outcome = Test.Failed ""}]
 
         it "captures failure details" do
             let output =
@@ -29,11 +30,11 @@ spec_TestOutput = do
                         <> "       but got: 2\n"
                         <> "    another test:                                       OK\n"
             parseHspecOutput output
-                `shouldBe` [ TestCase
+                `shouldBe` [ Test.Case
                                 { description = "a test:"
-                                , outcome = TestCaseFailed "expected: 1\nbut got: 2"
+                                , outcome = Test.Failed "expected: 1\nbut got: 2"
                                 }
-                           , TestCase {description = "another test:", outcome = TestCasePassed}
+                           , Test.Case {description = "another test:", outcome = Test.Passed}
                            ]
 
         it "stops collecting details when indentation returns to test level" do
@@ -44,7 +45,7 @@ spec_TestOutput = do
             let cases = parseHspecOutput output
             length cases `shouldBe` 2
             case cases of
-                (c : _) -> c.outcome `shouldBe` TestCaseFailed "detail line"
+                (c : _) -> c.outcome `shouldBe` Test.Failed "detail line"
                 [] -> expectationFailure "expected at least one test case"
 
         it "skips group header lines" do
@@ -53,7 +54,7 @@ spec_TestOutput = do
                         <> "    someFunction\n"
                         <> "      does the thing:                                  OK\n"
             parseHspecOutput output
-                `shouldBe` [TestCase {description = "does the thing:", outcome = TestCasePassed}]
+                `shouldBe` [Test.Case {description = "does the thing:", outcome = Test.Passed}]
 
         it "parses mixed passing and failing tests" do
             let output =
@@ -63,30 +64,30 @@ spec_TestOutput = do
                         <> "      reason\n"
                         <> "    also passes:                                       OK\n"
             parseHspecOutput output
-                `shouldBe` [ TestCase {description = "passes:", outcome = TestCasePassed}
-                           , TestCase {description = "fails:", outcome = TestCaseFailed "reason"}
-                           , TestCase {description = "also passes:", outcome = TestCasePassed}
+                `shouldBe` [ Test.Case {description = "passes:", outcome = Test.Passed}
+                           , Test.Case {description = "fails:", outcome = Test.Failed "reason"}
+                           , Test.Case {description = "also passes:", outcome = Test.Passed}
                            ]
 
         it "parses a passing test with a timing annotation" do
             let output = "  slow test:                                          OK (0.05s)\n"
             parseHspecOutput output
-                `shouldBe` [TestCase {description = "slow test:", outcome = TestCasePassed}]
+                `shouldBe` [Test.Case {description = "slow test:", outcome = Test.Passed}]
 
         it "parses a passing test with a millisecond annotation" do
             let output = "  fast property:                                      OK (12ms)\n"
             parseHspecOutput output
-                `shouldBe` [TestCase {description = "fast property:", outcome = TestCasePassed}]
+                `shouldBe` [Test.Case {description = "fast property:", outcome = Test.Passed}]
 
         it "parses a failing test with a timing annotation" do
             let output = "  slow fail:                                          FAIL (0.03s)\n"
             parseHspecOutput output
-                `shouldBe` [TestCase {description = "slow fail:", outcome = TestCaseFailed ""}]
+                `shouldBe` [Test.Case {description = "slow fail:", outcome = Test.Failed ""}]
 
         it "does not strip a non-timing parenthetical in the description" do
             let output = "  test (corner case):                                 OK\n"
             parseHspecOutput output
-                `shouldBe` [TestCase {description = "test (corner case):", outcome = TestCasePassed}]
+                `shouldBe` [Test.Case {description = "test (corner case):", outcome = Test.Passed}]
 
     describe "parseHspecDuration" do
         it "returns Nothing for empty output" do

--- a/tricorder/test/Unit/Tricorder/TestRunnerSpec.hs
+++ b/tricorder/test/Unit/Tricorder/TestRunnerSpec.hs
@@ -15,7 +15,17 @@ import Effectful.Reader.Static (runReader)
 import Effectful.State.Static.Shared (evalState)
 import Test.Hspec
 
-import Tricorder.BuildState (BuildId (..), BuildPhase (..), BuildProgress (..), BuildResult (..), BuildState (..), DaemonInfo (..), PostBuild (..), TestPhase (..), TestRun (..), TestRunCompletion (..))
+import Data.Map.Strict qualified as Map
+
+import Tricorder.BuildState
+    ( BuildId (..)
+    , BuildPhase (..)
+    , BuildResult (..)
+    , BuildState (..)
+    , DaemonInfo (..)
+    , PostBuild (..)
+    )
+import Tricorder.BuildState.BuildProgress (BuildProgress (..))
 import Tricorder.Effects.BuildStore (getState)
 import Tricorder.Effects.GhciSession.GhciParser (GhciLoading (..))
 import Tricorder.Effects.TestRunner
@@ -30,7 +40,9 @@ import Tricorder.Effects.TestRunner
     , runTestSuite
     )
 import Tricorder.Runtime (ProjectRoot (..))
+import Tricorder.Session (Target (..), TestTarget (..))
 
+import Tricorder.BuildState.Tests qualified as Test
 import Tricorder.Effects.BuildStore qualified as BuildStore
 
 
@@ -116,33 +128,34 @@ testDetectOutcome = do
 testScripted :: Spec
 testScripted = do
     it "returns scripted TestRun" do
-        result <- runScripted [Right passingRun] $ runTestSuite "test:foo"
+        result <- runScripted [Right passingRun] $ runTestSuite $ mkTestTarget "test:foo"
         result `shouldBe` passingRun
 
     it "ignores the target name argument" do
-        result <- runScripted [Right failingRun] $ runTestSuite "test:anything"
+        result <- runScripted [Right failingRun] $ runTestSuite $ mkTestTarget "test:anything"
         result `shouldBe` failingRun
 
     it "throws when scripted result is Left" do
         result <-
             runScripted [Left (toException boom)]
                 $ try @ErrorCall
-                $ runTestSuite "test:foo"
+                $ runTestSuite
+                $ mkTestTarget "test:foo"
         result `shouldBe` Left boom
 
     describe "sequencing" do
         it "consumes results in order across multiple calls" do
             (a, b) <- runScripted [Right passingRun, Right failingRun] do
-                a <- runTestSuite "test:foo"
-                b <- runTestSuite "test:bar"
+                a <- runTestSuite $ mkTestTarget "test:foo"
+                b <- runTestSuite $ mkTestTarget "test:bar"
                 pure (a, b)
             a `shouldBe` passingRun
             b `shouldBe` failingRun
 
         it "recover scenario: error then success" do
             result <- runScripted [Left (toException boom), Right passingRun] do
-                r1 <- try @ErrorCall $ runTestSuite "test:foo"
-                r2 <- runTestSuite "test:bar"
+                r1 <- try @ErrorCall $ runTestSuite $ mkTestTarget "test:foo"
+                r2 <- runTestSuite $ mkTestTarget "test:bar"
                 pure (r1, r2)
             fst result `shouldBe` Left boom
             snd result `shouldBe` passingRun
@@ -179,31 +192,29 @@ boom :: ErrorCall
 boom = ErrorCall "simulated process crash"
 
 
-passingRun :: TestRun
+passingRun :: Test.Suite
 passingRun =
-    TestRunCompleted
-        $ TestRunCompletion
-            { target = "test:foo"
-            , passed = True
+    Test.SuiteCompleted
+        $ Test.SuiteCompletion
+            { passed = True
             , output = "2 examples, 0 failures\n"
             , testCases = []
             , duration = Nothing
             }
 
 
-failingRun :: TestRun
+failingRun :: Test.Suite
 failingRun =
-    TestRunCompleted
-        $ TestRunCompletion
-            { target = "test:bar"
-            , passed = False
+    Test.SuiteCompleted
+        $ Test.SuiteCompletion
+            { passed = False
             , output = "1 example, 1 failure\n"
             , testCases = []
             , duration = Nothing
             }
 
 
-runScripted :: [Either SomeException TestRun] -> Eff '[TestRunner, Concurrent, IOE] a -> IO a
+runScripted :: [Either SomeException Test.Suite] -> Eff '[TestRunner, Concurrent, IOE] a -> IO a
 runScripted results = runEff . runConcurrent . runTestRunnerScripted results
 
 
@@ -222,7 +233,8 @@ testAbortGatedProgress :: Spec
 testAbortGatedProgress = do
     it "applies the progress update when abortedRef is False" do
         finalRuns <- runProgress False progress42 startingRuns
-        finalRuns `shouldBe` [TestRunning "test:foo" (Just expected42)]
+        Map.toList finalRuns.getSuites
+            `shouldMatchList` [(mkTestTarget "test:foo", Test.SuiteRunning (Just expected42))]
 
     it "drops the progress update when abortedRef is True" do
         finalRuns <- runProgress True progress42 startingRuns
@@ -233,12 +245,10 @@ testAbortGatedProgress = do
         let loadings = [mkLoading i 10 | i <- [1 .. 5]]
         finalRuns <- runStore do
             BuildStore.setPhase (BuildId 1)
-                $ BuildComplete
-                    PostBuild
-                        { testPhase = Testing
-                        , result = partialResultWith startingRuns
-                        }
-            for_ loadings (abortGatedProgress abortedRef "test:foo")
+                $ BuildComplete result
+                $ PostBuild startingRuns
+
+            for_ loadings $ abortGatedProgress abortedRef $ mkTestTarget "test:foo"
             phaseTestRuns <$> getState
         finalRuns `shouldBe` startingRuns
 
@@ -247,24 +257,21 @@ testAbortGatedProgress = do
         finalRuns <- runStore do
             BuildStore.setPhase
                 (BuildId 1)
-                $ BuildComplete
-                    PostBuild
-                        { testPhase = Testing
-                        , result = partialResultWith startingRuns
-                        }
+                $ BuildComplete result
+                $ PostBuild startingRuns
 
             -- This one applies.
-            abortGatedProgress abortedRef "test:foo" (mkLoading 3 10)
+            abortGatedProgress abortedRef (mkTestTarget "test:foo") (mkLoading 3 10)
             -- Simulate the interrupt firing.
             atomically (writeTVar abortedRef True)
             -- These should now be dropped.
-            abortGatedProgress abortedRef "test:foo" (mkLoading 8 10)
-            abortGatedProgress abortedRef "test:foo" (mkLoading 9 10)
+            abortGatedProgress abortedRef (mkTestTarget "test:foo") (mkLoading 8 10)
+            abortGatedProgress abortedRef (mkTestTarget "test:foo") (mkLoading 9 10)
             phaseTestRuns <$> getState
-        finalRuns
-            `shouldBe` [TestRunning "test:foo" (Just BuildProgress {compiled = 3, total = 10})]
+        Map.toList finalRuns.getSuites
+            `shouldMatchList` [(mkTestTarget "test:foo", Test.SuiteRunning (Just BuildProgress {compiled = 3, total = 10}))]
   where
-    startingRuns = [TestRunning "test:foo" Nothing]
+    startingRuns = Test.Suites $ Map.fromList [(mkTestTarget "test:foo", Test.SuiteRunning Nothing)]
     progress42 = mkLoading 4 10
     expected42 = BuildProgress {compiled = 4, total = 10}
 
@@ -272,12 +279,9 @@ testAbortGatedProgress = do
         abortedRef <- newTVarIO aborted
         runStore do
             BuildStore.setPhase (BuildId 1)
-                $ BuildComplete
-                    PostBuild
-                        { testPhase = Testing
-                        , result = partialResultWith runs
-                        }
-            abortGatedProgress abortedRef "test:foo" loading
+                $ BuildComplete result
+                $ PostBuild runs
+            abortGatedProgress abortedRef (mkTestTarget "test:foo") loading
             phaseTestRuns <$> getState
 
     runStore =
@@ -299,19 +303,18 @@ testAbortGatedProgress = do
             , sourceFile = "Mod.hs"
             }
 
-    partialResultWith runs =
+    result =
         BuildResult
             { completedAt = epoch
             , duration = 0
             , moduleCount = 0
             , diagnostics = []
-            , testRuns = runs
             }
 
-    phaseTestRuns :: BuildState -> [TestRun]
+    phaseTestRuns :: BuildState -> Test.Suites
     phaseTestRuns s = case s.phase of
-        BuildComplete (PostBuild Testing r) -> r.testRuns
-        _ -> []
+        BuildComplete _ (PostBuild r) -> r
+        _ -> Test.Suites mempty
 
     epoch :: UTCTime
     epoch = UTCTime (fromGregorian 2024 1 1) 0
@@ -325,3 +328,7 @@ testAbortGatedProgress = do
             , logFile = ""
             , metricsPort = Nothing
             }
+
+
+mkTestTarget :: Text -> TestTarget
+mkTestTarget = TestTarget . Bare

--- a/tricorder/test/Unit/Tricorder/TestRunnerSpec.hs
+++ b/tricorder/test/Unit/Tricorder/TestRunnerSpec.hs
@@ -249,7 +249,7 @@ testAbortGatedProgress = do
                 $ PostBuild startingRuns
 
             for_ loadings $ abortGatedProgress abortedRef $ mkTestTarget "test:foo"
-            phaseTestRuns <$> getState
+            phaseTestSuites <$> getState
         finalRuns `shouldBe` startingRuns
 
     it "flips behaviour mid-run if abortedRef is set between updates" do
@@ -267,7 +267,7 @@ testAbortGatedProgress = do
             -- These should now be dropped.
             abortGatedProgress abortedRef (mkTestTarget "test:foo") (mkLoading 8 10)
             abortGatedProgress abortedRef (mkTestTarget "test:foo") (mkLoading 9 10)
-            phaseTestRuns <$> getState
+            phaseTestSuites <$> getState
         Map.toList finalRuns.getSuites
             `shouldMatchList` [(mkTestTarget "test:foo", Test.SuiteRunning (Just BuildProgress {compiled = 3, total = 10}))]
   where
@@ -282,7 +282,7 @@ testAbortGatedProgress = do
                 $ BuildComplete result
                 $ PostBuild runs
             abortGatedProgress abortedRef (mkTestTarget "test:foo") loading
-            phaseTestRuns <$> getState
+            phaseTestSuites <$> getState
 
     runStore =
         runEff
@@ -311,9 +311,9 @@ testAbortGatedProgress = do
             , diagnostics = []
             }
 
-    phaseTestRuns :: BuildState -> Test.Suites
-    phaseTestRuns s = case s.phase of
-        BuildComplete _ (PostBuild r) -> r
+    phaseTestSuites :: BuildState -> Test.Suites
+    phaseTestSuites s = case s.phase of
+        BuildComplete _ (PostBuild testSuites) -> testSuites
         _ -> Test.Suites mempty
 
     epoch :: UTCTime

--- a/tricorder/test/Unit/Tricorder/TestRunnerSpec.hs
+++ b/tricorder/test/Unit/Tricorder/TestRunnerSpec.hs
@@ -42,7 +42,7 @@ import Tricorder.Effects.TestRunner
 import Tricorder.Runtime (ProjectRoot (..))
 import Tricorder.Session (Target (..), TestTarget (..))
 
-import Tricorder.BuildState.Tests qualified as Test
+import Tricorder.BuildState.Test qualified as Test
 import Tricorder.Effects.BuildStore qualified as BuildStore
 
 

--- a/tricorder/tricorder.cabal
+++ b/tricorder/tricorder.cabal
@@ -32,7 +32,7 @@ library tricorder-internal
       Tricorder.Builder.Dispatch
       Tricorder.BuildState
       Tricorder.BuildState.BuildProgress
-      Tricorder.BuildState.Tests
+      Tricorder.BuildState.Test
       Tricorder.CLI
       Tricorder.CLI.Main
       Tricorder.CLI.Render

--- a/tricorder/tricorder.cabal
+++ b/tricorder/tricorder.cabal
@@ -31,6 +31,8 @@ library tricorder-internal
       Tricorder.Builder
       Tricorder.Builder.Dispatch
       Tricorder.BuildState
+      Tricorder.BuildState.BuildProgress
+      Tricorder.BuildState.Tests
       Tricorder.CLI
       Tricorder.CLI.Main
       Tricorder.CLI.Render
@@ -46,6 +48,7 @@ library tricorder-internal
       Tricorder.Effects.GhciSession.GhciProcess
       Tricorder.Effects.GhcPkg
       Tricorder.Effects.Logging
+      Tricorder.Effects.PostBuildStore
       Tricorder.Effects.SessionStore
       Tricorder.Effects.TestRunner
       Tricorder.Effects.UnixSocket


### PR DESCRIPTION
- Separates the test results from `BuildResult` by moving them into `PostBuild` and having `PostBuild` be an entirely separate structure from `BuildResult`.
- Renames the `Done` build phase to `BuildComplete` to better match the other phases' names
- Make `BuildComplete` carry the `BuildResult` from the finished build as well as the `PostBuild` for subsequent phases that want to run, like tests, as separate values.
- Introduce `PostBuildStore` for tasks and actions that only care about the `PostBuild` part of the `BuildComplete` phase.
  - It can only be interpreted with a completed `BuildResult`, ensuring all actions run in the context of the `runPostBuildStore` can update the active `BuildComplete` phase.