### PR TITLE
feat: support evaluating comments

### DIFF
--- a/.claude-plugin/tricorder/skills/tricorder/SKILL.md
+++ b/.claude-plugin/tricorder/skills/tricorder/SKILL.md
@@ -26,6 +26,10 @@ tricorder is a daemon-based GHCi build monitor. It exposes build state over a Un
 - `tricorder test-results --failed` — show output only from failed test suites
 - `tricorder test-results --wait` — block until the current build cycle completes, then show results
 - `tricorder source MODULE...` — print Haskell source for one or more installed modules (e.g. `tricorder source Data.Map.Strict`)
+- `tricorder eval-comments` — print eval comments and their evaluated results from the current build result.
+- `tricorder eval-comments --wait` — print eval comments and their evaluated results, waiting for the current build to finish if it is in-progress
+- `tricorder eval-comments --json` — print eval comments and their evaluated results as JSON
+- `tricorder eval-comments --wait --json` — print eval comments and their evaluated results as JSON, waiting for the current build to finish if it is in-progress
 - `tricorder ui` — auto-refreshing terminal display (for humans)
 
 ## Checking Build Status
@@ -147,6 +151,45 @@ tricorder test-results --wait --failed
 ```
 
 **Exit code**: 1 when any shown test suite failed or errored, 0 otherwise.
+
+### Eval comments (`eval-comments`)
+
+The daemon evaluates eval comments in the watched source files it finds. These
+could be useful to you to run quick tests or for checking things.
+
+Default output lists each eval comment with its evaluated result:
+
+```
+./src/Source/Module.hs (line 123)
+Expression:
+:t someFunc
+Output:
+someFunc :: Int -> Int
+```
+
+With `--json`, the output is formatted as a JSON object:
+
+```
+{
+  "state": "done",
+  "comments": [
+    {
+      "expression": ":t someFunc",
+      "file": "./src/Source/Module.hs",
+      "line": 123,
+      "state": {
+        "output": "someFunc :: Int -> Int\n\n",
+        "state": "completed"
+      }
+    }
+  ]
+}
+```
+
+The `state` property on the top-level object represents the current build
+state. If a build is currently in-progress, the `state` will show which stage
+of the build the daemon is at. Only `done` will be accompanied by a `comments`
+array with the evaluated comments.
 
 ## Workflow
 

--- a/.tricorder.yaml
+++ b/.tricorder.yaml
@@ -1,3 +1,13 @@
+session:
+  targets:
+    - exe:tricorder
+    - exe:tricorder-daemon
+    - lib:atelier-core
+    - lib:atelier-db
+    - lib:atelier-testing
+    - lib:tricorder-internal
+    - test:atelier-test
+    - test:tricorder-test
 observability:
   log_file: /tmp/tricorder.log
   metrics:

--- a/tricorder/package.nix
+++ b/tricorder/package.nix
@@ -124,16 +124,17 @@ in
       ]
       ++ [ "tricorder-internal" ]
       ++ depList [
-        "atelier-prelude"
-        "atelier-core"
         "Cabal-syntax"
         "aeson"
+        "atelier-core"
+        "atelier-prelude"
         "bytestring"
         "containers"
         "data-default"
         "effectful"
         "filepath"
         "hspec"
+        "megaparsec"
         "process"
         "regex-tdfa"
         "stm"

--- a/tricorder/src/Tricorder/BuildState.hs
+++ b/tricorder/src/Tricorder/BuildState.hs
@@ -9,8 +9,8 @@ module Tricorder.BuildState
     ( BuildId (..)
     , BuildState (..)
     , BuildPhase (..)
-    , PostBuild (..)
     , BuildResult (..)
+    , PostBuild (..)
     , DaemonInfo (..)
     , loadDaemonInfo
     , runDaemonInfo
@@ -37,6 +37,7 @@ import Tricorder.Effects.SessionStore (SessionStore)
 import Tricorder.Runtime (LogPath (..), ProjectRoot (..), SocketPath (..))
 import Tricorder.Session (Session (..), Target, WatchDirs (..))
 
+import Tricorder.BuildState.EvalComments qualified as Eval
 import Tricorder.BuildState.Test qualified as Test
 import Tricorder.BuildState.Test qualified as Tests
 import Tricorder.Effects.SessionStore qualified as SessionStore
@@ -125,6 +126,7 @@ data BuildResult = BuildResult
 
 data PostBuild = PostBuild
     { testSuites :: Test.Suites
+    , evalComments :: Eval.Comments
     }
     deriving stock (Eq, Generic, Show)
     deriving (FromJSON, ToJSON) via Generically PostBuild
@@ -168,6 +170,7 @@ stateLabel (BuildComplete result postBuild)
     | any (\m -> m.severity == SError) result.diagnostics = "error"
     | any (\m -> m.severity == SWarning) result.diagnostics = "warning"
     | Tests.anyRunningTests postBuild.testSuites = "testing"
+    | Eval.anyRunningComments postBuild.evalComments = "evaluating comments"
     | otherwise = "ok"
 
 

--- a/tricorder/src/Tricorder/BuildState/EvalComments.hs
+++ b/tricorder/src/Tricorder/BuildState/EvalComments.hs
@@ -1,0 +1,189 @@
+module Tricorder.BuildState.EvalComments
+    ( Comments (..)
+    , anyRunningComments
+    , Evaluation (..)
+    , Comment (..)
+    , findComments
+    , evalCommentP
+    , singleLineEvalCommentP
+    , multiLineEvalCommentP
+    , blockCommentEvalP
+    , State (..)
+    ) where
+
+import Data.Aeson (FromJSON (..), ToJSON (..), Value (..), withObject, (.:))
+import GHC.Generics (Generically (..))
+import Text.Megaparsec
+    ( MonadParsec (takeWhile1P, takeWhileP)
+    , Parsec
+    , SourcePos (..)
+    , anySingle
+    , eof
+    , getSourcePos
+    , manyTill
+    , parse
+    , try
+    , unPos
+    )
+import Text.Megaparsec.Char (char, hspace, space, string)
+
+import Data.Aeson.KeyMap qualified as KM
+import Data.Text qualified as T
+
+
+newtype Comments = Comments {getComments :: [Evaluation]}
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via Generically Comments
+    deriving (Monoid, Semigroup) via [Evaluation]
+
+
+anyRunningComments :: Comments -> Bool
+anyRunningComments = any ((== Pending) . (.state)) . (.getComments)
+
+
+data Evaluation = Evaluation
+    { file :: FilePath
+    , comment :: Comment
+    , state :: State
+    }
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via Generically Evaluation
+
+
+-- | An eval comment found in a source file: a @-- $> \<expr\>@ annotation.
+data Comment = Comment
+    { lineNumber :: Int
+    , expression :: Text
+    }
+    deriving stock (Eq, Generic, Show)
+    deriving (FromJSON, ToJSON) via Generically Comment
+
+
+-- | Scan source file content for eval comments.
+-- Returns one 'Comment' per match, in source order.
+findComments :: Text -> [Comment]
+findComments content =
+    case parse fileP "" content of
+        Left _ -> []
+        Right comments -> comments
+  where
+    fileP = catMaybes <$> manyTill lineP eof
+    lineP = hspace *> ((Just <$> try evalCommentP) <|> (Nothing <$ skipRestOfLine))
+    skipRestOfLine = void $ takeWhileP Nothing (/= '\n') *> optional (char '\n')
+
+
+evalCommentP :: Parser Comment
+evalCommentP = singleLineEvalCommentP <|> multiLineEvalCommentP <|> blockCommentEvalP
+
+
+-- | @-- $> \<expr\>@ on a single line.
+singleLineEvalCommentP :: Parser Comment
+singleLineEvalCommentP = do
+    _ <- string "-- $>"
+    space
+    SourcePos {sourceLine} <- getSourcePos
+    expression <- takeWhile1P (Just "eval comment character") (/= '\n')
+    pure
+        Comment
+            { lineNumber = unPos sourceLine
+            , expression
+            }
+
+
+-- | Multi-line line-comment block:
+--
+-- @
+-- -- $$>
+-- -- line one
+-- -- line two
+-- -- \<$$
+-- @
+--
+-- Each content line must start with @--@ (optionally followed by a space).
+-- The leading @-- @ is stripped; relative indentation within the block is
+-- preserved.
+multiLineEvalCommentP :: Parser Comment
+multiLineEvalCommentP = do
+    SourcePos {sourceLine} <- getSourcePos
+    _ <- string "-- $$>"
+    expression <- try multiLineExpr <|> inlineExpr
+    pure
+        Comment
+            { expression
+            , lineNumber = unPos sourceLine
+            }
+  where
+    multiLineExpr = do
+        _ <- optional (char '\n')
+        lineContents <- manyTill commentLineP (try (string "-- <$$"))
+        pure $ T.intercalate "\n" lineContents
+    inlineExpr = do
+        chars <- manyTill anySingle (string "<$$")
+        pure $ T.strip (toText chars)
+    commentLineP = do
+        _ <- string "--"
+        _ <- optional (char ' ')
+        content <- takeWhileP Nothing (/= '\n')
+        _ <- optional (char '\n')
+        pure content
+
+
+-- | Block-comment eval:
+--
+-- @
+-- {- $$>
+-- expr
+-- \<$$ -}
+-- @
+--
+-- Content between the markers is stripped of leading\/trailing whitespace.
+-- For multi-line expressions use the layout that GHCi expects; do not indent
+-- the body relative to the opening @{- $>@ marker.
+blockCommentEvalP :: Parser Comment
+blockCommentEvalP = do
+    SourcePos {sourceLine} <- getSourcePos
+    _ <- string "{- $$>"
+    _ <- optional (char '\n')
+    chars <- manyTill anySingle (string "<$$ -}")
+    pure
+        Comment
+            { expression = T.strip (toText chars)
+            , lineNumber = unPos sourceLine
+            }
+
+
+type Parser = Parsec Void Text
+
+
+data State
+    = -- | The eval comment has yet to complete evaluation.
+      Pending
+    | -- | Combined stdout+stderr from GHCi, or an error message.
+      Completed Text
+    deriving stock (Eq, Generic, Show)
+
+
+instance ToJSON State where
+    toJSON = \case
+        Pending ->
+            toJSON
+                $ KM.fromList
+                    [ ("state", String "pending")
+                    ]
+        Completed output ->
+            toJSON
+                $ KM.fromList
+                    [ ("state", String "completed")
+                    , ("output", String output)
+                    ]
+
+
+instance FromJSON State where
+    parseJSON = withObject "State" \o -> do
+        state :: Text <- o .: "state"
+        case state of
+            "pending" -> pure $ Pending
+            "completed" -> do
+                output <- o .: "output"
+                pure $ Completed output
+            _ -> fail "invalid 'state' property"

--- a/tricorder/src/Tricorder/BuildState/Test.hs
+++ b/tricorder/src/Tricorder/BuildState/Test.hs
@@ -26,6 +26,7 @@ import Tricorder.Session (TestTarget)
 newtype Suites = Suites {getSuites :: Map TestTarget Suite}
     deriving stock (Eq, Generic, Show)
     deriving (FromJSON, ToJSON) via Generically Suites
+    deriving (Monoid, Semigroup) via Map TestTarget Suite
 
 
 hasFailedTests :: Suites -> Bool

--- a/tricorder/src/Tricorder/Builder.hs
+++ b/tricorder/src/Tricorder/Builder.hs
@@ -31,7 +31,7 @@ import Effectful.Concurrent (Concurrent)
 import Effectful.Concurrent.STM (atomically, newTVar)
 import Effectful.Exception (finally, trySync)
 import Effectful.Reader.Static (Reader, ask)
-import Effectful.State.Static.Shared (State, get, modify, put, state)
+import Effectful.State.Static.Shared (State, get, modify, put)
 import System.FilePath (normalise)
 
 import Atelier.Effects.Clock qualified as Clock
@@ -40,6 +40,7 @@ import Atelier.Effects.Log qualified as Log
 import Atelier.Effects.Publishing qualified as Sub
 import Data.Map.Strict qualified as Map
 import Data.Set qualified as Set
+import Effectful.State.Static.Shared qualified as State
 
 import Tricorder.BuildState
     ( BuildId (..)
@@ -63,6 +64,7 @@ import Tricorder.Builder.Dispatch
     , preserveFailureVisibility
     )
 import Tricorder.Effects.BuildStore (BuildStore)
+import Tricorder.Effects.EvalCommentRunner (EvalCommentRunner, findEvalCommentsInModules)
 import Tricorder.Effects.GhciSession (GhciSession, LoadResult (..))
 import Tricorder.Effects.GhciSession.GhciParser (resolveKnownTargets)
 import Tricorder.Effects.GhciSession.GhciProcess (GhciProcessError (..))
@@ -80,8 +82,10 @@ import Tricorder.Session
     , renderTestTarget
     )
 
+import Tricorder.BuildState.EvalComments qualified as Eval
 import Tricorder.BuildState.Test qualified as Test
 import Tricorder.Effects.BuildStore qualified as BuildStore
+import Tricorder.Effects.EvalCommentRunner qualified as EvalCommentRunner
 import Tricorder.Effects.GhciSession qualified as GhciSession
 import Tricorder.Effects.PostBuildStore qualified as PostBuild
 import Tricorder.Effects.SessionStore qualified as SessionStore
@@ -97,6 +101,7 @@ component
        , Conc :> es
        , Concurrent :> es
        , Debounce Text :> es
+       , EvalCommentRunner :> es
        , GhciSession :> es
        , Log :> es
        , Reader ProjectRoot :> es
@@ -156,6 +161,7 @@ runBuilder
        , Conc :> es
        , Concurrent :> es
        , Debounce Text :> es
+       , EvalCommentRunner :> es
        , GhciSession :> es
        , Log :> es
        , Reader ProjectRoot :> es
@@ -247,6 +253,7 @@ data GhciSessionHooks es = GhciSessionHooks
 defaultGhciSessionHooks
     :: ( BuildStore :> es
        , Clock :> es
+       , EvalCommentRunner :> es
        , Log :> es
        , Reader ProjectRoot :> es
        , State BuildId :> es
@@ -277,6 +284,7 @@ runGhciSessions
        , Conc :> es
        , Concurrent :> es
        , Debounce Text :> es
+       , EvalCommentRunner :> es
        , GhciSession :> es
        , Log :> es
        , Reader ProjectRoot :> es
@@ -322,6 +330,7 @@ buildWithGhciOnChange
        , Conc :> es
        , Concurrent :> es
        , Debounce Text :> es
+       , EvalCommentRunner :> es
        , GhciSession :> es
        , Log :> es
        , Reader ProjectRoot :> es
@@ -367,6 +376,7 @@ watchSourceChanges
        , Conc :> es
        , Concurrent :> es
        , Debounce Text :> es
+       , EvalCommentRunner :> es
        , Log :> es
        , State BuildId :> es
        , Sub SourceChangeDetected :> es
@@ -376,11 +386,12 @@ watchSourceChanges
     -> BuildConfig
     -> GhciSession.Controls (Eff es)
     -> Eff es Void
-watchSourceChanges hooks config controls = Conc.scoped do
+watchSourceChanges hooks config controls = do
     BuildId n <- get
     Log.debug $ "Builder: waiting for dirty flag (build #" <> show n <> ")"
     forever $ Conc.scoped do
         pending <- atomically (newTVar @(Maybe SourceChangeDetected) Nothing)
+        Log.debug "Builder: starting listeners"
         -- Write the latest event into a `TVar`, and a single worker fork
         -- drains it when it is ready to process a new event. Events that
         -- arrive while the worker is processing the previous one simply
@@ -390,7 +401,8 @@ watchSourceChanges hooks config controls = Conc.scoped do
         -- 'interruptCurrent' can't drop the in-flight cycle promptly — e.g.
         -- when a 'status --wait' caller has registered as a waiter, gating
         -- 'interruptCurrent' to a no-op.
-        Conc.fork_ $ Sub.listen_ \ev ->
+        Conc.fork_ $ Sub.listen_ \ev -> do
+            Log.debug $ "Builder: got source change"
             debounced 200 "source_change_reloader" do
                 atomically (writeTVar pending (Just ev))
                 -- Interrupts the currently running build as long as there are
@@ -400,19 +412,19 @@ watchSourceChanges hooks config controls = Conc.scoped do
         -- `hooks.onSourceChange` returns, which it will do once it completes
         -- or when it is interrupted. Only one worker should be running at any
         -- given time.
-        Conc.fork_ $ forever do
+        forever do
             ev <- atomically do
                 readTVar pending >>= \case
                     Nothing -> retry
                     Just e -> writeTVar pending Nothing >> pure e
             hooks.onSourceChange config controls ev
-        Conc.awaitAll
 
 
 -- 'controls.interrupt' is a safe no-op when GHCi is idle, and 'GhciSession'
 -- serialises subsequent reloads through its own STM state.
 interruptCurrent
     :: ( BuildStore :> es
+       , EvalCommentRunner :> es
        , Log :> es
        , TestRunner :> es
        )
@@ -420,14 +432,16 @@ interruptCurrent
 interruptCurrent controls = do
     hasWaiters <- BuildStore.hasWaiters
     unless hasWaiters do
-        Log.info "Change detected with no waiters. Interrupting current build/tests."
+        Log.info "Change detected with no waiters. Interrupting current build/tests/evals."
         controls.interrupt
         TestRunner.interruptCurrent
+        EvalCommentRunner.interruptCurrent
 
 
 reloadOnSourceChange
     :: ( BuildStore :> es
        , Clock :> es
+       , EvalCommentRunner :> es
        , Log :> es
        , Reader ProjectRoot :> es
        , State BuildId :> es
@@ -484,10 +498,11 @@ runAction controls = \case
 
 
 -- | Run the post-load pipeline synchronously: compile diagnostics into a
--- 'BuildResult', then (optionally) run tests and transition through the
--- corresponding phases.
+-- 'BuildResult', run eval comments in clean builds, then (optionally) run
+-- tests and transition through the corresponding phases.
 afterLoad
     :: ( BuildStore :> es
+       , EvalCommentRunner :> es
        , Log :> es
        , Reader ProjectRoot :> es
        , State BuilderState :> es
@@ -497,6 +512,7 @@ afterLoad
 afterLoad config newLoadResult = do
     buildResult <- compileLoadResultsIntoBuildResults config newLoadResult
     runPostBuildStore buildResult do
+        processEvalComments newLoadResult.loadResult
         if hasTargets config.testTargets && noErrors buildResult then
             runTestsForTargets config.testTargets >>= \case
                 Aborted -> Log.debug "Test run aborted by source change; skipping BuildComplete transition."
@@ -509,7 +525,9 @@ afterLoad config newLoadResult = do
                             BuildStore.setPhase curr.buildId
                                 $ BuildComplete buildResult
                                 $ PostBuild
-                                $ Test.Suites mempty
+                                    { testSuites = mempty
+                                    , evalComments = mempty
+                                    }
                     pure ()
         else do
             PostBuild.modifyPostBuild \postBuild ->
@@ -517,6 +535,25 @@ afterLoad config newLoadResult = do
   where
     hasTargets testTargets = not $ null testTargets.getTestTargets
     noErrors result = all (\d -> d.severity /= SError) result.diagnostics
+    processEvalComments loadResult = do
+        builderState <- get @BuilderState
+        evalComments <- findEvalCommentsInModules (resolveKnownTargets builderState.loadedModules loadResult)
+
+        let pendingComments =
+                (\(p, (_, ecs)) -> toPending p <$> toList ecs)
+                    `concatMap` Map.toList evalComments
+        PostBuild.modifyPostBuild \br -> br {evalComments = Eval.Comments pendingComments}
+        EvalCommentRunner.resetAbort
+        evaluatedComments <- EvalCommentRunner.evaluateComments evalComments
+        aborted <- EvalCommentRunner.isAborted
+        unless aborted
+            $ PostBuild.modifyPostBuild \br -> br {evalComments = Eval.Comments evaluatedComments}
+    toPending file comment =
+        Eval.Evaluation
+            { file
+            , comment
+            , state = Eval.Pending
+            }
 
 
 compileLoadResultsIntoBuildResults
@@ -535,7 +572,7 @@ compileLoadResultsIntoBuildResults session newLoadResult = do
                         $ filterToWatchDirs projectRoot watchDirs loadResult.diagnostics
                 }
 
-    newAccumulated <- state \s ->
+    newAccumulated <- State.state \s ->
         let merged = mergeDiagnostics s.diagnosticMap filteredResult
         in  (merged, s {diagnosticMap = merged})
 

--- a/tricorder/src/Tricorder/CLI.hs
+++ b/tricorder/src/Tricorder/CLI.hs
@@ -50,6 +50,7 @@ import Tricorder.Session (renderTestTarget)
 import Tricorder.Socket.Client (querySource, queryStatus, queryStatusWait)
 import Tricorder.TestOutput (stripGhciNoise)
 
+import Tricorder.BuildState.EvalComments qualified as Eval
 import Tricorder.BuildState.Test qualified as Test
 import Tricorder.BuildState.Test qualified as Tests
 
@@ -79,7 +80,10 @@ showStatus opts = do
             Right BuildState {phase = Building _} -> Console.putStrLn "Building..."
             Right BuildState {phase = Restarting} -> Console.putStrLn "Restarting..."
             Right BuildState {phase = BuildComplete _ postBuild}
+                | Tests.anyRunningTests postBuild.testSuites && Eval.anyRunningComments postBuild.evalComments ->
+                    Console.putStrLn "Testing and evaluating comments..."
                 | Tests.anyRunningTests postBuild.testSuites -> Console.putStrLn "Testing..."
+                | Eval.anyRunningComments postBuild.evalComments -> Console.putStrLn "Evaluating comments..."
                 | otherwise -> pure ()
             Right BuildState {phase = BuildFailed _} -> pure ()
             Left _ -> pure ()
@@ -101,34 +105,44 @@ showStatus opts = do
         Building _ -> Console.putStrLn "Building..."
         Restarting -> Console.putStrLn "Restarting..."
         BuildFailed msg -> reportBuildFailed msg
-        BuildComplete result postBuild
-            | Tests.anyRunningTests postBuild.testSuites -> Console.putStrLn "Testing..."
-            | otherwise -> do
-                tz <- currentTimeZone
-                case expand of
-                    Just n ->
-                        case result.diagnostics !!? (n - 1) of
-                            Nothing ->
-                                Console.putTextLn
-                                    $ "No diagnostic #"
-                                        <> show n
-                                        <> " (current build has "
-                                        <> show (length result.diagnostics)
-                                        <> ")"
-                            Just d -> do
-                                Console.putTextLn $ diagnosticLineIndexed n d
-                                Console.putText d.text
-                    Nothing -> do
-                        let printDiag (i, d) = case verbosity of
-                                Verbose -> do
-                                    Console.putTextLn $ diagnosticLineIndexed i d
-                                    Console.putText d.text
-                                Concise ->
-                                    Console.putTextLn $ diagnosticLineIndexed i d
-                        mapM_ printDiag (zip [1 ..] result.diagnostics)
-                        Console.putTextLn $ buildSummary tz result
-                        mapM_ (uncurry (printTestRun verbosity)) $ Map.toList postBuild.testSuites.getSuites
-                        when (buildHasErrors result || Tests.hasFailedTests postBuild.testSuites) exitFailure
+        BuildComplete result postBuild ->
+            let
+                testsRunning = Tests.anyRunningTests postBuild.testSuites
+                commentsEvaluating = Eval.anyRunningComments postBuild.evalComments
+            in
+                if
+                    | testsRunning && commentsEvaluating ->
+                        Console.putStrLn "Testing and evaluating comments..."
+                    | testsRunning ->
+                        Console.putStrLn "Testing..."
+                    | commentsEvaluating ->
+                        Console.putStrLn "Evaluating comments..."
+                    | otherwise -> do
+                        tz <- currentTimeZone
+                        case expand of
+                            Just n ->
+                                case result.diagnostics !!? (n - 1) of
+                                    Nothing ->
+                                        Console.putTextLn
+                                            $ "No diagnostic #"
+                                                <> show n
+                                                <> " (current build has "
+                                                <> show (length result.diagnostics)
+                                                <> ")"
+                                    Just d -> do
+                                        Console.putTextLn $ diagnosticLineIndexed n d
+                                        Console.putText d.text
+                            Nothing -> do
+                                let printDiag (i, d) = case verbosity of
+                                        Verbose -> do
+                                            Console.putTextLn $ diagnosticLineIndexed i d
+                                            Console.putText d.text
+                                        Concise ->
+                                            Console.putTextLn $ diagnosticLineIndexed i d
+                                mapM_ printDiag (zip [1 ..] result.diagnostics)
+                                Console.putTextLn $ buildSummary tz result
+                                mapM_ (uncurry (printTestRun verbosity)) $ Map.toList postBuild.testSuites.getSuites
+                                when (buildHasErrors result || Tests.hasFailedTests postBuild.testSuites) exitFailure
 
     printTestRun verbosity tgt tr = do
         Console.putTextLn $ case tr of

--- a/tricorder/src/Tricorder/Daemon/Main.hs
+++ b/tricorder/src/Tricorder/Daemon/Main.hs
@@ -31,6 +31,7 @@ import Tricorder.BuildState (BuildId (..), runDaemonInfo)
 import Tricorder.Config (restartOnConfigChange, runLoadedConfig)
 import Tricorder.Effects.BuildStore (runBuildStore)
 import Tricorder.Effects.Cabal (runCabalIO)
+import Tricorder.Effects.EvalCommentRunner (runEvalCommentRunnerIO)
 import Tricorder.Effects.GhcPkg (runGhcPkgIO)
 import Tricorder.Effects.GhciSession (runGhciSession)
 import Tricorder.Effects.Logging (runLogging)
@@ -95,6 +96,7 @@ main =
         . runEnv
         . runMetricsServerIO
         . runTestRunnerIO
+        . runEvalCommentRunnerIO
         . runGhcPkgIO
         . runUnixSocketIO
         . runGhciSession

--- a/tricorder/src/Tricorder/Effects/BuildStore.hs
+++ b/tricorder/src/Tricorder/Effects/BuildStore.hs
@@ -35,6 +35,7 @@ import Tricorder.BuildState
     , initialBuildState
     )
 
+import Tricorder.BuildState.EvalComments qualified as Eval
 import Tricorder.BuildState.Test qualified as Test
 
 
@@ -99,7 +100,9 @@ isBuilding :: BuildState -> Bool
 isBuilding s = case s.phase of
     Building _ -> True
     Restarting -> True
-    BuildComplete _ postBuild -> Test.anyRunningTests postBuild.testSuites
+    BuildComplete _ postBuild ->
+        Test.anyRunningTests postBuild.testSuites
+            || Eval.anyRunningComments postBuild.evalComments
     BuildFailed _ -> False
 
 

--- a/tricorder/src/Tricorder/Effects/EvalCommentRunner.hs
+++ b/tricorder/src/Tricorder/Effects/EvalCommentRunner.hs
@@ -1,0 +1,209 @@
+module Tricorder.Effects.EvalCommentRunner
+    ( -- * Effect
+      EvalCommentRunner (..)
+    , evaluateComments
+    , findEvalCommentsInModules
+    , interruptCurrent
+    , resetAbort
+    , isAborted
+
+      -- * Interpreters
+    , runEvalCommentRunnerIO
+    , runEvalCommentRunnerNoOp
+    ) where
+
+import Atelier.Effects.Conc (Conc)
+import Atelier.Effects.File (File)
+import Atelier.Effects.FileSystem (FileSystem, readFileBs)
+import Atelier.Effects.Log (Log)
+import Atelier.Effects.Process (Process)
+import Atelier.Effects.Timeout (Timeout)
+import Control.Concurrent.STM (TVar, readTVar, writeTVar)
+import Data.Default (def)
+import Data.Text.Encoding (decodeUtf8Lenient)
+import Data.Traversable (for)
+import Effectful (Effect)
+import Effectful.Concurrent (Concurrent)
+import Effectful.Concurrent.STM (atomically, newTVarIO)
+import Effectful.Dispatch.Dynamic (interpretWith_, interpret_)
+import Effectful.Exception (bracket_, trySync)
+import Effectful.Reader.Static (Reader, ask)
+import Effectful.TH (makeEffect)
+
+import Atelier.Effects.Log qualified as Log
+import Data.Map.Strict qualified as Map
+import Data.Text qualified as T
+
+import Tricorder.Effects.GhciSession.GhciParser (LoadedModule (..))
+import Tricorder.Effects.GhciSession.GhciProcess
+    ( GhciProcess
+    , execGhci
+    , terminateGhciProcess
+    , withGhciProcess
+    )
+import Tricorder.Effects.SessionStore (SessionStore)
+import Tricorder.Runtime (ProjectRoot (..))
+import Tricorder.Session (Command, Session (..))
+
+import Tricorder.BuildState.EvalComments qualified as Eval
+import Tricorder.Effects.SessionStore qualified as SessionStore
+
+
+data EvalCommentRunner :: Effect where
+    -- | Scan all loaded source files for eval comments and evaluate them, each
+    -- in a fresh GHCi session started in that file's module context.
+    EvaluateComments
+        :: Map FilePath (LoadedModule, NonEmpty Eval.Comment)
+        -> EvalCommentRunner m [Eval.Evaluation]
+    FindEvalCommentsInModules
+        :: Map FilePath LoadedModule
+        -> EvalCommentRunner m (Map FilePath (LoadedModule, NonEmpty Eval.Comment))
+    -- | Terminate the GHCi process currently running an eval (if any) and
+    -- latch the abort flag so that subsequent per-file evaluations
+    -- short-circuit until 'ResetAbort' is called.
+    InterruptCurrent :: EvalCommentRunner m ()
+    -- | Clear the abort flag. Call this at the start of a new eval run.
+    ResetAbort :: EvalCommentRunner m ()
+    -- | Read the abort flag without clearing it.
+    IsAborted :: EvalCommentRunner m Bool
+
+
+makeEffect ''EvalCommentRunner
+
+
+-- | Production interpreter: spawns one short-lived @cabal repl@ session per
+-- source file that contains at least one eval comment, then runs each
+-- eval comment in that module's context.
+runEvalCommentRunnerIO
+    :: ( Conc :> es
+       , Concurrent :> es
+       , File :> es
+       , FileSystem :> es
+       , Log :> es
+       , Process :> es
+       , Reader ProjectRoot :> es
+       , SessionStore :> es
+       , Timeout :> es
+       )
+    => Eff (EvalCommentRunner : es) a -> Eff es a
+runEvalCommentRunnerIO act = do
+    currentProcRef <- newTVarIO (Nothing :: Maybe GhciProcess)
+    abortedRef <- newTVarIO False
+    interpretWith_ act \case
+        InterruptCurrent -> do
+            mProc <- atomically do
+                writeTVar abortedRef True
+                readTVar currentProcRef
+            for_ mProc terminateGhciProcess
+        ResetAbort -> atomically (writeTVar abortedRef False)
+        IsAborted -> atomically (readTVar abortedRef)
+        FindEvalCommentsInModules loadedModules -> do
+            Map.fromList . concat <$> for (Map.toList loadedModules) \(absPath, lm) -> do
+                fileResult <- trySync $ readFileBs absPath
+                pure $ case fileResult of
+                    Left _ -> []
+                    Right bs ->
+                        case Eval.findComments $ decodeUtf8Lenient bs of
+                            [] -> []
+                            x : xs -> [(absPath, (lm, x :| xs))]
+        EvaluateComments modulesWithComments -> do
+            ProjectRoot projectRoot <- ask
+            session <- SessionStore.get
+            let go [] acc = pure acc
+                go ((absPath, (lm, comments)) : rest) acc = do
+                    aborted <- atomically (readTVar abortedRef)
+                    if aborted then
+                        pure acc
+                    else do
+                        res <- runFileEvals currentProcRef session.command projectRoot absPath lm.relPath lm.moduleName comments
+                        abortedNow <- atomically (readTVar abortedRef)
+                        if abortedNow then
+                            pure acc
+                        else
+                            go rest (acc <> toList res)
+            go (Map.toList modulesWithComments) []
+
+
+-- | Inert interpreter for testing: always returns empty results.
+runEvalCommentRunnerNoOp :: Eff (EvalCommentRunner : es) a -> Eff es a
+runEvalCommentRunnerNoOp = interpret_ \case
+    EvaluateComments _ -> pure []
+    FindEvalCommentsInModules _ -> pure Map.empty
+    InterruptCurrent -> pure ()
+    ResetAbort -> pure ()
+    IsAborted -> pure False
+
+
+-- ---------------------------------------------------------------------------
+-- Internal helpers
+
+-- | Spawn a fresh @cabal repl@ session for one source file and run all of its
+-- eval comments in that module's context. Returns an 'Evaluation' for each
+-- comment; on session startup failure returns a single error evaluation.
+--
+-- The process is registered in @currentProcRef@ as soon as @cabal repl@ has
+-- it running (before the initial compile drain), so that a concurrent
+-- 'InterruptCurrent' can terminate it promptly.
+runFileEvals
+    :: ( Conc :> es
+       , Concurrent :> es
+       , File :> es
+       , Log :> es
+       , Process :> es
+       , Timeout :> es
+       )
+    => TVar (Maybe GhciProcess)
+    -> Command
+    -> FilePath
+    -- ^ Project root (working directory for the GHCi process).
+    -> FilePath
+    -- ^ Absolute path to the source file (for logging and error results).
+    -> FilePath
+    -- ^ Relative path to the source file (stored in results).
+    -> Text
+    -- ^ Module name (e.g. @"Tricorder.Builder"@), used to load the module
+    -- in interpreted mode so that its full local scope is available.
+    -> NonEmpty Eval.Comment
+    -> Eff es (NonEmpty Eval.Evaluation)
+runFileEvals currentProcRef cmd projectRoot absPath relPath moduleName comments = do
+    let noProgress = \_ -> pure ()
+        wrapForGhci expr
+            | T.elem '\n' expr = ":{" <> "\n" <> expr <> "\n" <> ":}"
+            | otherwise = expr
+        onReady ghci = atomically (writeTVar currentProcRef (Just ghci))
+    sessionResult <- trySync
+        $ bracket_
+            (pure ())
+            (atomically (writeTVar currentProcRef Nothing))
+        $ withGhciProcess def cmd projectRoot noProgress onReady \ghci _ -> do
+            _ <- execGhci ghci (":load *" <> moduleName) noProgress
+            for comments \comment -> do
+                outputResult <- trySync $ execGhci ghci (wrapForGhci comment.expression) noProgress
+                pure
+                    Eval.Evaluation
+                        { file = relPath
+                        , comment
+                        , state = Eval.Completed $ case outputResult of
+                            Left ex -> "error: " <> toText (displayException ex)
+                            Right ls -> T.unlines ls
+                        }
+    case sessionResult of
+        Left ex -> do
+            let errMsg =
+                    "EvalRunner: session startup failed for "
+                        <> toText absPath
+                        <> ": "
+                        <> toText (displayException ex)
+            Log.warn errMsg
+            pure
+                $ Eval.Evaluation
+                    { file = relPath
+                    , comment =
+                        Eval.Comment
+                            { lineNumber = 0
+                            , expression = "<no expression>"
+                            }
+                    , state = Eval.Completed errMsg
+                    }
+                    :| []
+        Right results -> pure results

--- a/tricorder/src/Tricorder/Effects/PostBuildStore.hs
+++ b/tricorder/src/Tricorder/Effects/PostBuildStore.hs
@@ -16,7 +16,6 @@ import Effectful.Writer.Static.Shared (Writer, tell)
 import Tricorder.BuildState (BuildPhase (..), BuildResult, BuildState (..), PostBuild (..))
 import Tricorder.Effects.BuildStore (BuildStore)
 
-import Tricorder.BuildState.Test qualified as Test
 import Tricorder.Effects.BuildStore qualified as BuildStore
 
 
@@ -44,7 +43,12 @@ runPostBuildStore initialBuildResult = do
                 BuildComplete buildResult postBuild ->
                     BuildComplete buildResult $ f postBuild
                 _ ->
-                    BuildComplete initialBuildResult $ f $ PostBuild $ Test.Suites mempty
+                    BuildComplete initialBuildResult
+                        $ f
+                        $ PostBuild
+                            { testSuites = mempty
+                            , evalComments = mempty
+                            }
 
 
 runPostBuildState :: (State PostBuild :> es) => Eff (PostBuildStore : es) a -> Eff es a

--- a/tricorder/src/Tricorder/Socket/Server.hs
+++ b/tricorder/src/Tricorder/Socket/Server.hs
@@ -50,6 +50,7 @@ import Tricorder.Socket.Protocol
 import Tricorder.SourceLookup (ModuleName, ModuleSourceResult, PackageId, lookupModuleSource)
 import Tricorder.Version (VersionMismatch (..), checkVersion)
 
+import Tricorder.BuildState.EvalComments qualified as Eval
 import Tricorder.BuildState.Test qualified as Test
 import Tricorder.Effects.BuildStore qualified as BuildStore
 
@@ -206,26 +207,24 @@ respondWhenDone h = awaitResult >>= sendJson h
   where
     awaitResult = do
         s <- getState
-        case s.phase of
-            Building _ -> waitUntilDone
-            Restarting -> waitUntilDone
-            BuildComplete _ postBuild
-                | Test.anyRunningTests postBuild.testSuites -> waitUntilDone
-                | otherwise -> awaitBuildStart (5 :: Int) s
-            BuildFailed _ -> pure s
+        waitOrStart s (awaitBuildStart (5 :: Int) s) s.phase
 
     -- Poll up to n × 50ms for a build to start, then wait for it to finish.
     awaitBuildStart 0 s = pure s
     awaitBuildStart n _ = do
         wait (50 :: Millisecond)
         s' <- getState
-        case s'.phase of
-            Building _ -> waitUntilDone
-            Restarting -> waitUntilDone
-            BuildComplete _ postBuild
-                | Test.anyRunningTests postBuild.testSuites -> waitUntilDone
-                | otherwise -> awaitBuildStart (n - 1) s'
-            BuildFailed _ -> pure s'
+        waitOrStart s' (awaitBuildStart (n - 1) s') s'.phase
+
+    waitOrStart s start = \case
+        Building _ -> waitUntilDone
+        Restarting -> waitUntilDone
+        BuildComplete _ postBuild
+            | Test.anyRunningTests postBuild.testSuites
+                || Eval.anyRunningComments postBuild.evalComments ->
+                waitUntilDone
+            | otherwise -> start
+        BuildFailed _ -> pure s
 
 
 -- | Stream a JSON object after each state change (loops until handle closes or error).
@@ -246,7 +245,7 @@ respondDiagnostic idx h = do
     state <- getState
     case state.phase of
         BuildComplete result postBuild
-            | not $ Test.anyRunningTests postBuild.testSuites ->
+            | not $ Test.anyRunningTests postBuild.testSuites && Eval.anyRunningComments postBuild.evalComments ->
                 case result.diagnostics !!? (idx - 1) of
                     Nothing ->
                         sendJson h

--- a/tricorder/src/Tricorder/UI/Keys.hs
+++ b/tricorder/src/Tricorder/UI/Keys.hs
@@ -79,6 +79,7 @@ data KeyEvent
     = ToggleDaemonInfoView
     | ToggleHelp
     | CycleTestView
+    | ToggleEvalComments
     | RestartDaemon
     | ExitView
     | ScrollUp
@@ -105,6 +106,7 @@ keys =
         [ ("toggle daemon info", ToggleDaemonInfoView)
         , ("toggle help", ToggleHelp)
         , ("cycle test view", CycleTestView)
+        , ("toggle eval comments", ToggleEvalComments)
         , ("restart daemon", RestartDaemon)
         , ("exit view", ExitView)
         , ("scroll up", ScrollUp)
@@ -118,6 +120,7 @@ bindings =
     [ (ToggleDaemonInfoView, [bind 'g'])
     , (ToggleHelp, [bind 'h'])
     , (CycleTestView, [bind 't'])
+    , (ToggleEvalComments, [bind 'e'])
     , (RestartDaemon, [bind 'R'])
     , (ExitView, [binding KEsc []])
     , (ScrollUp, [binding KUp []])
@@ -197,6 +200,12 @@ dispatcher requestRestart cfg =
                         else
                             s {testFilter = cycleTestFilter s.testFilter}
                     _ -> navigate Route.Tests s
+            , onEvent ToggleEvalComments "Toggle eval comments view" do
+                modify \s ->
+                    if currentRoute s == Route.Evals then
+                        navigate Route.Main s
+                    else
+                        navigate Route.Evals s
             , onEvent RestartDaemon "Restart the daemon" do
                 liftIO requestRestart
                 modify \s -> s {buildState = Waiting}
@@ -252,3 +261,4 @@ keybindForRoute kc = \case
     Route.DaemonInfo -> firstActiveBinding kc ToggleDaemonInfoView
     Route.Help -> firstActiveBinding kc ToggleHelp
     Route.Tests -> firstActiveBinding kc CycleTestView
+    Route.Evals -> firstActiveBinding kc ToggleEvalComments

--- a/tricorder/src/Tricorder/UI/Route.hs
+++ b/tricorder/src/Tricorder/UI/Route.hs
@@ -9,6 +9,7 @@ data Route
     | Help
     | DaemonInfo
     | Tests
+    | Evals
     deriving stock (Bounded, Enum, Eq)
 
 
@@ -18,3 +19,4 @@ name = \case
     Help -> "Help"
     DaemonInfo -> "Daemon info"
     Tests -> "Tests"
+    Evals -> "Eval comments"

--- a/tricorder/src/Tricorder/UI/State.hs
+++ b/tricorder/src/Tricorder/UI/State.hs
@@ -25,6 +25,7 @@ data Viewports
     = MainViewport
     | DiagnosticViewport
     | TestViewport
+    | EvalResultsViewport
     deriving stock (Eq, Ord, Show)
 
 

--- a/tricorder/src/Tricorder/UI/View.hs
+++ b/tricorder/src/Tricorder/UI/View.hs
@@ -44,6 +44,7 @@ import Tricorder.BuildState
     , Severity (..)
     )
 import Tricorder.BuildState.BuildProgress (BuildProgress (..))
+import Tricorder.BuildState.EvalComments (Comment (..))
 import Tricorder.Session (Target, TestTarget, renderTarget, renderTestTarget)
 import Tricorder.TestOutput (stripGhciNoise)
 import Tricorder.UI.Keys (KeyEvent, keybindForRoute, viewKeybindings)
@@ -51,6 +52,7 @@ import Tricorder.UI.Misc (emphasis, err, hBoxSpaced, ok, subtle, vBoxSpaced, war
 import Tricorder.UI.Route (Route)
 import Tricorder.UI.State (Processed (..), State (..), TestFilter (..), Viewports (..), currentRoute)
 
+import Tricorder.BuildState.EvalComments qualified as Eval
 import Tricorder.BuildState.Test qualified as Test
 import Tricorder.UI.Keys qualified as Keys
 import Tricorder.UI.Route qualified as Route
@@ -88,6 +90,8 @@ view kc ws =
                 viewTests ws
             Route.Main ->
                 viewMain ws
+            Route.Evals ->
+                viewEvals ws
         ]
     ]
 
@@ -116,6 +120,11 @@ viewDaemonInfo ws =
 viewTests :: State -> Widget Viewports
 viewTests ws =
     withBuildState ws (viewTestResultsPanel ws)
+
+
+viewEvals :: State -> Widget Viewports
+viewEvals ws =
+    withBuildState ws $ viewEvalCommentsPanel ws
 
 
 viewMain :: State -> Widget Viewports
@@ -161,6 +170,7 @@ viewHeading ws = case currentRoute ws of
     Route.Help -> Just "Help"
     Route.DaemonInfo -> Just "Daemon info"
     Route.Main -> Nothing
+    Route.Evals -> Just "Eval comments"
 
 
 viewDefaultPanel :: TimeZone -> BuildState -> Widget Viewports
@@ -174,6 +184,45 @@ viewTestResultsPanel ws bs =
         [ viewBuildPhaseLine ws.timeZone bs.phase
         , viewTestPanel ws.testFilter (phaseTestRuns bs.phase)
         ]
+
+
+viewEvalCommentsPanel :: State -> BuildState -> Widget Viewports
+viewEvalCommentsPanel ws bs =
+    vBoxSpaced
+        1
+        [ viewBuildPhaseLine ws.timeZone bs.phase
+        , case bs.phase of
+            BuildComplete _ postBuild -> viewEvalComments postBuild.evalComments
+            _ -> txt "Waiting for build..."
+        ]
+
+
+viewEvalComments :: Eval.Comments -> Widget Viewports
+viewEvalComments (Eval.Comments []) =
+    txt "No eval comments detected"
+viewEvalComments (Eval.Comments results) =
+    vScrollViewport EvalResultsViewport $ vBoxSpaced 1 $ viewEvaluation <$> results
+
+
+viewEvaluation :: Eval.Evaluation -> Widget n
+viewEvaluation evaluation =
+    vBox
+        $ [ hBoxSpaced
+                1
+                [ subtle $ txt "File:"
+                , txt $ toText evaluation.file <> ":" <> show evaluation.comment.lineNumber
+                ]
+          , subtle $ txt "Expression:"
+          , txt evaluation.comment.expression
+          ]
+            <> case evaluation.state of
+                Eval.Completed output ->
+                    [ subtle $ txt "Result:"
+                    , vBox $ txt <$> T.lines output
+                    ]
+                Eval.Pending ->
+                    [ subtle $ txt "Running..."
+                    ]
 
 
 viewExpandedDaemonInfo :: DaemonInfo -> Widget n
@@ -270,18 +319,17 @@ viewBuildFailed :: Text -> Widget Viewports
 viewBuildFailed msg =
     vBox
         [ err $ txt "Build command failed"
-        , vScrollViewport DiagnosticViewport (txtWrap <$> T.lines msg)
+        , vScrollViewport DiagnosticViewport (vBox $ txtWrap <$> T.lines msg)
         ]
 
 
 -- | A vertically-scrollable viewport with clickable scrollbars on the right.
-vScrollViewport :: Viewports -> [Widget Viewports] -> Widget Viewports
-vScrollViewport vp children =
+vScrollViewport :: (Ord vp, Show vp) => vp -> Widget vp -> Widget vp
+vScrollViewport vp =
     withClickableVScrollBars (\_ _ -> vp)
-        $ withVScrollBarHandles
-        $ withVScrollBars OnRight
-        $ viewport vp Vertical
-        $ vBox children
+        . withVScrollBarHandles
+        . withVScrollBars OnRight
+        . viewport vp Vertical
 
 
 viewBuildResult :: TimeZone -> BuildResult -> Widget Viewports
@@ -310,7 +358,7 @@ viewBuildResult tz result
                     , viewDuration result.duration
                     , viewTimestamp tz result.completedAt
                     ]
-                , vScrollViewport DiagnosticViewport (viewDiagnostic <$> msgs)
+                , vScrollViewport DiagnosticViewport $ vBox $ viewDiagnostic <$> msgs
                 ]
 
 
@@ -442,7 +490,9 @@ viewTestPanel tvf suites
 
 scrollableRuns :: TestFilter -> Test.Suites -> Widget Viewports
 scrollableRuns tvf suites =
-    vScrollViewport TestViewport (uncurry (viewTestRunDetail tvf) <$> Map.toList suites.getSuites)
+    vScrollViewport TestViewport
+        $ vBox
+        $ uncurry (viewTestRunDetail tvf) <$> Map.toList suites.getSuites
 
 
 viewTestRunDetail :: TestFilter -> TestTarget -> Test.Suite -> Widget n

--- a/tricorder/test/Unit/Tricorder/BuildState/EvalCommentsSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuildState/EvalCommentsSpec.hs
@@ -1,0 +1,177 @@
+module Unit.Tricorder.BuildState.EvalCommentsSpec (spec_EvalComments) where
+
+import Test.Hspec (Spec, describe, it, shouldBe, shouldMatchList, shouldSatisfy)
+import Text.Megaparsec (parse)
+
+import Tricorder.BuildState.EvalComments qualified as Eval
+
+
+spec_EvalComments :: Spec
+spec_EvalComments = do
+    describe "singleLineEvalCommentP" testSingleLine
+    describe "multiLineEvalCommentP" testMultiLine
+    describe "blockCommentEvalP" testBlockComment
+    describe "findComments" testFindComments
+
+
+--------------------------------------------------------------------------------
+-- singleLineEvalCommentP
+--------------------------------------------------------------------------------
+
+testSingleLine :: Spec
+testSingleLine = do
+    it "parses a basic expression" do
+        parse Eval.singleLineEvalCommentP "" "-- $> 1 + 2"
+            `shouldBe` Right Eval.Comment {lineNumber = 1, expression = "1 + 2"}
+
+    it "handles no space between marker and expression" do
+        parse Eval.singleLineEvalCommentP "" "-- $>expr"
+            `shouldBe` Right Eval.Comment {lineNumber = 1, expression = "expr"}
+
+    it "strips leading whitespace from the expression" do
+        parse Eval.singleLineEvalCommentP "" "-- $>   expr"
+            `shouldBe` Right Eval.Comment {lineNumber = 1, expression = "expr"}
+
+    it "captures the full expression including inner spaces" do
+        parse Eval.singleLineEvalCommentP "" "-- $> foo bar baz"
+            `shouldBe` Right Eval.Comment {lineNumber = 1, expression = "foo bar baz"}
+
+    it "stops at a newline, not consuming it" do
+        parse Eval.singleLineEvalCommentP "" "-- $> expr\nnext line"
+            `shouldBe` Right Eval.Comment {lineNumber = 1, expression = "expr"}
+
+    it "fails when there is no expression after the marker" do
+        parse Eval.singleLineEvalCommentP "" "-- $>" `shouldSatisfy` isLeft
+
+    it "fails on the multi-line opening marker" do
+        parse Eval.singleLineEvalCommentP "" "-- $$> expr -- <$$" `shouldSatisfy` isLeft
+
+    it "fails on other text between comment start and eval marker" do
+        parse Eval.singleLineEvalCommentP "" "-- foo $> 1 + 2" `shouldSatisfy` isLeft
+
+    it "fails on unrelated text" do
+        parse Eval.singleLineEvalCommentP "" "hello world" `shouldSatisfy` isLeft
+
+
+--------------------------------------------------------------------------------
+-- multiLineEvalCommentP
+--------------------------------------------------------------------------------
+
+testMultiLine :: Spec
+testMultiLine = do
+    it "parses a single content line, stripping the -- prefix" do
+        parse Eval.multiLineEvalCommentP "" "-- $$>\n-- expr\n-- <$$"
+            `shouldBe` Right Eval.Comment {lineNumber = 1, expression = "expr"}
+
+    it "parses multiple content lines, stripping -- prefixes" do
+        parse Eval.multiLineEvalCommentP "" "-- $$>\n-- foo\n-- bar\n-- <$$"
+            `shouldBe` Right Eval.Comment {lineNumber = 1, expression = "foo\nbar"}
+
+    it "preserves relative indentation after stripping -- prefix" do
+        parse Eval.multiLineEvalCommentP "" "-- $$>\n-- let x = 1\n--     y = 2\n-- in x + y\n-- <$$"
+            `shouldBe` Right Eval.Comment {lineNumber = 1, expression = "let x = 1\n    y = 2\nin x + y"}
+
+    it "handles -- with no trailing space" do
+        parse Eval.multiLineEvalCommentP "" "-- $$>\n--expr\n-- <$$"
+            `shouldBe` Right Eval.Comment {lineNumber = 1, expression = "expr"}
+
+    it "parse multi-line eval comment in a single line" do
+        parse Eval.multiLineEvalCommentP "" "-- $$> expr <$$"
+            `shouldBe` Right Eval.Comment {lineNumber = 1, expression = "expr"}
+
+    it "fails when the closing marker is absent" do
+        parse Eval.multiLineEvalCommentP "" "-- $$>\n-- expr" `shouldSatisfy` isLeft
+
+    it "fails on the single-line marker" do
+        parse Eval.multiLineEvalCommentP "" "-- $> expr" `shouldSatisfy` isLeft
+
+    it "fails on unrelated text" do
+        parse Eval.multiLineEvalCommentP "" "hello world" `shouldSatisfy` isLeft
+
+
+--------------------------------------------------------------------------------
+-- blockCommentEvalP
+--------------------------------------------------------------------------------
+
+testBlockComment :: Spec
+testBlockComment = do
+    it "parses a single-line expression on its own line" do
+        parse Eval.blockCommentEvalP "" "{- $$>\n2 + 2\n<$$ -}"
+            `shouldBe` Right Eval.Comment {lineNumber = 1, expression = "2 + 2"}
+
+    it "parses an inline one-liner" do
+        parse Eval.blockCommentEvalP "" "{- $$> 2 + 2 <$$ -}"
+            `shouldBe` Right Eval.Comment {lineNumber = 1, expression = "2 + 2"}
+
+    it "parses a multi-line expression preserving layout" do
+        parse Eval.blockCommentEvalP "" "{- $$>\nlet x = 1\n    y = 2\nin x + y\n<$$ -}"
+            `shouldBe` Right Eval.Comment {lineNumber = 1, expression = "let x = 1\n    y = 2\nin x + y"}
+
+    it "fails when the closing marker is absent" do
+        parse Eval.blockCommentEvalP "" "{- $$>\nexpr" `shouldSatisfy` isLeft
+
+    it "fails on the line-comment multi-line eval marker" do
+        parse Eval.blockCommentEvalP "" "-- $$> expr" `shouldSatisfy` isLeft
+
+    it "fails on the single-line eval marker" do
+        parse Eval.blockCommentEvalP "" "{- $> expr -}" `shouldSatisfy` isLeft
+
+    it "fails on unrelated text" do
+        parse Eval.blockCommentEvalP "" "hello world" `shouldSatisfy` isLeft
+
+
+--------------------------------------------------------------------------------
+-- findComments
+--------------------------------------------------------------------------------
+
+testFindComments :: Spec
+testFindComments = do
+    it "returns empty list for empty text" do
+        Eval.findComments "" `shouldMatchList` []
+
+    it "returns empty list when there are no eval comments" do
+        Eval.findComments "hello world\nno comments here" `shouldMatchList` []
+
+    it "finds a single single-line eval comment" do
+        Eval.findComments "x = 1\n-- $> x\ny = 2"
+            `shouldMatchList` [Eval.Comment {lineNumber = 2, expression = "x"}]
+
+    it "finds multiple single-line eval comments in source order" do
+        Eval.findComments "-- $> a\n-- $> b"
+            `shouldMatchList` [ Eval.Comment {lineNumber = 1, expression = "a"}
+                              , Eval.Comment {lineNumber = 2, expression = "b"}
+                              ]
+
+    it "reports correct line numbers" do
+        Eval.findComments "line1\nline2\n-- $> expr\nline4"
+            `shouldMatchList` [Eval.Comment {lineNumber = 3, expression = "expr"}]
+
+    it "ignores lines that look like partial markers" do
+        Eval.findComments "-- $\n-- $> expr"
+            `shouldMatchList` [Eval.Comment {lineNumber = 2, expression = "expr"}]
+
+    it "does not match an eval marker embedded in another comment" do
+        Eval.findComments "-- foo -- $> expr" `shouldMatchList` []
+
+    it "does not match an inline eval marker appearing after code" do
+        Eval.findComments "x = 1  -- $> x" `shouldMatchList` []
+
+    it "finds a multi-line eval comment, stripping -- prefixes" do
+        Eval.findComments "-- $$>\n-- expr\n-- <$$"
+            `shouldMatchList` [Eval.Comment {lineNumber = 1, expression = "expr"}]
+
+    it "finds a block comment eval" do
+        Eval.findComments "{- $$>\nexpr\n<$$ -}"
+            `shouldMatchList` [Eval.Comment {lineNumber = 1, expression = "expr"}]
+
+    it "finds both single-line and multi-line eval comments" do
+        Eval.findComments "-- $> a\n-- $$>\n-- b\n-- <$$"
+            `shouldMatchList` [ Eval.Comment {lineNumber = 1, expression = "a"}
+                              , Eval.Comment {lineNumber = 2, expression = "b"}
+                              ]
+
+    it "finds both single-line and block comment eval comments" do
+        Eval.findComments "-- $> a\n{- $$>\nb\n<$$ -}"
+            `shouldMatchList` [ Eval.Comment {lineNumber = 1, expression = "a"}
+                              , Eval.Comment {lineNumber = 2, expression = "b"}
+                              ]

--- a/tricorder/test/Unit/Tricorder/BuildStateSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuildStateSpec.hs
@@ -15,8 +15,6 @@ import Tricorder.BuildState
     , Severity (..)
     )
 
-import Tricorder.BuildState.Test qualified as Test
-
 
 spec_BuildState :: Spec
 spec_BuildState = do
@@ -94,8 +92,7 @@ mkBuildState msgs =
                     , diagnostics = msgs
                     }
                 )
-                $ PostBuild
-                $ Test.Suites mempty
+                $ PostBuild mempty mempty
         , daemonInfo =
             DaemonInfo
                 { targets = []

--- a/tricorder/test/Unit/Tricorder/BuilderSpec.hs
+++ b/tricorder/test/Unit/Tricorder/BuilderSpec.hs
@@ -65,6 +65,7 @@ import Tricorder.Builder.Dispatch
     , mergeDiagnostics
     , preserveFailureVisibility
     )
+import Tricorder.Effects.EvalCommentRunner (runEvalCommentRunnerNoOp)
 import Tricorder.Effects.GhciSession
     ( Controls (..)
     , LoadResult (..)
@@ -211,6 +212,7 @@ testBuildWithGhciRecovery = do
             . execWriter @[EnteringNewPhase]
             . runBuildStoreCapture
             . runTestRunnerScripted []
+            . runEvalCommentRunnerNoOp
             . runGhciSessionScripted script
             . runPubSub @SourceChangeDetected
             . runConc
@@ -229,18 +231,26 @@ testReloadOnSourceChange :: Spec
 testReloadOnSourceChange = do
     describe "Modified" do
         describe "when the file is loaded in GHCi" do
-            it "transitions through Building then Done" do
+            it "transitions through Building then BuildComplete" do
                 phases <- runTest knownFoo noTargets distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Modified)
-                phases `shouldBe` flow reloadLr
+                phases `shouldMatchList` flow reloadLr
 
             it "calls controls.reload" do
                 phases <- runTest knownFoo noTargets distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Modified)
-                buildResultsFrom phases `shouldMatchList` [resultFor reloadLr]
+                buildResultsFrom phases
+                    `shouldMatchList` [ resultFor reloadLr
+                                      , resultFor reloadLr
+                                      , resultFor reloadLr
+                                      ]
 
         describe "when the file is not loaded in GHCi" do
             it "calls controls.add (the editor just wrote a new file)" do
                 phases <- runTest Map.empty noTargets distinctCtrls (SourceChangeDetected "/abs/path/New.hs" Modified)
-                buildResultsFrom phases `shouldMatchList` [resultFor addLr]
+                buildResultsFrom phases
+                    `shouldMatchList` [ resultFor addLr
+                                      , resultFor addLr
+                                      , resultFor addLr
+                                      ]
 
         -- Regression test for stale-diagnostics bug: cold-start with a
         -- pre-existing error then fix it. Foo is in :show targets but
@@ -254,7 +264,11 @@ testReloadOnSourceChange = do
                         (KnownTargetNames (Set.singleton "Foo"))
                         distinctCtrls
                         (SourceChangeDetected "/abs/src/Foo.hs" Modified)
-                buildResultsFrom phases `shouldMatchList` [resultFor reloadLr]
+                buildResultsFrom phases
+                    `shouldMatchList` [ resultFor reloadLr
+                                      , resultFor reloadLr
+                                      , resultFor reloadLr
+                                      ]
 
         -- A failed executable 'Main' appears in :show targets only as its
         -- path ("app/Main.hs", since the name 'Main' is ambiguous across home
@@ -267,21 +281,37 @@ testReloadOnSourceChange = do
                         (KnownTargetNames (Set.singleton "app/Main.hs"))
                         distinctCtrls
                         (SourceChangeDetected "/abs/app/Main.hs" Modified)
-                buildResultsFrom phases `shouldMatchList` [resultFor reloadLr]
+                buildResultsFrom phases
+                    `shouldMatchList` [ resultFor reloadLr
+                                      , resultFor reloadLr
+                                      , resultFor reloadLr
+                                      ]
 
     describe "Added" do
         describe "when the file is not loaded" $ it "calls controls.add" do
             phases <- runTest Map.empty noTargets distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Added)
-            buildResultsFrom phases `shouldMatchList` [resultFor addLr]
+            buildResultsFrom phases
+                `shouldMatchList` [ resultFor addLr
+                                  , resultFor addLr
+                                  , resultFor addLr
+                                  ]
 
         describe "when the file is already loaded" $ it "calls controls.reload (re-add is a reload)" do
             phases <- runTest knownFoo noTargets distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Added)
-            buildResultsFrom phases `shouldMatchList` [resultFor reloadLr]
+            buildResultsFrom phases
+                `shouldMatchList` [ resultFor reloadLr
+                                  , resultFor reloadLr
+                                  , resultFor reloadLr
+                                  ]
 
     describe "Removed" do
         describe "when the file is loaded" $ it "calls controls.unadd" do
             phases <- runTest knownFoo noTargets distinctCtrls (SourceChangeDetected "/abs/path/Foo.hs" Removed)
-            buildResultsFrom phases `shouldMatchList` [resultFor unaddLr]
+            buildResultsFrom phases
+                `shouldMatchList` [ resultFor unaddLr
+                                  , resultFor unaddLr
+                                  , resultFor unaddLr
+                                  ]
 
         describe "when the file is not loaded" $ it "is a no-op" do
             phases <- runTest Map.empty noTargets distinctCtrls (SourceChangeDetected "/abs/path/Unknown.hs" Removed)
@@ -314,11 +344,14 @@ testReloadOnSourceChange = do
             . execWriter @[EnteringNewPhase]
             . runBuildStoreCapture
             . runTestRunnerScripted []
+            . runEvalCommentRunnerNoOp
             $ reloadOnSourceChange (def @BuildConfig) ctrls event
 
     flow lr =
         [ EnteringNewPhase (BuildId 1) $ Building Nothing
-        , EnteringNewPhase (BuildId 1) $ BuildComplete (resultFor lr) $ PostBuild $ Test.Suites mempty
+        , EnteringNewPhase (BuildId 1) $ BuildComplete (resultFor lr) $ PostBuild mempty mempty
+        , EnteringNewPhase (BuildId 1) $ BuildComplete (resultFor lr) $ PostBuild mempty mempty
+        , EnteringNewPhase (BuildId 1) $ BuildComplete (resultFor lr) $ PostBuild mempty mempty
         ]
 
     buildResultsFrom phases = [result | EnteringNewPhase _ (BuildComplete result _) <- phases]
@@ -496,7 +529,7 @@ testRunTestsForTargets = do
             runEff
                 . runConcurrent
                 . runLogNoOp
-                . evalState (PostBuild $ Test.Suites mempty)
+                . evalState (PostBuild mempty mempty)
                 . execWriter @[PostBuild]
                 . runPostBuildState
                 . runPostBuildCapture
@@ -505,25 +538,32 @@ testRunTestsForTargets = do
                 $ parseTestTargets ["test:foo", "test:bar"]
         phases
             `shouldMatchList` [ PostBuild
-                                    $ Test.Suites
-                                    $ Map.fromList
-                                        [ (mkTestTarget "test:bar", Test.SuiteRunning Nothing)
-                                        , (mkTestTarget "test:foo", Test.SuiteRunning Nothing)
-                                        ]
+                                    { testSuites =
+                                        Test.Suites
+                                            $ Map.fromList
+                                                [ (mkTestTarget "test:bar", Test.SuiteRunning Nothing)
+                                                , (mkTestTarget "test:foo", Test.SuiteRunning Nothing)
+                                                ]
+                                    , evalComments = mempty
+                                    }
                               ]
   where
     runTest testTargets script =
         runEff
             . runConcurrent
             . runLogNoOp
-            . evalState (PostBuild $ Test.Suites mempty)
+            . evalState (PostBuild mempty mempty)
             . execWriter @[PostBuild]
             . runPostBuildState
             . runPostBuildCapture
             . runTestRunnerScripted script
             $ runTestsForTargets testTargets
 
-    postBuildWithTests = PostBuild . Test.Suites . Map.fromList
+    postBuildWithTests tests =
+        PostBuild
+            { testSuites = Test.Suites $ Map.fromList tests
+            , evalComments = mempty
+            }
 
     suiteCompleted =
         Test.SuiteCompleted
@@ -1101,6 +1141,7 @@ testEventCoalescing = do
                 . runLogNoOp
                 . runBuildStoreWaiterPresent
                 . runTestRunnerScripted []
+                . runEvalCommentRunnerNoOp
                 . runPubSub @SourceChangeDetected
                 . runErrorNoCallStack @StopSignal
                 . runConc
@@ -1181,6 +1222,7 @@ testEventCoalescing = do
                 . runLogNoOp
                 . runBuildStoreWaiterPresent
                 . runTestRunnerScripted []
+                . runEvalCommentRunnerNoOp
                 . runPubSub @SourceChangeDetected
                 . runErrorNoCallStack @StopSignal
                 . runConc
@@ -1258,6 +1300,7 @@ testInterruptCurrent = do
             . runLogNoOp
             . runHasWaitersConst waiterPresent
             . runTestRunnerInterruptCounter trCalled
+            . runEvalCommentRunnerNoOp
             $ Builder.interruptCurrent mockCtrls
         (,)
             <$> STM.atomically (readTVar ctrlsCalled)
@@ -1331,8 +1374,7 @@ completeBuildState =
                     , diagnostics = []
                     }
                 )
-                $ PostBuild
-                $ Test.Suites mempty
+                $ PostBuild mempty mempty
         , daemonInfo = emptyDaemonInfo
         }
 

--- a/tricorder/test/Unit/Tricorder/Effects/BuildStoreSpec.hs
+++ b/tricorder/test/Unit/Tricorder/Effects/BuildStoreSpec.hs
@@ -1,4 +1,4 @@
-module Unit.Tricorder.BuildStoreSpec (spec_BuildStore) where
+module Unit.Tricorder.Effects.BuildStoreSpec (spec_BuildStore) where
 
 import Atelier.Effects.Conc (Conc, runConc)
 import Atelier.Effects.Delay (Delay, runDelay)
@@ -20,7 +20,7 @@ import Tricorder.BuildState
     , PostBuild (..)
     )
 import Tricorder.Effects.BuildStore
-    ( BuildStore
+    ( BuildStore (..)
     , getState
     , runBuildStore
     , runBuildStoreScripted
@@ -28,8 +28,6 @@ import Tricorder.Effects.BuildStore
     , waitForNext
     , waitUntilDone
     )
-
-import Tricorder.BuildState.Test qualified as Test
 
 
 spec_BuildStore :: Spec
@@ -186,8 +184,7 @@ donePhase =
             , diagnostics = []
             }
         )
-        $ PostBuild
-        $ Test.Suites mempty
+        $ PostBuild mempty mempty
 
 
 doneAt :: Int -> BuildState

--- a/tricorder/test/Unit/Tricorder/Effects/PostBuildStoreSpec.hs
+++ b/tricorder/test/Unit/Tricorder/Effects/PostBuildStoreSpec.hs
@@ -1,0 +1,163 @@
+module Unit.Tricorder.Effects.PostBuildStoreSpec (spec_PostBuildStore) where
+
+import Data.Time (UTCTime (..), fromGregorian)
+import Effectful (runPureEff)
+import Effectful.Dispatch.Dynamic (interpret_)
+import Effectful.State.Static.Shared (State, execState, modify)
+import Test.Hspec (Spec, describe, it, shouldBe)
+
+import Tricorder.BuildState
+    ( BuildId (..)
+    , BuildPhase (..)
+    , BuildResult (..)
+    , BuildState (..)
+    , DaemonInfo (..)
+    , PostBuild (..)
+    )
+import Tricorder.Effects.BuildStore (BuildStore (..))
+import Tricorder.Effects.PostBuildStore (runPostBuildStore)
+
+import Tricorder.BuildState.EvalComments qualified as Eval
+import Tricorder.Effects.PostBuildStore qualified as PostBuild
+
+
+spec_PostBuildStore :: Spec
+spec_PostBuildStore = do
+    describe "runPostBuildStore" testRunPostBuildStore
+
+
+testRunPostBuildStore :: Spec
+testRunPostBuildStore = do
+    describe "with BuildComplete build phase" do
+        let runTest = runTest' buildingBuildState
+        describe "modifyPostBuild" do
+            it "updates the build result" do
+                let actualState = runTest $ PostBuild.modifyPostBuild \postBuild ->
+                        postBuild
+                            { evalComments =
+                                Eval.Comments
+                                    $ [ Eval.Evaluation
+                                            { file = "foo"
+                                            , comment = Eval.Comment 0 "expr"
+                                            , state = Eval.Pending
+                                            }
+                                      ]
+                            }
+                actualState
+                    `shouldBe` ( doneBuildState
+                                    { phase =
+                                        BuildComplete
+                                            emptyBuildResult
+                                            PostBuild
+                                                { testSuites = mempty
+                                                , evalComments =
+                                                    Eval.Comments
+                                                        $ [ Eval.Evaluation
+                                                                { file = "foo"
+                                                                , comment = Eval.Comment 0 "expr"
+                                                                , state = Eval.Pending
+                                                                }
+                                                          ]
+                                                }
+                                    }
+                               )
+
+    describe "with non-Done build phase" do
+        let runTest = runTest' buildingBuildState
+        describe "updateBuildResult" do
+            it "sets the build phase to Done and updates the build result from the initial build result" do
+                let actualState = runTest $ PostBuild.modifyPostBuild \postBuild ->
+                        postBuild
+                            { evalComments =
+                                Eval.Comments
+                                    $ [ Eval.Evaluation
+                                            { file = "foo"
+                                            , comment = Eval.Comment 0 "expr"
+                                            , state = Eval.Pending
+                                            }
+                                      ]
+                            }
+                actualState
+                    `shouldBe` ( doneBuildState
+                                    { phase =
+                                        BuildComplete
+                                            emptyBuildResult
+                                            PostBuild
+                                                { testSuites = mempty
+                                                , evalComments =
+                                                    Eval.Comments
+                                                        $ [ Eval.Evaluation
+                                                                { file = "foo"
+                                                                , comment = Eval.Comment 0 "expr"
+                                                                , state = Eval.Pending
+                                                                }
+                                                          ]
+                                                }
+                                    }
+                               )
+  where
+    runTest' initialBuildState =
+        runPureEff
+            . execState initialBuildState
+            . runBuildStoreSimple
+            . runPostBuildStore emptyBuildResult
+    runBuildStoreSimple :: (State BuildState :> es) => Eff (BuildStore : es) a -> Eff es a
+    runBuildStoreSimple = interpret_ \case
+        ModifyPhase f -> modify \s -> s {phase = f s}
+        _ -> error "runBuildStoreSimple: Unsupported operation"
+
+
+buildingBuildState :: BuildState
+buildingBuildState =
+    BuildState
+        { buildId = BuildId 1
+        , phase = Building Nothing
+        , daemonInfo = emptyDaemonInfo
+        }
+
+
+doneBuildState :: BuildState
+doneBuildState =
+    BuildState
+        { buildId = BuildId 1
+        , phase = donePhase
+        , daemonInfo = emptyDaemonInfo
+        }
+
+
+donePhase :: BuildPhase
+donePhase =
+    BuildComplete
+        ( BuildResult
+            { completedAt = epoch
+            , duration = 0
+            , moduleCount = 0
+            , diagnostics = []
+            }
+        )
+        $ PostBuild mempty mempty
+
+
+emptyBuildResult :: BuildResult
+emptyBuildResult =
+    BuildResult
+        { completedAt = epoch
+        , duration = 0
+        , moduleCount = 0
+        , diagnostics = []
+        }
+
+
+emptyDaemonInfo :: DaemonInfo
+emptyDaemonInfo =
+    DaemonInfo
+        { targets = []
+        , watchDirs = []
+        , sockPath = ""
+        , logFile = ""
+        , metricsPort = Nothing
+        }
+
+
+epoch :: UTCTime
+epoch = UTCTime (fromGregorian 1970 1 1) 0

--- a/tricorder/test/Unit/Tricorder/TestRunnerSpec.hs
+++ b/tricorder/test/Unit/Tricorder/TestRunnerSpec.hs
@@ -232,13 +232,13 @@ runScripted results = runEff . runConcurrent . runTestRunnerScripted results
 testAbortGatedProgress :: Spec
 testAbortGatedProgress = do
     it "applies the progress update when abortedRef is False" do
-        finalRuns <- runProgress False progress42 startingRuns
+        finalRuns <- runProgress False progress42 startingSuites
         Map.toList finalRuns.getSuites
             `shouldMatchList` [(mkTestTarget "test:foo", Test.SuiteRunning (Just expected42))]
 
     it "drops the progress update when abortedRef is True" do
-        finalRuns <- runProgress True progress42 startingRuns
-        finalRuns `shouldBe` startingRuns
+        finalRuns <- runProgress True progress42 startingSuites
+        finalRuns `shouldBe` startingSuites
 
     it "drops every update applied while abortedRef stays True" do
         abortedRef <- newTVarIO True
@@ -246,11 +246,11 @@ testAbortGatedProgress = do
         finalRuns <- runStore do
             BuildStore.setPhase (BuildId 1)
                 $ BuildComplete result
-                $ PostBuild startingRuns
+                $ PostBuild startingSuites mempty
 
             for_ loadings $ abortGatedProgress abortedRef $ mkTestTarget "test:foo"
             phaseTestSuites <$> getState
-        finalRuns `shouldBe` startingRuns
+        finalRuns `shouldBe` startingSuites
 
     it "flips behaviour mid-run if abortedRef is set between updates" do
         abortedRef <- newTVarIO False
@@ -258,7 +258,7 @@ testAbortGatedProgress = do
             BuildStore.setPhase
                 (BuildId 1)
                 $ BuildComplete result
-                $ PostBuild startingRuns
+                $ PostBuild startingSuites mempty
 
             -- This one applies.
             abortGatedProgress abortedRef (mkTestTarget "test:foo") (mkLoading 3 10)
@@ -271,16 +271,16 @@ testAbortGatedProgress = do
         Map.toList finalRuns.getSuites
             `shouldMatchList` [(mkTestTarget "test:foo", Test.SuiteRunning (Just BuildProgress {compiled = 3, total = 10}))]
   where
-    startingRuns = Test.Suites $ Map.fromList [(mkTestTarget "test:foo", Test.SuiteRunning Nothing)]
+    startingSuites = Test.Suites $ Map.fromList [(mkTestTarget "test:foo", Test.SuiteRunning Nothing)]
     progress42 = mkLoading 4 10
     expected42 = BuildProgress {compiled = 4, total = 10}
 
-    runProgress aborted loading runs = do
+    runProgress aborted loading suites = do
         abortedRef <- newTVarIO aborted
         runStore do
             BuildStore.setPhase (BuildId 1)
                 $ BuildComplete result
-                $ PostBuild runs
+                $ PostBuild suites mempty
             abortGatedProgress abortedRef (mkTestTarget "test:foo") loading
             phaseTestSuites <$> getState
 
@@ -313,7 +313,7 @@ testAbortGatedProgress = do
 
     phaseTestSuites :: BuildState -> Test.Suites
     phaseTestSuites s = case s.phase of
-        BuildComplete _ (PostBuild testSuites) -> testSuites
+        BuildComplete _ (PostBuild testSuites _) -> testSuites
         _ -> Test.Suites mempty
 
     epoch :: UTCTime

--- a/tricorder/tricorder.cabal
+++ b/tricorder/tricorder.cabal
@@ -32,6 +32,7 @@ library tricorder-internal
       Tricorder.Builder.Dispatch
       Tricorder.BuildState
       Tricorder.BuildState.BuildProgress
+      Tricorder.BuildState.EvalComments
       Tricorder.BuildState.Test
       Tricorder.CLI
       Tricorder.CLI.Main
@@ -43,6 +44,7 @@ library tricorder-internal
       Tricorder.Effects.BrickChan
       Tricorder.Effects.BuildStore
       Tricorder.Effects.Cabal
+      Tricorder.Effects.EvalCommentRunner
       Tricorder.Effects.GhciSession
       Tricorder.Effects.GhciSession.GhciParser
       Tricorder.Effects.GhciSession.GhciProcess
@@ -221,12 +223,14 @@ test-suite tricorder-test
   main-is: Driver.hs
   other-modules:
       Unit.Tricorder.BuilderSpec
+      Unit.Tricorder.BuildState.EvalCommentsSpec
       Unit.Tricorder.BuildStateSpec
-      Unit.Tricorder.BuildStoreSpec
       Unit.Tricorder.CLI.RenderSpec
+      Unit.Tricorder.Effects.BuildStoreSpec
       Unit.Tricorder.Effects.GhciSession.GhciParserSpec
       Unit.Tricorder.Effects.GhciSession.GhciProcessSpec
       Unit.Tricorder.Effects.GhciSessionSpec
+      Unit.Tricorder.Effects.PostBuildStoreSpec
       Unit.Tricorder.Effects.SessionStoreSpec
       Unit.Tricorder.GhcPkgSpec
       Unit.Tricorder.SessionSpec
@@ -276,6 +280,7 @@ test-suite tricorder-test
     , effectful-plugin >=2.0 && <2.2
     , filepath >=1.4 && <1.6
     , hspec ==2.11.*
+    , megaparsec ==9.7.*
     , process ==1.6.*
     , regex-tdfa >=1.3.2.5 && <1.4
     , stm ==2.5.*


### PR DESCRIPTION
Related #205

Known limitation: evaluating comments does not properly abort on `SourceChangeDetected`.