### PR TITLE
feat: add tricorder log --path flag

### DIFF
--- a/.claude-plugin/tricorder/skills/tricorder/SKILL.md
+++ b/.claude-plugin/tricorder/skills/tricorder/SKILL.md
@@ -32,7 +32,7 @@ tricorder is a daemon-based GHCi build monitor. It exposes build state over a Un
 - `tricorder eval-comments --wait --json` — print eval comments and their evaluated results as JSON, waiting for the current build to finish if it is in-progress
 - `tricorder log` — print the daemon log output
 - `tricorder log --follow` / `-f` — keep streaming new log lines as they are written
-- `tricorder log --path` — print the path to the log file instead of its contents
+- `tricorder log --print-path` — print the path to the log file instead of its contents
 - `tricorder ui` — auto-refreshing terminal display (for humans)
 
 ## Checking Build Status

--- a/.claude-plugin/tricorder/skills/tricorder/SKILL.md
+++ b/.claude-plugin/tricorder/skills/tricorder/SKILL.md
@@ -30,6 +30,9 @@ tricorder is a daemon-based GHCi build monitor. It exposes build state over a Un
 - `tricorder eval-comments --wait` — print eval comments and their evaluated results, waiting for the current build to finish if it is in-progress
 - `tricorder eval-comments --json` — print eval comments and their evaluated results as JSON
 - `tricorder eval-comments --wait --json` — print eval comments and their evaluated results as JSON, waiting for the current build to finish if it is in-progress
+- `tricorder log` — print the daemon log output
+- `tricorder log --follow` / `-f` — keep streaming new log lines as they are written
+- `tricorder log --path` — print the path to the log file instead of its contents
 - `tricorder ui` — auto-refreshing terminal display (for humans)
 
 ## Checking Build Status

--- a/tricorder/src/Tricorder.hs
+++ b/tricorder/src/Tricorder.hs
@@ -18,7 +18,7 @@ import Prelude hiding (force)
 import Atelier.Effects.Console qualified as Console
 import Data.Text qualified as T
 
-import Tricorder.Arguments (Command (..))
+import Tricorder.Arguments (Command (..), LogMode (..))
 import Tricorder.BuildState (BuildState (..), DaemonInfo (..))
 import Tricorder.CLI (showLog, showSource, showStatus, showTests)
 import Tricorder.Daemon (restartDaemon, startDaemon, stopDaemon, waitForDaemon)
@@ -90,7 +90,7 @@ run =
                 Console.putStrLn "Stopped."
             else
                 showTests opts
-        Log followMode -> do
+        Log logMode -> do
             running <- isDaemonRunning
             logFile <-
                 if running then do
@@ -102,7 +102,9 @@ run =
                         Left _ -> fallback
                 else
                     asks @LogPath (.getLogPath)
-            showLog logFile followMode
+            case logMode of
+                ShowLog followMode -> showLog logFile followMode
+                ShowLogPath -> Console.putTextLn (toText logFile)
         UI -> do
             running <- isDaemonRunning
             unless running do

--- a/tricorder/src/Tricorder/Arguments.hs
+++ b/tricorder/src/Tricorder/Arguments.hs
@@ -1,6 +1,7 @@
 module Tricorder.Arguments
     ( Command (..)
     , FollowMode (..)
+    , LogMode (..)
     , OutputFormat (..)
     , StatusOptions (..)
     , TestOptions (..)
@@ -22,6 +23,7 @@ import Options.Applicative
     , command
     , eitherReader
     , flag
+    , flag'
     , fullDesc
     , header
     , help
@@ -67,6 +69,11 @@ data FollowMode
     deriving stock (Eq)
 
 
+data LogMode
+    = ShowLog FollowMode
+    | ShowLogPath
+
+
 data StatusOptions = StatusOptions
     { wait :: WaitMode
     , format :: OutputFormat
@@ -90,7 +97,7 @@ data Command
     | Status StatusOptions
     | Test TestOptions
     | UI
-    | Log FollowMode
+    | Log LogMode
     | Source [SourceQuery]
     | Restart Force
 
@@ -133,14 +140,23 @@ commandParser =
 
 logParser :: Parser Command
 logParser =
-    Log
-        <$> flag
-            NoFollow
-            Follow
-            ( long "follow"
-                <> short 'f'
-                <> help "Keep streaming new log lines as they are written"
+    Log <$> (pathFlag <|> followFlag)
+  where
+    pathFlag =
+        flag'
+            ShowLogPath
+            ( long "path"
+                <> help "Print the path to the log file instead of its contents"
             )
+    followFlag =
+        ShowLog
+            <$> flag
+                NoFollow
+                Follow
+                ( long "follow"
+                    <> short 'f'
+                    <> help "Keep streaming new log lines as they are written"
+                )
 
 
 statusParser :: Parser Command

--- a/tricorder/src/Tricorder/Arguments.hs
+++ b/tricorder/src/Tricorder/Arguments.hs
@@ -145,7 +145,7 @@ logParser =
     pathFlag =
         flag'
             ShowLogPath
-            ( long "path"
+            ( long "print-path"
                 <> help "Print the path to the log file instead of its contents"
             )
     followFlag =


### PR DESCRIPTION
- Print the path to the daemon log file instead of its contents
- Model the log command's mode as `LogMode` so `--path` and `--follow` are mutually exclusive at the parser level
- Document the `log` command and its flags in the tricorder SKILL