### PR TITLE
fix: MCP output must be stdio for local MCP server


### DIFF
--- a/tricorder-mcp/src/Tricorder/MCP/Main.hs
+++ b/tricorder-mcp/src/Tricorder/MCP/Main.hs
@@ -5,7 +5,7 @@ import MCP.Server
     ( McpServerHandlers (..)
     , McpServerInfo (..)
     , noHandlers
-    , runMcpServerHttp
+    , runMcpServerStdio
     )
 import MCP.Server.Derive (deriveToolHandlerWithDescription)
 
@@ -14,7 +14,7 @@ import Tricorder.MCP.Tools (Tool, handleTool, toolDescriptions)
 
 
 main :: IO ()
-main = runMcpServerHttp serverInfo handlers
+main = runMcpServerStdio serverInfo handlers
 
 
 handlers :: McpServerHandlers


### PR DESCRIPTION
Related https://github.com/tweag/tricorder/issues/244