### PR TITLE
tricorder: fix parsing comma-separated packages list in cabal.project

### DIFF
--- a/tricorder/CHANGELOG.md
+++ b/tricorder/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to the [PVP](https://pvp.haskell.org/).
   build process. See [Configuring Tricorder](/docs/configuring-tricorder.md)
   for more information.
 
+### Fixed
+
+- Unable to correctly parse `packages` lists in `cabal.project` files when the
+  list was formatted as a single-line, comma-separated list.
+
 ## [0.2.1.0] - 2026-08-17
 
 ### Added

--- a/tricorder/src/Tricorder/Session/CabalFile.hs
+++ b/tricorder/src/Tricorder/Session/CabalFile.hs
@@ -109,7 +109,13 @@ projectPackageEntries contents =
         Left _ -> []
         Right fields -> filter (notElem '*') $ concatMap fromField fields
   where
-    fromField (Field (Name _ name) fieldLines)
-        | name == "packages" = concatMap fromLine fieldLines
-    fromField _ = []
-    fromLine (FieldLine _ bs) = map BC.unpack (BC.words bs)
+    fromField = \case
+        (Field (Name _ name) fieldLines)
+            | name == "packages" -> concatMap fromLine fieldLines
+            | otherwise -> []
+        _ -> []
+    fromLine (FieldLine _ bs) =
+        fmap BC.unpack $ filter (not . BC.null) $ BC.words $ BC.map dropComma bs
+
+    dropComma ',' = ' '
+    dropComma c = c

--- a/tricorder/test/Unit/Tricorder/Session/CabalFileSpec.hs
+++ b/tricorder/test/Unit/Tricorder/Session/CabalFileSpec.hs
@@ -5,13 +5,13 @@ import Atelier.Effects.FileSystem (runFileSystemState)
 import Effectful (runPureEff)
 import Effectful.Reader.Static (runReader)
 import Effectful.State.Static.Shared (evalState)
-import Test.Hspec (Spec, describe, it, shouldBe)
+import Test.Hspec (Spec, describe, it, shouldBe, shouldMatchList)
 
 import Data.Map.Strict qualified as Map
 
 import Tricorder.Runtime (ProjectRoot (..))
 import Tricorder.Session.CabalFile (discoverCabalFiles)
-import Unit.Tricorder.Session.Helpers (cabalFixture, libTestCabal, multiPackageFs)
+import Unit.Tricorder.Session.Helpers (cabalFixture, multiPackageCabalFs, multiPackageFs)
 
 
 spec_CabalFile :: Spec
@@ -49,7 +49,7 @@ testDiscoverCabalFiles = do
                         [ ("/cabal.project.local", "packages: pkg-a\n")
                         , ("/cabal.project", "packages: pkg-b\n")
                         ]
-                        `Map.union` multiPackageCabalFiles
+                        `Map.union` multiPackageCabalFs
                 actual = runDiscovery fs [] discoverCabalFiles
             actual `shouldBe` ["/pkg-a/pkg-a.cabal"]
 
@@ -59,7 +59,7 @@ testDiscoverCabalFiles = do
                         [ ("/cabal.project.freeze", "packages: pkg-a\n")
                         , ("/cabal.project", "packages: pkg-b\n")
                         ]
-                        `Map.union` multiPackageCabalFiles
+                        `Map.union` multiPackageCabalFs
                 actual = runDiscovery fs [] discoverCabalFiles
             actual `shouldBe` ["/pkg-a/pkg-a.cabal"]
 
@@ -70,7 +70,7 @@ testDiscoverCabalFiles = do
                             [ ("/cabal.project.local", "tests: True\n")
                             , ("/cabal.project", "packages: pkg-b\n")
                             ]
-                            `Map.union` multiPackageCabalFiles
+                            `Map.union` multiPackageCabalFs
                     actual = runDiscovery fs [] discoverCabalFiles
                 actual `shouldBe` ["/pkg-b/pkg-b.cabal"]
 
@@ -90,7 +90,7 @@ testDiscoverCabalFiles = do
             it "uses $HOME/.cabal/config as a last-resort packages source" do
                 let fs =
                         Map.singleton "/home/user/.cabal/config" "packages: pkg-a\n"
-                            `Map.union` multiPackageCabalFiles
+                            `Map.union` multiPackageCabalFs
                     actual = runDiscovery fs [("HOME", "/home/user")] discoverCabalFiles
                 actual `shouldBe` ["/pkg-a/pkg-a.cabal"]
 
@@ -103,13 +103,17 @@ testDiscoverCabalFiles = do
                             ]
                     actual = runDiscovery fs [("HOME", "/home/user")] discoverCabalFiles
                 actual `shouldBe` ["/myapp.cabal"]
+
+    describe "packages: single-line list" do
+        describe "when package list is comma-separated" do
+            it "parses package names correctly" do
+                let fs =
+                        Map.singleton "/cabal.project" "packages: pkg-a, pkg-b\n"
+                            `Map.union` multiPackageCabalFs
+                    actual = runDiscovery fs [] discoverCabalFiles
+                actual `shouldMatchList` ["/pkg-a/pkg-a.cabal", "/pkg-b/pkg-b.cabal"]
   where
     pr = ProjectRoot "/"
-    multiPackageCabalFiles =
-        Map.fromList
-            [ ("/pkg-a/pkg-a.cabal", libTestCabal "pkg-a")
-            , ("/pkg-b/pkg-b.cabal", libTestCabal "pkg-b")
-            ]
     runDiscovery fs env =
         runPureEff
             . runEnvConst env

--- a/tricorder/test/Unit/Tricorder/Session/Helpers.hs
+++ b/tricorder/test/Unit/Tricorder/Session/Helpers.hs
@@ -2,6 +2,7 @@ module Unit.Tricorder.Session.Helpers
     ( multiCabalFiles
     , singleCabalFile
     , multiPackageFs
+    , multiPackageCabalFs
     , preludeOnlyLibCabal
     , libWithPreludeCabal
     , libTestCabal


### PR DESCRIPTION
Related https://github.com/tweag/tricorder/issues/415